### PR TITLE
Some refactors

### DIFF
--- a/classes/resilient/base.lua
+++ b/classes/resilient/base.lua
@@ -1,7 +1,12 @@
 --
--- Base resilient class
+-- Base resilient class for SILE.
+-- Following the resilient styling paradigm.
+--
 -- 2023, 2025 Didier Willis
 -- License: MIT
+--
+-- It provides a base class for document classes that want to use styles,
+-- and a few convenience methods hide the internals.
 --
 require("silex")
 
@@ -49,9 +54,6 @@ function class:hasStyle (name)
   return self.styles:hasStyle(name)
 end
 
--- For overriding in subclass
-function class.registerStyles (_) end
-
 function class:declareOptions ()
   parent.declareOptions(self)
 
@@ -65,12 +67,14 @@ end
 
 function class:registerRawHandlers ()
   parent.registerRawHandlers(self)
-
 end
 
 function class:registerCommands ()
   parent.registerCommands(self)
-
 end
+
+-- For overriding in any document subclass, as a convenient hook
+-- where to register all styles.
+function class.registerStyles (_) end
 
 return class

--- a/classes/resilient/book.lua
+++ b/classes/resilient/book.lua
@@ -1,5 +1,7 @@
 --
--- A new advanced book class for SILE
+-- A new advanced book class for SILE.
+-- Following the resilient styling paradigm, and providing a more features.
+--
 -- 2021-2025, Didier Willis
 -- License: MIT
 --

--- a/classes/resilient/resume.lua
+++ b/classes/resilient/resume.lua
@@ -1,5 +1,7 @@
 --
 -- A minimalist SILE class for a "resumé" (CV)
+-- Following the resilient styling paradigm.
+--
 -- 2021-2023, Didier Willis
 -- License: MIT
 --

--- a/packages/resilient/abbr/init.lua
+++ b/packages/resilient/abbr/init.lua
@@ -1,5 +1,6 @@
 --
--- Some common shorthands and abbreviations
+-- Some common shorthands and abbreviations for SILE.
+--
 -- 2021-2023, Didier Willis
 -- License: MIT
 --

--- a/packages/resilient/base.lua
+++ b/packages/resilient/base.lua
@@ -1,7 +1,11 @@
 --
--- Resilient base package
--- 2023, Didier Willis
+-- Resilient base for style-enabled packages for SILE
+--
+-- 2023, 2025, Didier Willis
 -- License: MIT
+--
+-- It provides a base class for packages that want to use styles,
+-- and a few convenience methods hide the internals.
 --
 require("silex")
 local base = require("packages.base")
@@ -26,7 +30,12 @@ function package:resolveStyle (name, discardable)
   return self.styles:resolveStyle(name, discardable)
 end
 
--- For overriding in subclass
+function package:hasStyle (name)
+  return self.styles:hasStyle(name)
+end
+
+-- For overriding in any package subclass, as a convenient hook
+-- where to register all styles.
 function package.registerStyles (_) end
 
 return package

--- a/packages/resilient/bible/tei/init.lua
+++ b/packages/resilient/bible/tei/init.lua
@@ -1,6 +1,8 @@
 --
 -- TEI bible format with critical apparatus as used for the Gothic Bible
--- from wulfila.be (TEI Gothica)
+-- from wulfila.be (TEI Gothica).
+-- Following the resilient styling paradigm.
+--
 -- 2022, 2023, Didier Willis
 -- License: MIT
 --

--- a/packages/resilient/bible/usx/init.lua
+++ b/packages/resilient/bible/usx/init.lua
@@ -1,5 +1,7 @@
 --
--- USX (XML bible format) support for SILE
+-- USX (XML bible format) support for SILE.
+-- Following the resilient styling paradigm.
+--
 -- 2023, Didier Willis
 -- License: MIT
 --

--- a/packages/resilient/bookmatters/init.lua
+++ b/packages/resilient/bookmatters/init.lua
@@ -1,5 +1,12 @@
 --
--- Book matter support (mostly for master documents)
+-- Book matter support (front and back covers, half-title, title pages,
+-- endpapers, etc.) for SILE.
+-- Following the resilient styling paradigm.
+--
+-- This package is for internal use only.
+-- It is used (mostly) by the "master document".
+-- API is subject to change.
+--
 -- 2023, Didier Willis
 -- License: MIT
 --

