### PR TITLE
fix: wrong section number level in odd page header

### DIFF
--- a/classes/resilient/book.lua
+++ b/classes/resilient/book.lua
@@ -435,7 +435,10 @@ function class:registerCommands ()
           and sty.sectioning.numberstyle.header
         if numsty and sty.sectioning.counter.id then
           local number = self.packages.counters:formatMultilevelCounter(
-            self:getMultilevelCounter(sty.sectioning.counter.id), { noleadingzeros = true }
+            self:getMultilevelCounter(sty.sectioning.counter.id), {
+              noleadingzeros = true,
+              level = sty.sectioning.counter.level -- up to the section level
+            }
           )
           SILE.call("style:apply:number", { name = numsty, text = number })
         end


### PR DESCRIPTION
#46

Regression introduced in 2.0 when switching to the new style paradigm in #13: The section counter level is no longer used in formatting the counter, so we may get the current subsection instead!