### PR TITLE
feat: support a default URL-styling with SILE 0.14.9 urlstyle

### DIFF
--- a/classes/resilient/resume.lua
+++ b/classes/resilient/resume.lua
@@ -5,8 +5,8 @@
 --
 -- This is indeed very minimalist :)
 --
-local plain = require("classes.resilient.base")
-local class = pl.class(plain)
+local base = require("classes.resilient.base")
+local class = pl.class(base)
 class._name = "resilient.resume"
 
 local utils = require("resilient.utils")
@@ -79,7 +79,7 @@ class.nextFrameset = {
 }
 
 function class:_init (options)
-  plain._init(self, options)
+  base._init(self, options)
 
   self:loadPackage("color")
   self:loadPackage("rules") -- for section rules
@@ -139,7 +139,7 @@ function class:newPage ()
   -- See https://github.com/sile-typesetter/sile/issues/1544
   -- Ditching the folio numbering check as the folio is not even incremented yet (?!)
   -- Then the mess below _seems_ to work:
-  plain:newPage() -- It calls and returns self:initialFrame(), but heh...
+  base:newPage() -- It calls and returns self:initialFrame(), but heh...
   self:switchMaster("next")
   return self:initialFrame() -- And now this (?!)
 end
@@ -162,11 +162,13 @@ function class:endPage ()
     SILE.call("eject") -- for vfill to be effective
     SILE.settings:popState()
   end)
-  return plain:endPage()
+  return base:endPage()
 end
 
 -- STYLES
 function class:registerStyles ()
+  base:registerStyles()
+
   self:registerStyle("resume-firstname", {}, {
     font = { style = "light" },
     color = "#a6a6a6"
@@ -290,7 +292,7 @@ local doSection = function (rows, _, content)
 end
 
 function class:registerCommands ()
-  plain:registerCommands()
+  base:registerCommands()
 
   self:registerCommand("cv-header", function (_, content)
     local closure = SILE.settings:wrap()

--- a/examples/lefevre-tuor-idril-styles.yml
+++ b/examples/lefevre-tuor-idril-styles.yml
@@ -683,3 +683,7 @@ toc-pageno:
   origin: "resilient.tableofcontents"
   style:
 
+url:
+  origin: "resilient.book"
+  style:
+

--- a/examples/lefevre-tuor-idril.sil
+++ b/examples/lefevre-tuor-idril.sil
@@ -11,14 +11,6 @@
 \language[main=fr]
 \font[family=Libertinus Serif]
 %
-% No longer required (bug in SILE 0.14.2
-%\script{SILE.outputter:_ensureInit()}
-%
-% UGLY: We don't want URLs to be typeset using a typewriter font :)
-% Just cancel the \code command so the default text font is used.
-% Waiting for urlstyle in SILE code...
-\define[command=code]{\process}%
-%
 \define[command=smallcaps]{\font[features=+smcp]{\process}}
 \define[command=foreign:en]{\em{\language[main=en]{\process}}}
 \define[command=foreign:gr]{\em{\language[main=und]{\process}}}
@@ -33,7 +25,8 @@
 % We therefore wrap the concerned paragraph in a temporary environment where the
 % stretchability is canceled...
 \script{
-SILE.registerCommand("initial", function (options, content)
+local class = SILE.documentState.documentClass
+class:registerCommand("initial", function (options, content)
   SILE.settings:temporarily(function()
     local blSkip = SILE.settings:get("document.baselineskip")
     SILE.settings:set("document.baselineskip", SILE.nodefactory.vglue(SILE.length(blSkip.height.length)))

--- a/examples/manual-styles.yml
+++ b/examples/manual-styles.yml
@@ -898,3 +898,10 @@ toc-pageno:
   origin: "resilient.tableofcontents"
   style:
 
+url:
+  origin: "resilient.book"
+  style:
+    font:
+      family: "Hack"
+      size: "1.4ex"
+


### PR DESCRIPTION
Close #28 

Override the new urlstyle hook from SILE 0.14.9 in resilient.book, so it can rely on a dedicated style.