--- a/packages/resilient/defn/init.lua
+++ b/packages/resilient/defn/init.lua
@@ -1,6 +1,8 @@
 --
--- Definition environment for SILE
+-- Definition environment for SILE,
 -- Very minimal implementation for Djot/Markdown needs, with styling support.
+-- Following the resilient styling paradigm.
+--
 -- 2023, 2025 Didier Willis
 -- License: MIT
 --

--- a/packages/resilient/epigraph/init.lua
+++ b/packages/resilient/epigraph/init.lua
@@ -1,5 +1,7 @@
 --
--- An epigraph package for SILE
+-- An epigraph package for SILE.
+-- Following the resilient styling paradigm.
+--
 -- 2021-2023, Didier Willis
 -- License: MIT
 --

--- a/packages/resilient/footnotes/init.lua
+++ b/packages/resilient/footnotes/init.lua
@@ -1,6 +1,9 @@
 --
--- Re-implementation of the footnotes package
+-- Re-implementation of the footnotes package for SILE.
+-- Following the resilient styling paradigm.
+--
 -- 2021-2023, Didier Willis
+-- License: MIT
 --
 local base = require("packages.resilient.base")
 

--- a/packages/resilient/headers/init.lua
+++ b/packages/resilient/headers/init.lua
@@ -1,9 +1,8 @@
 --
--- headers package for book-like classes
--- Core logic for activating/deactivating headers
--- and handling their output.
--- 2021-2022, Didier Willis
+-- headers package for book-like classes for SILE.
+-- Core logic for activating/deactivating headers- and handling their output.
 --
+-- 2021-2022, Didier Willis
 -- License: MIT
 --
 local base = require("packages.base")

--- a/packages/resilient/lists/init.lua
+++ b/packages/resilient/lists/init.lua
@@ -1,8 +1,11 @@
 --
--- Enumerations and bullet lists for SILE
+-- Enumerations and bullet lists for SILE.
+-- Following the resilient styling paradigm.
+
 -- This a replacement to the "lists" package introduced in SILE,
--- with (expectedly) the same user API but with additional
--- features and styling methods.
+-- with (expectedly) the same user API but with additiona features and styling
+-- methods.
+--
 -- 2021-2023, Didier Willis
 -- License: MIT
 --

--- a/packages/resilient/poetry/init.lua
+++ b/packages/resilient/poetry/init.lua
@@ -1,5 +1,7 @@
 --
--- A poetry package for SILE
+-- A poetry package for SILE.
+-- Following the resilient styling paradigm.
+--
 -- 2021, 2023 Didier Willis
 -- License: MIT
 --

--- a/packages/resilient/sectioning/init.lua
+++ b/packages/resilient/sectioning/init.lua
@@ -1,6 +1,8 @@
 --
--- Generic sectioning command and styles for SILE
--- An extension of the "styles" package and the sectioning paradigm
+-- Generic sectioning command and styles for SILE.
+-- Following the resilient styling paradigm.
+-- It is nn extension of the "styles" package and the sectioning paradigm.
+--
 -- 2021-2023, Didier Willis
 -- License: MIT
 --
@@ -18,7 +20,7 @@ function package:_init (options)
   self.class:loadPackage("counters")
 end
 
-local function hasContent()
+local function hasContentInCurrentPage()
   -- Important, flushes nodes to output queue.
   SILE.typesetter:leaveHmode()
   -- The frame breaking logic is a bit messy:
@@ -239,7 +241,7 @@ function package:registerCommands ()
     end
 
     SILE.typesetter:leaveHmode() -- Important, flushes nodes to output queue.
-    if hasContent() then
+    if hasContentInCurrentPage() then
       -- We are not at the top of a page, eject the current content.
       SILE.call("supereject")
     end
