### PR TITLE
fix: figure caption causes paragraph indent to be lost after it

### DIFF
--- a/classes/resilient/book.lua
+++ b/classes/resilient/book.lua
@@ -255,7 +255,7 @@ function class:registerStyles ()
     paragraph = { skipbefore = "smallskip",
                   align = "center", breakafter = false },
   })
-  self:registerStyle("figure-caption", { inherit = "sectioning-base" }, {
+  self:registerStyle("figure-caption", {}, {
     font = { size = "-0.5" },
     paragraph = { indentbefore = false, skipbefore = "medskip", breakbefore = false,
                   align = "center",


### PR DESCRIPTION
Closes #1 

I was so convinced that it was something tricky that I didn't look at it earlier - heh, it was just a wrong style definition.

Obviously, it might be revisited in #12, but no reason not to fix it here first.