### PR TITLE
Handle documents on STDIN and/or via Lua 5.1

### DIFF
--- a/packages/resilient/styles/init.lua
+++ b/packages/resilient/styles/init.lua
@@ -88,7 +88,8 @@ end
 
 function package:readStyles ()
   local yaml = require("resilient-tinyyaml")
-  local fname = SILE.masterFilename .. '-styles.yml'
+  local basename = pl.path.splitext(SILE.input.filenames[1])
+  local fname = basename .. '-styles.yml'
   local styfile, _ = io.open(fname)
   if not styfile then
     SILE.scratch.styles.loaded = {}
@@ -136,7 +137,8 @@ function package.writeStyles () -- NOTE: Not called as a package method (invoked
   end
 
   local stydata = tableToYaml(SILE.scratch.styles.specs)
-  local fname = SILE.masterFilename .. '-styles.yml'
+  local basename = pl.path.splitext(SILE.input.filenames[1])
+  local fname = basename .. '-styles.yml'
   SU.debug("resilient.styles", "Writing style file", fname, ":", count, "new style(s)")
   local styfile, err = io.open(fname, "w")
   if not styfile then return SU.error(err) end

--- a/packages/resilient/tableofcontents/init.lua
+++ b/packages/resilient/tableofcontents/init.lua
@@ -100,7 +100,8 @@ end
 
 function package.writeToc (_)
   local tocdata = pl.pretty.write(SILE.scratch.tableofcontents)
-  local tocfile, err = io.open(SILE.masterFilename .. '.toc', "w")
+  local basename = pl.path.splitext(SILE.input.filenames[1])
+  local tocfile, err = io.open(basename .. '.toc', "w")
   if not tocfile then return SU.error(err) end
   tocfile:write("return " .. tocdata)
   tocfile:close()
@@ -115,7 +116,8 @@ function package.readToc (_)
     -- already loaded
     return SILE.scratch._tableofcontents
   end
-  local tocfile, _ = io.open(SILE.masterFilename .. '.toc')
+  local basename = pl.path.splitext(pl.path.normpath(SILE.input.filenames[1]))
+  local tocfile, _ = io.open(basename .. '.toc')
   if not tocfile then
     return false -- No TOC yet
   end


### PR DESCRIPTION
I noticed while checking my suggestions in [this comment](https://github.com/sile-typesetter/sile/discussions/1921#discussioncomment-7793404) that resilient is tripping up on documents coming from STDIN, e.g.:

```console
$ sile -o test.pdf - <<< "\\document[class=resilient.book]{test}"
SILE v0.14.13 (LuaJIT 2.1.1696562864)
<STDIN> as sil

! Unexpected Lua error

error summary:
        Processing at: STDIN: in <snippet>:
                [[\document[class=resilient.book]{test}␤]]
        Using code at: ...es/share/lua/5.1/sile/packages/resilient/styles/init.lua:91: attempt to concatenate field 'masterFilename' (a nil value)

Run with --traceback for more detailed trace leading up to errors.
```

This should fix that by doing the same thing SILE is internally, but I haven't actually tested it.
