### PR TITLE
fix: avoid extra ToC rerun warnings when the ToC hasn't changed

### DIFF
--- a/packages/resilient/tableofcontents/init.lua
+++ b/packages/resilient/tableofcontents/init.lua
@@ -230,7 +230,7 @@ function package:registerCommands ()
     SILE.call("info", {
       category = "toc",
       value = {
-        label = content,
+        label = SU.stripContentPos(content),
         level = (options.level or 1),
         number = options.number,
         link = dest

--- a/resilient/hacks.lua
+++ b/resilient/hacks.lua
@@ -85,3 +85,32 @@ SILE.typesetters.base.initline = function (self)
   oldInitLine(self)
 end
 -- END HACK FOR PARINDENT HBOX ISSUE
+
+-- BEGIN HACK TOC
+-- See https://github.com/sile-typesetter/sile/issues/1732
+if not SU.stripContentPos then
+  --- Strip position, line and column recursively from a content tree.
+  -- This can be used to remove position details where we do not want them,
+  -- e.g. in table of contents entries (referring to the original content,
+  -- regardless where it was exactly, for the purpose of checking whether
+  -- the table of contents changed.)
+  --
+  SU.stripContentPos = function (content)
+    if type(content) ~= "table" then
+      return content
+    end
+    local stripped = {}
+    for k, v in pairs(content) do
+      if type(v) == "table" then
+        v = SU.stripContentPos(v)
+      end
+      stripped[k] = v
+    end
+    if content.id or content.command then
+      stripped.pos, stripped.col, stripped.lno = nil, nil, nil
+    end
+    return stripped
+  end
+end
+
+-- END HACK TOC


### PR DESCRIPTION
Stripping positions from ToC entries avoids a mere text change that would not affect the ToC (same title, same page, only some inner character position changed) to be seen as a difference.

Implemented as a resilient "hack", but see also SILE https://github.com/sile-typesetter/sile/issues/1732 for the more general context.

(The "problem" occurs when some ToC entries contain commands, e.g. an emphasis etc.)