@@ -275,7 +277,7 @@ function package:registerCommands ()
 
   self:registerCommand("open-on-any-page", function (_, _)
     SILE.typesetter:leaveHmode() -- Important, flushes nodes to output queue.
-    if hasContent() then
+    if hasContentInCurrentPage() then
       -- We are not at the top of a page, eject the current content.
       SILE.call("supereject")
     end

--- a/packages/resilient/verbatim/init.lua
+++ b/packages/resilient/verbatim/init.lua
@@ -1,3 +1,10 @@
+--
+-- Re-implementation of the verbatim package for SILE
+-- Following the resilient styling paradigm.
+--
+-- 2023,-2025, Didier Willis
+-- License: MIT
+--
 local base = require("packages.resilient.base")
 
 local package = pl.class(base)
@@ -31,12 +38,9 @@ function package:registerCommands ()
     SILE.typesetter:leaveHmode()
     SILE.settings:temporarily(function()
       SILE.settings:set("typesetter.parseppattern", "\n")
-      SILE.settings:set("typesetter.obeyspaces", true) -- Dubious
-      -- IMPLEMENTATION NOTE
-      -- Contrary to SILE's original implementation, we don't set the
-      -- document.baselineskip to zero, this does not seem to be a sane thing.
-      -- Moreover we handle the right and left skip nesting, and use a true
-      -- left alignment (= infinite right stretchability rather than some 10000pt).
+      SILE.settings:set("typesetter.obeyspaces", true) -- FIXME Dubious setting
+      -- We handle the fixed part of right and left skip to support nesting.
+      -- We use use a true left alignment (= infinite right stretchability).
       SILE.settings:set("document.lskip", SILE.types.node.glue(lskip.width.length))
       SILE.settings:set("document.rskip", SILE.types.node.hfillglue(rskip.width.length))
       SILE.settings:set("document.parindent", SILE.types.node.glue())
@@ -75,7 +79,6 @@ function package:registerStyles ()
     }
   })
 end
-
 
 package.documentation = [[
 \begin{document}

--- a/resilient/adapters/frameset.lua
+++ b/resilient/adapters/frameset.lua
@@ -1,6 +1,7 @@
 --
 -- Lightweight frameset parser/solver.
 -- Aimed at resolving a master frameset so as to render it graphically, etc.
+--
 -- 2023, Didier Willis
 -- License: MIT
 --

--- a/resilient/layouts/base.lua
+++ b/resilient/layouts/base.lua
@@ -1,5 +1,6 @@
 --
 -- Base layout class (a.k.a. default/none)
+--
 -- 2022-2023, Didier Willis
 -- License: MIT
 --

--- a/resilient/layouts/canonical.lua
+++ b/resilient/layouts/canonical.lua
@@ -1,5 +1,6 @@
 --
 -- Jan Tschichold's canonical page layout.
+--
 -- 2022-2023, Didier Willis
 -- License: MIT
 --

--- a/resilient/layouts/division.lua
+++ b/resilient/layouts/division.lua
@@ -1,5 +1,6 @@
 --
 -- Division-based layouts
+--
 -- 2022-2023, Didier Willis
 -- License: MIT
 --

--- a/resilient/layouts/frenchcanon.lua
+++ b/resilient/layouts/frenchcanon.lua
@@ -1,5 +1,6 @@
 --
 -- French "Canon des Ateliers" page layout.
+--
 -- 2022-2023, Didier Willis
 -- License: MIT
 --

--- a/resilient/layouts/geometry.lua
+++ b/resilient/layouts/geometry.lua
@@ -1,5 +1,6 @@
 --
 -- Geometry page layout (explicit dimensions).
+--
 -- 2023, Didier Willis
 -- License: MIT
 --

--- a/resilient/layouts/marginal.lua
+++ b/resilient/layouts/marginal.lua
@@ -1,5 +1,6 @@
 --
--- Division-based layout with wide margin for annotations
+-- Division-based layout with wide margin for annotations.
+--
 -- 2022-2023, Didier Willis
 -- License: MIT
 --

--- a/resilient/utils.lua
+++ b/resilient/utils.lua
@@ -1,5 +1,6 @@
 --
 -- Common utilities for RESILIENT
+--
 -- 2023 Didier Willis
 -- License: MIT
 --
@@ -11,7 +12,7 @@ local function interwordSpace()
 end
 
 -- Cast a kern length (e.g. in styles), also supporting the special "iwsp"
--- pseudo unit.
+-- pseudo unit for interword space.
 local function castKern(kern)
   if type(kern) == "string" then
     local value, rest = kern:match("^(%d*)iwsp[ ]*(.*)$")


### PR DESCRIPTION
Nothing much to say, just a usual quick refactor pass on some code, without behavioral changes:
- Re-align some in-code comments across packages and classes
- Extend resilient base package API (`hasStyle`): not used yet but was clearly missing for consistency
- Use new typesetter's content to text in tableofcontents instead of re-inventing the wheel each time we need this thing.