### PR TITLE
feat: Display math equation numbers now use a resilient style (eqno)

### DIFF
--- a/examples/manual-front.sil
+++ b/examples/manual-front.sil
@@ -1,7 +1,9 @@
 \begin{document}
 \footnote:rule
-\define[command=admon]{%
+\define[command=admon]{% This is a quick but bad implementation. We ought to have used a style.
+\novbreak
 \smallskip%
+\novbreak
 \set[parameter=document.parindent, value=0]{%
 \roughbox[enlarge=true, singlestroke=true, preserve=true,
 padding=2%fw, bordercolor=#59b24c, fillcolor=230, shadowcolor=#96A8C7, shadow=false]{%

--- a/examples/manual-styling/advanced/eqno.md
+++ b/examples/manual-styling/advanced/eqno.md
@@ -1,0 +1,54 @@
+## Styling equation numbers
+
+Mathematical equations that are displayed on their own line (in the so-called "display" mode) can be numbered.
+This feature is not available in Markdown, but is supported for input documents in Djot or SIL.
+In Djot, for instance, you can write, using the default `equation` counter:
+
+```
+$$`e^{i\pi} = -1`{numbered=true}
+```
+
+The equation numbers are then rendered using the `eqno` numbering style, which is defined as follows by default:
+
+```yaml
+eqno:
+  numbering:
+    display: "arabic"
+    before:
+      text: "("
+    after:
+      text: ")"
+```
+
+But as any style, this can be adjusted to your needs.
+For the sake of this example, we could have used old-style numbers, and put the equation numbers in square brackets:
+
+```yaml
+eqno:
+  font:
+    features: "+onum"
+  numbering:
+    display: "arabic"
+    before:
+      text: "["
+    after:
+      text: "]"
+```
+
+Moreover, in Djot or SIL, you can also specify a custom counter to be used for numbering an equation, starting from 1 on its first occurrence, and automatically incremented.
+
+```
+$$`e^{i\pi} = -1`{counter=myname}
+```
+
+By default, the `eqno` style applies, but if your style definion file contains a style appropriately named `eqno-myname`, it will be used instead.
+This is something you will likely want to do, for these custom counters to have a distinct appearance.
+Style inheritance is useful here, as you can define a general style for equation numbers, and then override a subset of its properties for specific counters.
+For instance, we could want to switch to alpha numbering for this sample `myname` counter:
+
+```yaml
+eqno-myname:
+  inherit: eqno
+  numbering:
+    display: "alpha"
+```

--- a/examples/manual-styling/advanced/other.md
+++ b/examples/manual-styling/advanced/other.md
@@ -9,6 +9,6 @@ Readers experienced with SILE’s standard packages also have to be aware that t
 For instance, the (standard) **url** package provides a `urlstyle` hook command. While you could override it---that is, redefine that command---, please note that this is what the resilient classes already do, so as to delegate the decision to a style conveniently called `urlstyle` too.[^other-sile-hooks]
 
 [^other-sile-hooks]: The same principle actually applies to page numbers, relying on the standard **folio** package. The latter provides a `foliostyle` hook, which the resilient styling system overrides with its own clever logic.
-Likewise, the `math:numberstyle` hook from the **math** package is also redefined, to rely on the `eqno` style for display math equation numbers (and actually, if it exist and is non-emppty, to the `eqno-⟨counter⟩` style specific to the counter in question, by default `equation`).
+Likewise, the `math:numberstyle` hook from the **math** package is also redefined, to rely on the `eqno` style for display math equation numbers (and actually, if it exist and is non-emppty, to the `eqno-⟨counter⟩` style specific to the counter in question, by default `equation`), as described in the previous section.
 
 In other terms, even for standard SILE packages, we may already have provided a style-aware version of their original customization hooks.

--- a/examples/manual-styling/advanced/other.md
+++ b/examples/manual-styling/advanced/other.md
@@ -9,5 +9,6 @@ Readers experienced with SILE’s standard packages also have to be aware that t
 For instance, the (standard) **url** package provides a `urlstyle` hook command. While you could override it---that is, redefine that command---, please note that this is what the resilient classes already do, so as to delegate the decision to a style conveniently called `urlstyle` too.[^other-sile-hooks]
 
 [^other-sile-hooks]: The same principle actually applies to page numbers, relying on the standard **folio** package. The latter provides a `foliostyle` hook, which the resilient styling system overrides with its own clever logic.
+Likewise, the `math:numberstyle` hook from the **math** package is also redefined, to rely on the `eqno` style for display math equation numbers (and actually, if it exist and is non-emppty, to the `eqno-⟨counter⟩` style specific to the counter in question, by default `equation`).
 
 In other terms, even for standard SILE packages, we may already have provided a style-aware version of their original customization hooks.

--- a/examples/sile-resilient-manual-styles.yml
+++ b/examples/sile-resilient-manual-styles.yml
@@ -1,9 +1,3 @@
-md-mark:
-  style:
-    decoration:
-      line: "mark"
-      color: "orange"
-      rough: true
 
 blockquote:
   origin: "resilient.book"
@@ -172,6 +166,16 @@ epigraph-text:
   style:
     paragraph:
       align: "justify"
+
+eqno:
+  origin: "resilient.book"
+  style:
+    numbering:
+      after:
+        text: ")"
+      before:
+        text: "("
+      display: "arabic"
 
 fancytoc-base:
   style:
@@ -531,6 +535,13 @@ lists-itemize6:
   style:
     itemize:
       symbol: "–"
+
+md-mark:
+  style:
+    decoration:
+      color: "orange"
+      line: "mark"
+      rough: true
 
 poetry:
   origin: "resilient.poetry"
@@ -1050,9 +1061,9 @@ verbatim:
   origin: "resilient.verbatim"
   style:
     paragraph:
+      after:
+        skip: "smallskip"
       align: "obeylines"
       before:
-        skip: "smallskip"
-      after:
         skip: "smallskip"
 

--- a/examples/sile-resilient-manual.silm
+++ b/examples/sile-resilient-manual.silm
@@ -39,7 +39,7 @@ sile:
     textsubsuper.fake: false
     autodoc.highlighting: true
     document.baselineskip: 1.2em
-    typesetter.italicCorrection: true
+    typesetter.italicCorrection: true # Available in SILE 0.15 (comment out for earlier versions)
   packages:
     - autodoc-resilient # REQUIRED FOR RESILIENT, do not use regular autodoc
     - background        # Some of the packages below might not be required...
@@ -78,6 +78,7 @@ parts:
       - manual-styling/advanced/footnotes.md
       - manual-styling/advanced/toclevels.md
       - manual-styling/advanced/liststyles.md
+      - manual-styling/advanced/eqno.md
       - manual-styling/advanced/other.md
       # unfinished
       # - manual-styling/captioned.md


### PR DESCRIPTION
... and also subscribe for labelrefs cross-referencing.

Closes #90 

A SIL test input file:

```
\begin[class=resilient.book, papersize=a6]{document}
\font[family=Libertinus Serif]
\math[mode=display, numbered=true]{e^{i\pi} = -1}
\math[mode=display, number=2A]{e^{i\pi} = -1}
\math[mode=display, counter=stuff]{e^{i\pi} = -1}
\math[mode=display, marker=myeq, counter=stuff]{e^{i\pi} = -1}
\math[mode=display, counter=stuff]{e^{i\pi} = -1}

Equation \ref[marker=myeq] is especially remarkable.
\end{document}
```

Let's use a totally dumb style (purple color, oldstyle numbers, roman numbering, square brackets instead of parentheses), because... why not.

```
eqno:
  style:
    font:
      features: "+onum"
    color: "purple"
    numbering:
      after:
        text: "]"
      before:
        text: "["
      display: "roman"
```

Yay!

![image](https://github.com/user-attachments/assets/68efb7d8-2e9a-4966-94a0-0804cdb0a80c)

Solid and consistent :rofl: 
