### PR TITLE
Lua 5.1 compatibility

### DIFF
--- a/.github/workflows/luacheck.yml
+++ b/.github/workflows/luacheck.yml
@@ -8,6 +8,6 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Luacheck
-        uses: lunarmodules/luacheck@v0
+        uses: lunarmodules/luacheck@v1

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,4 +1,4 @@
-std = "max"
+std = "min+sile"
 include_files = {
   "**/*.lua",
   "sile.in",
@@ -18,15 +18,6 @@ exclude_files = {
 }
 files["**/*_spec.lua"] = {
   std = "+busted"
-}
-globals = {
-  "SILE",
-  "SU",
-  "luautf8",
-  "pl",
-  "fluent",
-  "SYSTEM_SILE_PATH",
-  "SHARED_LIB_EXT"
 }
 max_line_length = false
 ignore = {

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -11,7 +11,7 @@ exclude_files = {
   "compare-*",
   "sile-*",
   "lua_modules",
-  "lua-libraries",
+  -- "lua-libraries",
   ".lua",
   ".luarocks",
   ".install"

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -11,13 +11,20 @@ exclude_files = {
   "compare-*",
   "sile-*",
   "lua_modules",
-  -- "lua-libraries",
   ".lua",
   ".luarocks",
   ".install"
 }
 files["**/*_spec.lua"] = {
   std = "+busted"
+}
+files["lua-libraries"] = {
+  -- matter of taste and not harmful
+  ignore = {
+    "211", -- unused function / unused variable
+    "212/self", -- unused argument self
+    "412", --variable was previously defined as an argument
+  }
 }
 max_line_length = false
 ignore = {

--- a/inputters/silm.lua
+++ b/inputters/silm.lua
@@ -578,7 +578,7 @@ function inputter:parse (doc)
   end
 
   -- Document wrap-up
-  local options = master.sile.options or {}
+  local options = sile.options or {}
   local classopts = isRoot and {
       class = options.class or "resilient.book", -- Sane default. We Are Resilient.
       papersize = options.papersize,

--- a/lua-libraries/README.tinyyaml
+++ b/lua-libraries/README.tinyyaml
@@ -18,3 +18,5 @@ RESILIENT was to avoid a C binding dependency, since style files are
 reasonably small theoretically (so performance do not really matter) and
 only need a subset of YAML (so a pure-Lua implementation, even possibly
 incomplete, ought to be sufficient.)
+
+Modications are marked with comments MODIFIED RESILIENT

--- a/lua-libraries/README.tinyyaml
+++ b/lua-libraries/README.tinyyaml
@@ -1,6 +1,5 @@
 The "vendored" version of tinyyaml used here is:
-https://github.com/api7/lua-tinyyaml (0.4.3 rockspec at the time of initial
-import)
+https://github.com/api7/lua-tinyyaml (0.4.4 rockspec)
 
 It's a fork from:
 https://github.com/peposso/lua-tinyyaml (which had a 1.0 rockspec earlier)

--- a/lua-libraries/resilient-tinyyaml.lua
+++ b/lua-libraries/resilient-tinyyaml.lua
@@ -775,6 +775,11 @@ end
 -- : (list<str>)->dict
 function Parser:parsedocuments(lines)
   lines = compactifyemptylines(lines)
+  -- BEGIN MODIFIED RESILIENT
+  if #lines == 0 then
+    return {}
+  end
+  -- END MODIFIED RESILIENT
 
   if sfind(lines[1], '^%%YAML') then tremove(lines, 1) end
 

--- a/lua-libraries/resilient-tinyyaml.lua
+++ b/lua-libraries/resilient-tinyyaml.lua
@@ -107,7 +107,7 @@ function types.timestamp:__init(y, m, d, h, i, s, f, z)
   self.minute = tonumber(i or 0)
   self.second = tonumber(s or 0)
   if type(f) == 'string' and sfind(f, '^%d+$') then
-    self.fraction = tonumber(f) * math.pow(10, 3 - #f)
+    self.fraction = tonumber(f) * 10^(3 - #f) -- MODIFIED RESILIENT Lua min compat
   elseif f then
     self.fraction = f
   else

--- a/lua-libraries/resilient-tinyyaml.lua
+++ b/lua-libraries/resilient-tinyyaml.lua
@@ -611,8 +611,10 @@ function Parser:parseseq(line, lines, indent)
       error("did not find expected alphabetic or numeric character")
     elseif rest then
       -- Array entry with a value
+      local nextline = lines[1]
+      local indent2 = countindent(nextline)
       tremove(lines, 1)
-      tinsert(seq, self:parsescalar(rest, lines))
+      tinsert(seq, self:parsescalar(rest, lines, indent2))
     end
   end
   return seq

--- a/packages/resilient/bookmatters/init.lua
+++ b/packages/resilient/bookmatters/init.lua
@@ -77,7 +77,11 @@ end
 
 -- Source: https://www.nbdtech.com/Blog/archive/2008/04/27/Calculating-the-Perceived-Brightness-of-a-Color.aspx
 local function weightedColorDistanceIn3D (color)
-  return math.sqrt(math.pow(color.r * 255, 2) * 0.241 + math.pow(color.g * 255, 2) * 0.691 + math.pow(color.b * 255, 2) * 0.068)
+  return math.sqrt(
+    (color.r * 255)^2 * 0.241
+    + (color.g * 255)^2 * 0.691
+    + (color.b * 255)^2 * 0.068
+  )
 end
 local function contrastColor(color)
   if not color.r then
@@ -160,7 +164,6 @@ function package:registerCommands ()
     end
 
     if metadata["meta:isbn"] then
-      -- local H = SILE.measurement("100%fh"):tonumber() - SILE.measurement("40mm"):tonumber()
       SILE.call("skip", { height = offset })
       SILE.call("kern", { width = SILE.nodefactory.hfillglue() })
       SILE.call("framebox", { fillcolor = "white", padding = pad1, borderwidth = 0 }, {

--- a/packages/resilient/poetry/init.lua
+++ b/packages/resilient/poetry/init.lua
@@ -5,6 +5,7 @@
 --
 local ast = require("silex.ast")
 local createStructuredCommand = ast.createStructuredCommand
+local LOG10 = math.log(10)
 
 local base = require("packages.resilient.base")
 
@@ -178,7 +179,8 @@ function package:registerCommands ()
         digitSize = SILE.shaper:measureChar("0").width
       end)
       local setback = SILE.length("1.75em"):absolute()
-      indent = SILE.length((math.floor(math.log10(nVerse + iVerse)) + 1) * digitSize):absolute()
+      local logv = math.floor(math.log(nVerse + iVerse) / LOG10) -- Reminder: math.log10 is not in Lua "min" profiile
+      indent = SILE.length((logv + 1) * digitSize):absolute()
         + setback
         + SILE.length(SILE.settings:get("document.parindent")):absolute()
     end

--- a/packages/resilient/styles/init.lua
+++ b/packages/resilient/styles/init.lua
@@ -563,14 +563,14 @@ function package:registerCommands ()
       local hbox = SILE.typesetter:makeHbox(function ()
         SILE.call("style:apply", { name = name }, { text })
       end)
-      if hbox.width < 0 then
+      if hbox.width:tonumber() < 0 then
         SU.warn("Negative hbox width should not occur any more, please report an issue")
       end
-      local remainingSpace = hbox.width < 0 and -hbox.width or -beforekern:absolute() - hbox.width
+      local remainingSpace = hbox.width:tonumber() < 0 and -hbox.width or -beforekern:absolute() - hbox.width
 
       -- We want at least the space of a figure digit between the number
       -- and the text.
-      if remainingSpace:tonumber() - SILE.length("1nspc"):absolute() <= 0 then
+      if remainingSpace:tonumber() - SILE.length("1nspc"):tonumber() <= 0 then
         -- It's not the case, the number goes beyond the available space.
         -- So add a fixed interword space after it.
         SILE.call("style:apply", { name = name }, { text })


### PR DESCRIPTION
Closes #71 

Stage 1:

- [x] Compile resilient manual (covers a bit good of all other dependencies incl. Djot, Markdown)
- [x] Compile books from awesome-sile-books
   - [x] LSG
   - [x] lovecraft --> Well, there's a dropcap bug when using Gentium (default) instead of Zallman Caps. Likely unrelated, **to open** --> indeed reproduced with standard SILE, reported as https://github.com/sile-typesetter/sile/issues/1925
   - (not dragon-de-brume-5 as it requires a special build)
- [ ] Compile markdown.sile manual --> breaks but due to things fixed here in the resilient.styles package.

Stage 2:
- Apply same "min" Luacheck CI fix to all dependencies, fix issues and bump releases if need be:
  - [x] barcodes.sile
  - [x] couyards.sile
  - [x] embedders.sile
  - [x] fancytoc.sile
  - [x] labelrefs.sile
  - [ ] markdown.sile
  - [x] printoptions.sile -> Since we are heading toward a release, consider finalizing the minor PR there...
  - [x] ptable.sile -> **update to 2.0.1**
  - [x] qrcode.sile
  - [ ] silex.sile
  - [x] smartquotes.sile
  - [x] spreadsheet.sile
  - [x] teidict.sile
  - [x] textsubsuper.sile

Stage 3

- [ ] Prepare releasing resilient.sile with updated dependencies
- [ ] Compile resilient manual
- [ ] Compile books from awesome-sile-books
   - [ ] LSG
   - [ ] lovecraft
- [ ] Compile markdown.sile manual