### PR TITLE
Ensure running chapter or section headers land on the correct page

### DIFF
--- a/classes/resilient/resume.lua
+++ b/classes/resilient/resume.lua
@@ -285,8 +285,7 @@ function class:registerCommands ()
   base.registerCommands(self)
 
   self:registerCommand("cv-header", function (_, content)
-    local closure = SILE.settings:wrap()
-    SILE.scratch.headers.content = function () closure(content) end
+    SILE.scratch.headers.content = content
   end, "Text to appear at the top of the page")
 
   self:registerCommand("cv-footer", function (_, content)

--- a/examples/manual-classes/classes.sil
+++ b/examples/manual-classes/classes.sil
@@ -229,9 +229,20 @@ The class also defines two commands for manipulating the page headers.
     \cell[valign=top]{\autodoc:command{\odd-running-header{<content>}}}
     \cell[valign=top]{Registers the content to be used in odd running headers.}
   \end{row}
+  \begin{row}
+    \cell[valign=top]{\autodoc:command{\even-tracked-header{<content>}}}
+    \cell[valign=top]{Registers the content to be used in even running headers, tracked.}
+  \end{row}
+  \begin{row}
+    \cell[valign=top]{\autodoc:command{\odd-tracked-header{<content>}}}
+    \cell[valign=top]{Registers the content to be used in odd running headers, tracked.}
+  \end{row}  
 \end{ptable}
 \caption{Commands for manipulating page headers.}
 \end{table}
+
+The “tracked” variants ensure the content is tracked per page (using “info nodes”), which is usually what you want for section headers.
+The other versions do not introduce info nodes, are intended to be used with direct content (such as a document title) or content already tracked elsewhere.
 
 Page headers rely on the functionality provided by the \autodoc:package{resilient.headers} package,
 so the \autodoc:command{\noheaders}, \autodoc:command{\noheaderthispage} and \autodoc:command{\headers}

--- a/packages/resilient/headers/init.lua
+++ b/packages/resilient/headers/init.lua
@@ -55,26 +55,28 @@ function package.outputHeader (_, headerContent, frame)
     local headerFrame = SILE.getFrame(frame)
     if headerFrame then
       SILE.typesetNaturally(headerFrame, function ()
-        SILE.settings:pushState()
-        -- Restore the settings to the top of the queue, which should be the document
-        SILE.settings:toplevelState()
-        SILE.settings:set("current.parindent", SILE.nodefactory.glue())
-        SILE.settings:set("document.lskip", SILE.nodefactory.glue())
-        SILE.settings:set("document.rskip", SILE.nodefactory.glue())
+        if headerContent then
+          SILE.settings:pushState()
+          -- Restore the settings to the top of the queue, which should be the document
+          SILE.settings:toplevelState()
+          SILE.settings:set("current.parindent", SILE.nodefactory.glue())
+          SILE.settings:set("document.lskip", SILE.nodefactory.glue())
+          SILE.settings:set("document.rskip", SILE.nodefactory.glue())
 
-        -- Temporarilly kill footnotes and labels (fragile)
-        local oldFt = SILE.Commands["footnote"]
-        SILE.Commands["footnote"] = function() end
-        local oldLbl = SILE.Commands["label"]
-        SILE.Commands["label"] = function () end
+          -- Temporarilly kill footnotes and labels (fragile)
+          local oldFt = SILE.Commands["footnote"]
+          SILE.Commands["footnote"] = function() end
+          local oldLbl = SILE.Commands["label"]
+          SILE.Commands["label"] = function () end
 
-        SILE.process(headerContent)
+          SILE.process(headerContent)
 
-        SILE.typesetter:leaveHmode()
+          SILE.typesetter:leaveHmode()
 
-        SILE.Commands["footnote"] = oldFt
-        SILE.Commands["label"] = oldLbl
-        SILE.settings:popState()
+          SILE.Commands["footnote"] = oldFt
+          SILE.Commands["label"] = oldLbl
+          SILE.settings:popState()
+        end
 
         if SILE.scratch.headers.rule then
           local rule = SILE.scratch.headers.rule

--- a/packages/resilient/styles/init.lua
+++ b/packages/resilient/styles/init.lua
@@ -10,8 +10,8 @@ package._name = "resilient.styles"
 
 local utils = require("resilient.utils")
 local ast = require("silex.ast")
-local createCommand, subContent, extractFromTree
-        = ast.createCommand, ast.subContent, ast.extractFromTree
+local createCommand, subContent
+        = ast.createCommand, ast.subContent
 
 function package:_init (options)
   base._init(self, options)
@@ -269,7 +269,6 @@ function package:registerCommands ()
   local function characterStyle (style, content, options)
     options = options or {}
     if style.properties then
-      local tocentry = extractFromTree(content, "tocentry") -- HACK for sectioning styles
       if style.properties.position and style.properties.position ~= "normal" then
         local positionCommand = SILE.scratch.styles.positions[style.properties.position]
         if not positionCommand then
@@ -283,12 +282,6 @@ function package:registerCommands ()
           SU.error("Invalid style case '"..style.properties.case.."'")
         end
         content = createCommand(caseCommand, {}, content)
-      end
-      if tocentry then -- HACK for sectioning styles
-        -- We don't want character styles from a paragraph level to be applied
-        -- to the TOC entry content, esp. text casing.
-        SU.debug("resilient.styles", "TOC entry reinserted due to character styling")
-        content = { tocentry, content }
       end
     end
     if style.color then


### PR DESCRIPTION
Closes #43

A workaround, rather than a true fix, with ugly hacks in the sectioning logic and the section hooks.
We should reconsider these hooks one day, but it will break existing style files, so that can't be addressed in 2.x 