### PR TITLE
fix: defaults folio styles were not cancelling paragraph indentation

### DIFF
--- a/classes/resilient/book.lua
+++ b/classes/resilient/book.lua
@@ -56,7 +56,6 @@ function class:_init (options)
   -- TRICKY, TO REMEMBER: Such overrides cannot be done in registerCommands()
   -- as packages are not loaded yet.
   self:registerCommand("foliostyle", function (_, content)
-    SILE.call("noindent")
     local styleName = SILE.documentState.documentClass:oddPage() and "folio-odd" or "folio-even"
     SILE.call("style:apply:paragraph", { name = styleName }, function ()
       -- Ensure proper baseline alignment with a strut rule.
@@ -236,9 +235,12 @@ function class:registerStyles ()
     font = { features = "+onum" }
   })
   self:registerStyle("folio-even", { inherit = "folio-base" }, {
+    paragraph = { align = "left" ,
+                  before = { indent = false } }
   })
   self:registerStyle("folio-odd", { inherit = "folio-base" }, {
-    paragraph = { align = "right" }
+    paragraph = { align = "right" ,
+                  before = { indent = false } }
   })
 
   -- header styles

--- a/examples/lefevre-tuor-idril-styles.yml
+++ b/examples/lefevre-tuor-idril-styles.yml
@@ -25,7 +25,7 @@ epigraph:
 epigraph-source:
   origin: "resilient.epigraph"
   style:
-   paragraph:
+    paragraph:
       align: "right"
       before:
         indent: false
@@ -59,6 +59,7 @@ figure:
         vbreak: false
       align: "center"
       before:
+        indent: false
         skip: "smallskip"
 
 figure-caption:
@@ -121,19 +122,19 @@ folio-even:
   inherit: "folio-base"
   origin: "resilient.book"
   style:
+    paragraph:
+      align: "left"
+      before:
+        indent: false
 
 folio-odd:
   inherit: "folio-base"
   origin: "resilient.book"
   style:
     paragraph:
-      after:
-        indent: true
-        vbreak: true
       align: "right"
       before:
-        indent: true
-        vbreak: true
+        indent: false
 
 footnote:
   origin: "resilient.footnotes"
@@ -170,7 +171,7 @@ footnote-reference:
   style:
     numbering:
       before:
-        kern: "1thsp"  
+        kern: "1thsp"
     properties:
       position: "super"
 
@@ -188,12 +189,12 @@ header-base:
   origin: "resilient.book"
   style:
     font:
-      size: "0.9em"
       features: "+smcp"
+      size: "0.9em"
     paragraph:
-      align: "center"
       after:
         indent: false
+      align: "center"
       before:
         indent: false
 
@@ -237,8 +238,6 @@ sectioning-chapter:
         main: "sectioning-chapter-main-number"
         reference: "sectioning-chapter-ref-number"
       settings:
-        bookmark: true
-        goodbreak: true
         open: "odd"
         toclevel: 1
 
@@ -422,6 +421,8 @@ table:
       after:
         vbreak: false
       align: "center"
+      before:
+        indent: false
 
 table-caption:
   origin: "resilient.book"

--- a/examples/manual-styles.yml
+++ b/examples/manual-styles.yml
@@ -141,19 +141,19 @@ folio-even:
   inherit: "folio-base"
   origin: "resilient.book"
   style:
+    paragraph:
+      align: "left"
+      before:
+        indent: false
 
 folio-odd:
   inherit: "folio-base"
   origin: "resilient.book"
   style:
     paragraph:
-      after:
-        indent: true
-        vbreak: true
       align: "right"
       before:
-        indent: true
-        vbreak: true
+        indent: false
 
 footnote:
   origin: "resilient.footnotes"
@@ -453,8 +453,6 @@ sectioning-chapter:
         main: "sectioning-chapter-main-number"
         reference: "sectioning-chapter-ref-number"
       settings:
-        bookmark: true
-        goodbreak: true
         open: "odd"
         toclevel: 1
 
@@ -523,8 +521,6 @@ sectioning-part:
         main: "sectioning-part-main-number"
         reference: "sectioning-part-ref-number"
       settings:
-        bookmark: true
-        goodbreak: true
         open: "odd"
         toclevel: 0
 
@@ -585,8 +581,6 @@ sectioning-section:
         main: "sectioning-other-number"
         reference: "sectioning-other-number"
       settings:
-        bookmark: true
-        goodbreak: true
         toclevel: 2
 
 sectioning-subsection:
@@ -611,8 +605,6 @@ sectioning-subsection:
         main: "sectioning-other-number"
         reference: "sectioning-other-number"
       settings:
-        bookmark: true
-        goodbreak: true
         toclevel: 3
 
 sectioning-subsubsection:
@@ -635,8 +627,6 @@ sectioning-subsubsection:
         main: "sectioning-other-number"
         reference: "sectioning-other-number"
       settings:
-        bookmark: true
-        goodbreak: true
         toclevel: 4
 
 table:
@@ -715,13 +705,11 @@ toc-level0:
       weight: 800
     paragraph:
       after:
-        indent: true
         skip: "medskip"
         vbreak: false
       before:
         indent: false
         skip: "medskip"
-        vbreak: true
     toc:
       numbered: true
       pageno: false
@@ -735,12 +723,9 @@ toc-level1:
       weight: 800
     paragraph:
       after:
-        indent: true
         skip: "smallskip"
-        vbreak: true
       before:
         indent: false
-        vbreak: true
     toc:
       dotfill: false
 
@@ -752,12 +737,9 @@ toc-level2:
       size: "1em"
     paragraph:
       after:
-        indent: true
         skip: "smallskip"
-        vbreak: true
       before:
         indent: false
-        vbreak: true
     toc:
 
 toc-level3:
@@ -766,12 +748,9 @@ toc-level3:
   style:
     paragraph:
       after:
-        indent: true
         skip: "smallskip"
-        vbreak: true
       before:
         indent: true
-        vbreak: true
     toc:
       dotfill: false
 
@@ -793,12 +772,9 @@ toc-level5:
   style:
     paragraph:
       after:
-        indent: true
         skip: "smallskip"
-        vbreak: true
       before:
         indent: false
-        vbreak: true
     toc:
       numbered: true
 
@@ -808,12 +784,9 @@ toc-level6:
   style:
     paragraph:
       after:
-        indent: true
         skip: "smallskip"
-        vbreak: true
       before:
         indent: false
-        vbreak: true
     toc:
       numbered: true
 

--- a/examples/manual-styling/advanced/folio.md
+++ b/examples/manual-styling/advanced/folio.md
@@ -11,12 +11,16 @@ folio-even:
   style:
     paragraph:
       align: "left"
+      before:
+        indent: false
 
 folio-odd:
   inherit: "folio-base"
   style:
     paragraph:
       align: "right"
+      before:
+        indent: false
 ```
 
 That common parent style is where we would ideally define the font, for instance


### PR DESCRIPTION
Closes #30 

Minimal fix - One day we might propose lskip/rskip/parindent via styling, but we are not yet there...

N.B. I also re-generated some style files which had useless definitions (from the time when default values got propagated).