### PR TITLE
Updates for markdown 2.4 and SILE 0.15.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Did we say complete? Well, we lied a bit. For Markdown and Djot input, there is 
 
 ## Installation
 
-These packages require SILE v0.15 or upper (recommended: SILE v0.15.8 or upper).
+These packages require SILE v0.15 or upper (recommended: SILE v0.15.10 or upper).
 
 Installation relies on the **luarocks** package manager.
 See its installation instructions on the [LuaRocks](https://luarocks.org/) website.
@@ -64,6 +64,7 @@ This collection also imports several modules also provided separately, would you
 - [Textual graphics embedders](https://github.com/Omikhleia/embedders.sile) (support for Graphviz, Lilypond, &c)
 - [Markdown](https://github.com/Omikhleia/markdown.sile) (support for Markdown, Djot etc.)
 - [Pie charts](https://github.com/Omikhleia/piecharts.sile) (support for pie charts)
+- [Code syntax highlighting](https://github.com/Omikhleia/highlighter.sile)
 
 When used with this collection, the Markdown packages and the fancy table of contents are leveraged with additional capabilities.
 

--- a/classes/resilient/book.lua
+++ b/classes/resilient/book.lua
@@ -527,7 +527,7 @@ function class:registerStyles ()
   self:registerStyle("code", {}, {
     font = {
       family = "Hack",
-      size = "1.4ex"
+      adjust = "ex-height",
     }
   })
 

--- a/examples/manual-appendices/biblio.dj
+++ b/examples/manual-appendices/biblio.dj
@@ -1,14 +1,7 @@
 # Selected bibliography
 
 ```=sile
-% For now, we use SIL language, and hack several things.
-% Eventually we'll get to a higher level of abstraction.
-%
-\use[module=packages.bibtex]
-\begin[size=10pt]{font}
-\set[parameter=document.parskip, value=4pt]
-\set[parameter=linebreak.emergencyStretch,value=1em]
-\set[parameter=linebreak.tolerance,value=2000]
+% Customize the bibliography link hook
 \lua{
 local class = SILE.documentState.documentClass
 class:registerCommand("bibLink", function (options, content)
@@ -19,11 +12,6 @@ class:registerCommand("bibLink", function (options, content)
   })
 end)
 }
-\set[parameter=document.lskip,value=3em]
-\set[parameter=document.parindent,value=-3em]
-\set[parameter=current.parindent,value=-3em]
-
-\printbibliography[cited=false]
-
-\end{font}
 ```
+
+:_BIBLIOGRAPHY_:{cited=false}

--- a/examples/manual-classes/book.dj
+++ b/examples/manual-classes/book.dj
@@ -194,6 +194,7 @@ The footnotes are based on the **resilient.footnotes** package and therefore hav
 The table of contents relies on the **resilient.tableofcontents** package. One can therefore change many styling and appearance aspects to create a custom table of contents.
 
 Cross-references are supported via the **labelrefs** package, henceforth the `\autodoc:command{\label}`{=sile}, `\autodoc:command{\ref}`{=sile} and `\autodoc:command{\pageref}`{=sile} commands are available.
+All sectioning commands accept the `marker` option to introduce a label at the appropriate place (e.g., the section title) in a convenient way.
 
 A few layout-related commands are also provided.
 

--- a/examples/manual-intro/installation.dj
+++ b/examples/manual-intro/installation.dj
@@ -16,7 +16,7 @@ Then, to install the latest official version:
 
 {custom-style=CodeBlock}
 :::
-    ```bash
+```bash
 luarocks install resilient.sile
 ```
 :::

--- a/examples/manual-masterdoc/bookmatters.dj
+++ b/examples/manual-masterdoc/bookmatters.dj
@@ -5,13 +5,13 @@ But beyond the pun, this chapter addresses usual material that make a real book.
 An assumption here is that your book is using a resilient class, such as *resilient.book*.
 We will also suppose your master document only contains the elements briefly introduced in the previous chapter, and you processed it with:
 
-```shell
+```bash
 sile -u inputters.silm mybook.silm
 ```
 
 Then you got all your parts or chapters assembled, but you do know that they do not yet make a book, right? Well, try this, now:
 
-```shell
+```bash
 sile -u inputters.silm[bookmatter=true] mybook.silm
 ```
 
@@ -96,7 +96,7 @@ In the absence of an image, a `background` element can be used to set a color fo
 
 The covers can be disabled by passing the `cover=false` option to the master document handler:
 
-```shell
+```bash
 sile -u inputters.silm[cover=false] mybook.silm
 ```
 
@@ -193,6 +193,6 @@ It then take cares of invoking the relevant SILE packages and commands.
 
 If your paper size is 6 per 9 inches (US trade book), for instance, you can print it on A4 sheets and have cropmarks shown:
 
-```shell
+```bash
 sile -u inputters.silm[cropmarks=true] -O sheetsize=a4 mybook.silm
 ```

--- a/examples/manual-masterdoc/masterdoc.dj
+++ b/examples/manual-masterdoc/masterdoc.dj
@@ -16,7 +16,7 @@ The resilient collection introduces a "master document" format which aims at sim
 
 Master documents usually have the `.silm` extension and can be processed as shown below.
 
-```shell
+```bash
 sile -u inputters.silm mybook.silm
 ```
 
@@ -263,7 +263,7 @@ In this structured form, other fields are accepted, for enforcing the input form
 Refer to the documentation of that handler to know which options are available.
 
 ```yaml
-content
+content:
   chapters:
     - file: chap1.txt
       format: markdown

--- a/examples/manual-packages/packages.dj
+++ b/examples/manual-packages/packages.dj
@@ -207,16 +207,25 @@ This package is part of the *printoptions.sile* collection.
 \package-documentation{resilient.poetry}
 ```
 
+## Definition items
+
+``` =sile
+\package-documentation{resilient.defn}
+```
+
 ## Verbatim content
 
 ``` =sile
 \package-documentation{resilient.verbatim}
 ```
 
-## Definition items
+## Syntax-highlighted code blocks
+
+{custom-style=admon}
+This package is part of the *highlighter.sile* collection.
 
 ``` =sile
-\package-documentation{resilient.defn}
+\package-documentation{highlighter}
 ```
 
 # Other input formats

--- a/examples/resilient-ecosystem.dot
+++ b/examples/resilient-ecosystem.dot
@@ -108,6 +108,15 @@ digraph omikhleia {
     smartquotes [shape=component,style=filled,fillcolor=aliceblue]
   }
 
+  subgraph cluster_highlighter {
+    label = "highlighter.sile";
+
+    highlighter [shape=component,style=filled,fillcolor=aliceblue]
+    scintillua [shape=component,style=filled,fillcolor=gainsboro,label="scintillua"]
+
+    highlighter -> scintillua
+  }
+
   subgraph cluster_markdown {
     label = "markdown.sile";
 
@@ -125,6 +134,7 @@ digraph omikhleia {
     markcmd -> ptable
     markcmd -> embedders
     markcmd -> smartquotes
+    markcmd -> highlighter
   }
 
   subgraph cluster_fancytoc {

--- a/examples/sile-resilient-manual-styles.yml
+++ b/examples/sile-resilient-manual-styles.yml
@@ -1,6 +1,7 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Omikhleia/resilient.sile/v2.8.0/schemas/stylefile.json
+# $schema: https://raw.githubusercontent.com/Omikhleia/resilient.sile/v2.8.0/schemas/stylefile.json
 
 blockquote:
-  origin: "resilient.book"
   style:
     font:
       size: "0.95em"
@@ -13,7 +14,6 @@ blockquote:
 
 bookmatter-author:
   inherit: "bookmatter-titlepage"
-  origin: "resilient.bookmatters"
   style:
     font:
       size: "16pt"
@@ -21,20 +21,17 @@ bookmatter-author:
       case: "upper"
 
 bookmatter-backcover:
-  origin: "resilient.bookmatters"
   style:
     font:
       size: "0.95em"
 
 bookmatter-copyright:
-  origin: "resilient.bookmatters"
   style:
     paragraph:
       align: "noparindent"
 
 bookmatter-cover-author:
   inherit: "bookmatter-coverpage"
-  origin: "resilient.bookmatters"
   style:
     font:
       size: "16pt"
@@ -43,12 +40,10 @@ bookmatter-cover-author:
 
 bookmatter-cover-publisher:
   inherit: "bookmatter-coverpage"
-  origin: "resilient.bookmatters"
   style:
 
 bookmatter-cover-subtitle:
   inherit: "bookmatter-coverpage"
-  origin: "resilient.bookmatters"
   style:
     font:
       size: "16pt"
@@ -58,7 +53,6 @@ bookmatter-cover-subtitle:
 
 bookmatter-cover-title:
   inherit: "bookmatter-coverpage"
-  origin: "resilient.bookmatters"
   style:
     font:
       size: "20pt"
@@ -69,11 +63,9 @@ bookmatter-cover-title:
         skip: "30%fh"
 
 bookmatter-coverpage:
-  origin: "resilient.bookmatters"
   style:
 
 bookmatter-halftitle:
-  origin: "resilient.bookmatters"
   style:
     font:
       size: "14pt"
@@ -87,7 +79,6 @@ bookmatter-halftitle:
       case: "upper"
 
 bookmatter-legal:
-  origin: "resilient.bookmatters"
   style:
     font:
       size: "0.8em"
@@ -97,12 +88,10 @@ bookmatter-legal:
 
 bookmatter-publisher:
   inherit: "bookmatter-titlepage"
-  origin: "resilient.bookmatters"
   style:
 
 bookmatter-subtitle:
   inherit: "bookmatter-titlepage"
-  origin: "resilient.bookmatters"
   style:
     font:
       size: "16pt"
@@ -112,7 +101,6 @@ bookmatter-subtitle:
 
 bookmatter-title:
   inherit: "bookmatter-titlepage"
-  origin: "resilient.bookmatters"
   style:
     font:
       size: "20pt"
@@ -123,23 +111,19 @@ bookmatter-title:
         skip: "30%fh"
 
 bookmatter-titlepage:
-  origin: "resilient.bookmatters"
   style:
 
 code:
-  origin: "resilient.book"
   style:
     font:
+      adjust: "ex-height"
       family: "Hack"
-      size: "1.4ex"
 
 defn-base:
-  origin: "resilient.defn"
   style:
 
 defn-desc:
   inherit: "defn-base"
-  origin: "resilient.defn"
   style:
     paragraph:
       after:
@@ -157,7 +141,6 @@ defn-desc-Simple:
 
 defn-term:
   inherit: "defn-base"
-  origin: "resilient.defn"
   style:
     font:
       weight: 700
@@ -176,7 +159,6 @@ defn-term-Simple:
       align: "noparindent"
 
 dropcap:
-  origin: "resilient.book"
   style:
     font:
       family: "Zallman Caps"
@@ -184,7 +166,6 @@ dropcap:
       lines: 2
 
 epigraph:
-  origin: "resilient.epigraph"
   style:
     font:
       size: "0.9em"
@@ -195,7 +176,6 @@ epigraph:
         skip: "medskip"
 
 epigraph-source:
-  origin: "resilient.epigraph"
   style:
     paragraph:
       align: "right"
@@ -205,7 +185,6 @@ epigraph-source:
 
 epigraph-source-norule:
   inherit: "epigraph-source"
-  origin: "resilient.epigraph"
   style:
     paragraph:
       before:
@@ -213,18 +192,15 @@ epigraph-source-norule:
 
 epigraph-source-rule:
   inherit: "epigraph-source"
-  origin: "resilient.epigraph"
   style:
 
 epigraph-text:
   inherit: "epigraph"
-  origin: "resilient.epigraph"
   style:
     paragraph:
       align: "justify"
 
 eqno:
-  origin: "resilient.book"
   style:
     numbering:
       after:
@@ -253,7 +229,6 @@ fancytoc-pageno:
       features: "+onum"
 
 figure:
-  origin: "resilient.book"
   style:
     paragraph:
       after:
@@ -264,7 +239,6 @@ figure:
         skip: "smallskip"
 
 figure-caption:
-  origin: "resilient.book"
   style:
     font:
       size: "0.95em"
@@ -289,12 +263,10 @@ figure-caption:
         toclevel: 5
 
 figure-caption-base-number:
-  origin: "resilient.book"
   style:
 
 figure-caption-main-number:
   inherit: "figure-caption-base-number"
-  origin: "resilient.book"
   style:
     font:
       features: "+smcp"
@@ -307,27 +279,23 @@ figure-caption-main-number:
 
 figure-caption-ref-number:
   inherit: "figure-caption-base-number"
-  origin: "resilient.book"
   style:
     numbering:
       before:
         text: "fig. "
 
 folio-backmatter:
-  origin: "resilient.book"
   style:
     numbering:
       display: "arabic"
 
 folio-base:
-  origin: "resilient.book"
   style:
     font:
       features: "+onum"
 
 folio-even:
   inherit: "folio-base"
-  origin: "resilient.book"
   style:
     paragraph:
       align: "left"
@@ -335,20 +303,17 @@ folio-even:
         indent: false
 
 folio-frontmatter:
-  origin: "resilient.book"
   style:
     numbering:
       display: "roman"
 
 folio-mainmatter:
-  origin: "resilient.book"
   style:
     numbering:
       display: "arabic"
 
 folio-odd:
   inherit: "folio-base"
-  origin: "resilient.book"
   style:
     paragraph:
       align: "right"
@@ -356,7 +321,6 @@ folio-odd:
         indent: false
 
 footnote:
-  origin: "resilient.footnotes"
   style:
     font:
       size: "0.8em"
@@ -364,7 +328,6 @@ footnote:
       display: "arabic"
 
 footnote-marker:
-  origin: "resilient.footnotes"
   style:
     numbering:
       after:
@@ -374,7 +337,6 @@ footnote-marker:
 
 footnote-marker-counter:
   inherit: "footnote-marker"
-  origin: "resilient.footnotes"
   style:
     numbering:
       after:
@@ -382,27 +344,22 @@ footnote-marker-counter:
 
 footnote-marker-symbol:
   inherit: "footnote-marker"
-  origin: "resilient.footnotes"
   style:
 
 footnote-reference:
-  origin: "resilient.footnotes"
   style:
     properties:
       position: "super"
 
 footnote-reference-counter:
   inherit: "footnote-reference"
-  origin: "resilient.footnotes"
   style:
 
 footnote-reference-symbol:
   inherit: "footnote-reference"
-  origin: "resilient.footnotes"
   style:
 
 header-base:
-  origin: "resilient.book"
   style:
     font:
       size: "0.9em"
@@ -414,20 +371,182 @@ header-base:
 
 header-even:
   inherit: "header-base"
-  origin: "resilient.book"
   style:
 
 header-odd:
   inherit: "header-base"
-  origin: "resilient.book"
   style:
     font:
       style: "italic"
     paragraph:
       align: "right"
 
+highlight-addition:
+  style:
+    color: "#7F6600"
+    decoration:
+      color: "#FFDE8A"
+      line: "mark"
+
+highlight-attribute:
+  style:
+    color: "#0000C0"
+
+highlight-bold:
+  style:
+    font:
+      weight: 400
+
+highlight-change:
+  style:
+    color: "#0000C0"
+    decoration:
+      color: "#B2D8FF"
+      line: "mark"
+
+highlight-class:
+  style:
+    color: "#C99000"
+
+highlight-command:
+  style:
+    color: "#7F0055"
+
+highlight-command.section:
+  style:
+    color: "#C99000"
+
+highlight-comment:
+  style:
+    color: "#8E908C"
+    font:
+      style: "italic"
+
+highlight-constant:
+  style:
+    color: "#116644"
+
+highlight-constant.builtin:
+  style:
+    color: "#F5871F"
+
+highlight-deletion:
+  style:
+    color: "#8B0000"
+    decoration:
+      color: "#F6B2B2"
+      line: "mark"
+      rough: true
+
+highlight-embedded:
+  style:
+    color: "#4271AE"
+
+highlight-environment:
+  style:
+    color: "#C99000"
+
+highlight-environment.math:
+  style:
+    color: "#116644"
+
+highlight-error:
+  style:
+    color: "#8B0000"
+
+highlight-function:
+  style:
+    color: "#4271AE"
+
+highlight-function.builtin:
+  style:
+    color: "#4271AE"
+
+highlight-function.method:
+  style:
+    color: "#4271AE"
+
+highlight-heading:
+  style:
+    color: "#2A00FF"
+
+highlight-identifier:
+  style:
+    color: "#3F009B"
+
+highlight-italic:
+  style:
+    font:
+      style: "italic"
+
+highlight-keyword:
+  style:
+    color: "#7F0055"
+
+highlight-label:
+  style:
+    color: "#2A00FF"
+
+highlight-link:
+  style:
+    decoration:
+      line: "underline"
+
+highlight-list:
+  style:
+    color: "#116644"
+
+highlight-number:
+  style:
+    color: "#116644"
+
+highlight-operator:
+  style:
+    color: "#3E999F"
+
+highlight-preprocessor:
+  style:
+    color: "#4D4D4C"
+
+highlight-property:
+  style:
+    color: "#0000C0"
+
+highlight-reference:
+  style:
+    decoration:
+      line: "underline"
+
+highlight-regex:
+  style:
+    color: "#0000C0"
+
+highlight-string:
+  style:
+    color: "#3F7F5F"
+
+highlight-tag:
+  style:
+    color: "#7F0055"
+
+highlight-type:
+  style:
+    color: "#C99000"
+
+highlight-underline:
+  style:
+    decoration:
+      line: "underline"
+
+highlight-variable:
+  style:
+    color: "#0000C0"
+
+highlight-variable.builtin:
+  style:
+    color: "#C82829"
+
 listing:
-  origin: "resilient.book"
   style:
     paragraph:
       after:
@@ -436,7 +555,6 @@ listing:
         indent: false
 
 listing-caption:
-  origin: "resilient.book"
   style:
     font:
       size: "0.95em"
@@ -461,12 +579,10 @@ listing-caption:
         toclevel: 7
 
 listing-caption-base-number:
-  origin: "resilient.book"
   style:
 
 listing-caption-main-number:
   inherit: "listing-caption-base-number"
-  origin: "resilient.book"
   style:
     font:
       features: "+smcp"
@@ -479,7 +595,6 @@ listing-caption-main-number:
 
 listing-caption-ref-number:
   inherit: "listing-caption-base-number"
-  origin: "resilient.book"
   style:
     numbering:
       before:
@@ -487,7 +602,6 @@ listing-caption-ref-number:
 
 lists-enumerate-alternate1:
   inherit: "lists-enumerate-base"
-  origin: "resilient.lists"
   style:
     numbering:
       after:
@@ -496,7 +610,6 @@ lists-enumerate-alternate1:
 
 lists-enumerate-alternate2:
   inherit: "lists-enumerate-base"
-  origin: "resilient.lists"
   style:
     numbering:
       after:
@@ -505,7 +618,6 @@ lists-enumerate-alternate2:
 
 lists-enumerate-alternate3:
   inherit: "lists-enumerate-base"
-  origin: "resilient.lists"
   style:
     numbering:
       after:
@@ -514,7 +626,6 @@ lists-enumerate-alternate3:
 
 lists-enumerate-alternate4:
   inherit: "lists-enumerate-base"
-  origin: "resilient.lists"
   style:
     font:
       style: "italic"
@@ -525,18 +636,15 @@ lists-enumerate-alternate4:
 
 lists-enumerate-alternate5:
   inherit: "lists-enumerate-base"
-  origin: "resilient.lists"
   style:
     enumerate:
       symbol: "U+2474"
 
 lists-enumerate-base:
-  origin: "resilient.lists"
   style:
 
 lists-enumerate1:
   inherit: "lists-enumerate-base"
-  origin: "resilient.lists"
   style:
     numbering:
       after:
@@ -545,7 +653,6 @@ lists-enumerate1:
 
 lists-enumerate2:
   inherit: "lists-enumerate-base"
-  origin: "resilient.lists"
   style:
     numbering:
       after:
@@ -554,7 +661,6 @@ lists-enumerate2:
 
 lists-enumerate3:
   inherit: "lists-enumerate-base"
-  origin: "resilient.lists"
   style:
     numbering:
       after:
@@ -563,7 +669,6 @@ lists-enumerate3:
 
 lists-enumerate4:
   inherit: "lists-enumerate-base"
-  origin: "resilient.lists"
   style:
     numbering:
       after:
@@ -572,7 +677,6 @@ lists-enumerate4:
 
 lists-enumerate5:
   inherit: "lists-enumerate-base"
-  origin: "resilient.lists"
   style:
     numbering:
       after:
@@ -583,88 +687,75 @@ lists-enumerate5:
 
 lists-itemize-alternate1:
   inherit: "lists-itemize-base"
-  origin: "resilient.lists"
   style:
     itemize:
       symbol: "—"
 
 lists-itemize-alternate2:
   inherit: "lists-itemize-base"
-  origin: "resilient.lists"
   style:
     itemize:
       symbol: "•"
 
 lists-itemize-alternate3:
   inherit: "lists-itemize-base"
-  origin: "resilient.lists"
   style:
     itemize:
       symbol: "◦"
 
 lists-itemize-alternate4:
   inherit: "lists-itemize-base"
-  origin: "resilient.lists"
   style:
     itemize:
       symbol: "–"
 
 lists-itemize-alternate5:
   inherit: "lists-itemize-base"
-  origin: "resilient.lists"
   style:
     itemize:
       symbol: "•"
 
 lists-itemize-alternate6:
   inherit: "lists-itemize-base"
-  origin: "resilient.lists"
   style:
     itemize:
       symbol: "◦"
 
 lists-itemize-base:
-  origin: "resilient.lists"
   style:
 
 lists-itemize1:
   inherit: "lists-itemize-base"
-  origin: "resilient.lists"
   style:
     itemize:
       symbol: "•"
 
 lists-itemize2:
   inherit: "lists-itemize-base"
-  origin: "resilient.lists"
   style:
     itemize:
       symbol: "◦"
 
 lists-itemize3:
   inherit: "lists-itemize-base"
-  origin: "resilient.lists"
   style:
     itemize:
       symbol: "–"
 
 lists-itemize4:
   inherit: "lists-itemize-base"
-  origin: "resilient.lists"
   style:
     itemize:
       symbol: "•"
 
 lists-itemize5:
   inherit: "lists-itemize-base"
-  origin: "resilient.lists"
   style:
     itemize:
       symbol: "◦"
 
 lists-itemize6:
   inherit: "lists-itemize-base"
-  origin: "resilient.lists"
   style:
     itemize:
       symbol: "–"
@@ -677,7 +768,6 @@ md-mark:
       rough: true
 
 poetry:
-  origin: "resilient.poetry"
   style:
     font:
       size: "0.95em"
@@ -689,13 +779,11 @@ poetry:
         skip: "medskip"
 
 poetry-prosody:
-  origin: "resilient.poetry"
   style:
     font:
       style: "normal"
 
 poetry-verseno:
-  origin: "resilient.poetry"
   style:
     font:
       features: "+onum"
@@ -704,7 +792,6 @@ poetry-verseno:
       display: "arabic"
 
 prosody:
-  origin: "resilient.poetry"
   style:
     font:
       size: "0.95em"
@@ -715,7 +802,6 @@ prosody:
 
 sectioning-appendix:
   inherit: "sectioning-chapter"
-  origin: "resilient.book"
   style:
     sectioning:
       numberstyle:
@@ -725,26 +811,22 @@ sectioning-appendix:
 
 sectioning-appendix-head-number:
   inherit: "sectioning-chapter-head-number"
-  origin: "resilient.book"
   style:
 
 sectioning-appendix-main-number:
   inherit: "sectioning-chapter-main-number"
-  origin: "resilient.book"
   style:
     numbering:
       display: "ALPHA"
 
 sectioning-appendix-ref-number:
   inherit: "sectioning-chapter-ref-number"
-  origin: "resilient.book"
   style:
     numbering:
       before:
         text: "app. "
 
 sectioning-base:
-  origin: "resilient.book"
   style:
     paragraph:
       after:
@@ -754,7 +836,6 @@ sectioning-base:
 
 sectioning-chapter:
   inherit: "sectioning-base"
-  origin: "resilient.book"
   style:
     font:
       size: "1.4em"
@@ -776,12 +857,10 @@ sectioning-chapter:
         toclevel: 1
 
 sectioning-chapter-base-number:
-  origin: "resilient.book"
   style:
 
 sectioning-chapter-head-number:
   inherit: "sectioning-chapter-base-number"
-  origin: "resilient.book"
   style:
     numbering:
       after:
@@ -790,7 +869,6 @@ sectioning-chapter-head-number:
 
 sectioning-chapter-main-number:
   inherit: "sectioning-chapter-base-number"
-  origin: "resilient.book"
   style:
     color: "#66a0b3"
     font:
@@ -798,19 +876,16 @@ sectioning-chapter-main-number:
     numbering:
       after:
         kern: "3spc"
-      before:
       standalone: false
 
 sectioning-chapter-ref-number:
   inherit: "sectioning-chapter-base-number"
-  origin: "resilient.book"
   style:
     numbering:
       before:
         text: "chap. "
 
 sectioning-other-number:
-  origin: "resilient.book"
   style:
     numbering:
       after:
@@ -819,7 +894,6 @@ sectioning-other-number:
 
 sectioning-part:
   inherit: "sectioning-base"
-  origin: "resilient.book"
   style:
     font:
       size: "1.6em"
@@ -844,14 +918,12 @@ sectioning-part:
         toclevel: 0
 
 sectioning-part-base-number:
-  origin: "resilient.book"
   style:
     numbering:
       display: "ROMAN"
 
 sectioning-part-head-number:
   inherit: "sectioning-part-base-number"
-  origin: "resilient.book"
   style:
     numbering:
       after:
@@ -860,7 +932,6 @@ sectioning-part-head-number:
 
 sectioning-part-main-number:
   inherit: "sectioning-part-base-number"
-  origin: "resilient.book"
   style:
     font:
       features: "+smcp"
@@ -871,7 +942,6 @@ sectioning-part-main-number:
 
 sectioning-part-ref-number:
   inherit: "sectioning-part-base-number"
-  origin: "resilient.book"
   style:
     numbering:
       before:
@@ -879,7 +949,6 @@ sectioning-part-ref-number:
 
 sectioning-section:
   inherit: "sectioning-base"
-  origin: "resilient.book"
   style:
     font:
       size: "1.2em"
@@ -903,7 +972,6 @@ sectioning-section:
 
 sectioning-subsection:
   inherit: "sectioning-base"
-  origin: "resilient.book"
   style:
     font:
       size: "1.1em"
@@ -926,7 +994,6 @@ sectioning-subsection:
 
 sectioning-subsubsection:
   inherit: "sectioning-base"
-  origin: "resilient.book"
   style:
     font:
       weight: 700
@@ -946,7 +1013,6 @@ sectioning-subsubsection:
         toclevel: 4
 
 table:
-  origin: "resilient.book"
   style:
     paragraph:
       after:
@@ -956,7 +1022,6 @@ table:
         indent: false
 
 table-caption:
-  origin: "resilient.book"
   style:
     font:
       size: "0.95em"
@@ -980,12 +1045,10 @@ table-caption:
         toclevel: 6
 
 table-caption-base-number:
-  origin: "resilient.book"
   style:
 
 table-caption-main-number:
   inherit: "table-caption-base-number"
-  origin: "resilient.book"
   style:
     font:
       features: "+smcp"
@@ -998,23 +1061,19 @@ table-caption-main-number:
 
 table-caption-ref-number:
   inherit: "table-caption-base-number"
-  origin: "resilient.book"
   style:
     numbering:
       before:
         text: "table "
 
 toc:
-  origin: "resilient.tableofcontents"
   style:
 
 toc-level-base:
-  origin: "resilient.tableofcontents"
   style:
 
 toc-level0:
   inherit: "toc-level-base"
-  origin: "resilient.tableofcontents"
   style:
     font:
       size: "1.15em"
@@ -1032,7 +1091,6 @@ toc-level0:
 
 toc-level1:
   inherit: "toc-level-base"
-  origin: "resilient.tableofcontents"
   style:
     font:
       size: "1.1em"
@@ -1047,7 +1105,6 @@ toc-level1:
 
 toc-level2:
   inherit: "toc-level-base"
-  origin: "resilient.tableofcontents"
   style:
     font:
       size: "1em"
@@ -1060,7 +1117,6 @@ toc-level2:
 
 toc-level3:
   inherit: "toc-level-base"
-  origin: "resilient.tableofcontents"
   style:
     paragraph:
       after:
@@ -1072,7 +1128,6 @@ toc-level3:
 
 toc-level4:
   inherit: "toc-level-base"
-  origin: "resilient.tableofcontents"
   style:
     paragraph:
       after:
@@ -1084,7 +1139,6 @@ toc-level4:
 
 toc-level5:
   inherit: "toc-level-base"
-  origin: "resilient.tableofcontents"
   style:
     paragraph:
       after:
@@ -1096,7 +1150,6 @@ toc-level5:
 
 toc-level6:
   inherit: "toc-level-base"
-  origin: "resilient.tableofcontents"
   style:
     paragraph:
       after:
@@ -1108,7 +1161,6 @@ toc-level6:
 
 toc-level7:
   inherit: "toc-level-base"
-  origin: "resilient.tableofcontents"
   style:
     paragraph:
       before:
@@ -1118,7 +1170,6 @@ toc-level7:
 
 toc-level8:
   inherit: "toc-level-base"
-  origin: "resilient.tableofcontents"
   style:
     paragraph:
       before:
@@ -1128,7 +1179,6 @@ toc-level8:
 
 toc-level9:
   inherit: "toc-level-base"
-  origin: "resilient.tableofcontents"
   style:
     paragraph:
       before:
@@ -1137,7 +1187,6 @@ toc-level9:
       pageno: false
 
 toc-number-base:
-  origin: "resilient.tableofcontents"
   style:
     numbering:
       after:
@@ -1146,32 +1195,26 @@ toc-number-base:
 
 toc-number-level0:
   inherit: "toc-number-base"
-  origin: "resilient.tableofcontents"
   style:
 
 toc-number-level1:
   inherit: "toc-number-base"
-  origin: "resilient.tableofcontents"
   style:
 
 toc-number-level2:
   inherit: "toc-number-base"
-  origin: "resilient.tableofcontents"
   style:
 
 toc-number-level3:
   inherit: "toc-number-base"
-  origin: "resilient.tableofcontents"
   style:
 
 toc-number-level4:
   inherit: "toc-number-base"
-  origin: "resilient.tableofcontents"
   style:
 
 toc-number-level5:
   inherit: "toc-number-base"
-  origin: "resilient.tableofcontents"
   style:
     font:
       features: "+smcp"
@@ -1184,7 +1227,6 @@ toc-number-level5:
 
 toc-number-level6:
   inherit: "toc-number-base"
-  origin: "resilient.tableofcontents"
   style:
     font:
       features: "+smcp"
@@ -1197,31 +1239,25 @@ toc-number-level6:
 
 toc-number-level7:
   inherit: "toc-number-base"
-  origin: "resilient.tableofcontents"
   style:
 
 toc-number-level8:
   inherit: "toc-number-base"
-  origin: "resilient.tableofcontents"
   style:
 
 toc-number-level9:
   inherit: "toc-number-base"
-  origin: "resilient.tableofcontents"
   style:
 
 toc-pageno:
-  origin: "resilient.tableofcontents"
   style:
 
 url:
   inherit: "code"
-  origin: "resilient.book"
   style:
 
 verbatim:
   inherit: "code"
-  origin: "resilient.verbatim"
   style:
     paragraph:
       after:

--- a/examples/sile-resilient-manual.silm
+++ b/examples/sile-resilient-manual.silm
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Omikhleia/resilient.sile/v2.8.0/schemas/masterfile.json
+# $schema: https://raw.githubusercontent.com/Omikhleia/resilient.sile/v2.8.0/schemas/masterfile.json
 masterfile: 1.0
 metadata:
   title: The re·sil·ient collection of classes & packages for SILE
@@ -9,7 +11,7 @@ metadata:
     - book
   authors: Didier Willis
   publisher: Omikhleia
-  pubdate: 2025-01-31
+  pubdate: 2025-03-22
   url: https://github.com/Omikhleia/resilient.sile
   copyright: © 2021–2025, Didier Willis.
   legal: |

--- a/examples/typography.bib
+++ b/examples/typography.bib
@@ -1,4 +1,4 @@
--- Major books on typography
+-- Selected works books on typography and digital typesetting
 
 @book{bringhurst2002,
   title      = {The Elements of Typographic Style},
@@ -93,7 +93,7 @@
   title      = {The SILE Book},
   author     = {Cozens, Simon and Maclennan, Caleb and Nicole, Olivier and Willis, Didier},
   origdate   = {2014},
-  date       = {2024},
+  date       = {2025},
   url        = {https://sile-typesetter.org/},
 }
 

--- a/packages/resilient/styles/init.lua
+++ b/packages/resilient/styles/init.lua
@@ -141,6 +141,10 @@ function package.writeStyles () -- NOTE: Not called as a package method (invoked
   SU.debug("resilient.styles", "Writing style file", fname, ":", count, "new style(s)")
   local styfile, err = io.open(fname, "w")
   if not styfile then return SU.error(err) end
+  styfile:write([[
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Omikhleia/resilient.sile/v2.8.0/schemas/stylefile.json
+# $schema: https://raw.githubusercontent.com/Omikhleia/resilient.sile/v2.8.0/schemas/stylefile.json
+]])
   styfile:write(stydata)
   styfile:close()
 end
@@ -192,17 +196,17 @@ SILE.scratch.styles = {
 }
 
 -- programmatically define a style
--- optional origin allows tracking e.g which package declared that style.
+-- optional origin allows tracking e.g which package declared that style and just used for debugging
 -- after styles are 'frozen', we can still define new styles but not override
 -- existing styles.
 function package.defineStyle (_, name, opts, styledef, origin)
   if SILE.scratch.styles.state.locked then
     if SILE.scratch.styles.specs[name] then
-      return SU.debug("resilient.styles", "Styles are now frozen: ignoring redefinition for", name)
+      return SU.debug("resilient.styles", "Styles are now frozen: ignoring redefinition for", name, "from", origin)
     end
-    SU.debug("resilient.styles", "Defining new style", name)
+    SU.debug("resilient.styles", "Defining new style", name, "from", origin)
   end
-  SILE.scratch.styles.specs[name] = { inherit = opts.inherit, style = styledef, origin = origin }
+  SILE.scratch.styles.specs[name] = { inherit = opts.inherit, style = styledef }
 end
 
 

--- a/packages/resilient/verbatim/init.lua
+++ b/packages/resilient/verbatim/init.lua
@@ -20,7 +20,9 @@ function package:registerCommands ()
     this warning and possibly report an issue, depending on your findings.
 ]])
     options.family = options.family or "Hack"
-    options.size = options.size or SILE.settings:get("font.size") - 3
+    if not options.size and not options.adjust then
+      options.adjust = "ex-height"
+    end
     SILE.call("font", options, content)
   end)
 

--- a/schemas/masterfile.json
+++ b/schemas/masterfile.json
@@ -1,6 +1,6 @@
 {
-  "$id": "urn:example:omikhleia:resilient-masterfile:v1.0.0",
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:example:omikhleia:resilient:masterfile",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "additionalProperties": true,
   "properties": {

--- a/schemas/stylefile.json
+++ b/schemas/stylefile.json
@@ -1,0 +1,403 @@
+{
+  "$id": "urn:example:omikhleia:resilient:stylefile",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "additionalProperties": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "inherit": {
+        "description": "Name of the style to inherit from",
+        "type": "string"
+      },
+      "origin": {
+        "description": "DEPRECATED",
+        "type": "string"
+      },
+      "style": {
+        "description": "Style definition",
+        "$ref": "#/$defs/BaseStyle"
+      }
+    }
+  },
+  "properties": {},
+  "$defs": {
+    "BaseStyle": {
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "additionalProperties": false,
+          "type": "object",
+          "properties": {
+            "font": {
+              "description": "Font specification",
+              "$ref": "#/$defs/FontSpecification"
+            },
+            "color": {
+              "description": "Color specification",
+              "$ref": "#/$defs/ColorSpecification"
+            },
+            "properties": {
+              "description": "Character properties",
+              "additionalProperties": false,
+              "type": "object",
+              "properties": {
+                "position": {
+                  "description": "Position of the text",
+                  "type": "string",
+                  "enum": [
+                    "normal",
+                    "super",
+                    "sub"
+                  ]
+                },
+                "case": {
+                  "description": "Case of the text",
+                  "oneOf": [
+                    {
+                      "type": "string",
+                      "enum": [
+                        "normal",
+                        "upper",
+                        "lower",
+                        "title"
+                      ]
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                }
+              }
+            },
+            "decoration": {
+              "description": "Decoration specification",
+              "$ref": "#/$defs/DecorationSpecification"
+            },
+            "numbering": {
+              "description": "Numbering properties",
+              "$ref": "#/$defs/NumberingProperties"
+            },
+            "paragraph": {
+              "description": "Paragraph properties",
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "align": {
+                  "description": "Alignment of the paragraph",
+                  "type": "string"
+                },
+                "before": {
+                  "description": "Properties before the paragraph",
+                  "$ref": "#/$defs/ParagraphProperties"
+                },
+                "after": {
+                  "description": "Properties after the paragraph",
+                  "$ref": "#/$defs/ParagraphProperties"
+                }
+              }
+            },
+            "sectioning": {
+              "description": "Sectioning specification",
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "counter": {
+                  "description": "Counter properties",
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "id": {
+                      "description": "Counter ID",
+                      "type": "string"
+                    },
+                    "level": {
+                      "description": "Level of the section",
+                      "type": "integer"
+                    }
+                  }
+                },
+                "settings": {
+                  "description": "Settings for the sectioning style",
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "toclevel": {
+                      "description": "Level in the table of contents",
+                      "type": "integer"
+                    },
+                    "bookmark": {
+                      "description": "Whether to create a bookmark",
+                      "type": "boolean"
+                    },
+                    "open": {
+                      "description": "Whether to start on an odd page, on any page, or unset",
+                      "type": "string",
+                      "enum": [
+                        "unset",
+                        "any",
+                        "odd"
+                      ]
+                    },
+                    "goodbreak": {
+                      "description": "Whether a good break is considered good",
+                      "type": "boolean"
+                    }
+                  }
+                },
+                "numberstyle": {
+                  "description": "Numbering style",
+                  "type": "object",
+                  "properties": {
+                    "main": {
+                      "description": "Main numbering style name",
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "header": {
+                      "description": "Header numbering style name",
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "reference": {
+                      "description": "Reference numbering style name",
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  }
+                },
+                "hook": {
+                  "description": "Hook command",
+                  "type": "string"
+                }
+              }
+            },
+            "special": {
+              "description": "Special properties",
+              "$ref": "#/$defs/SpecialProperties"
+            },
+            "enumerate": {
+              "description": "Enumerate properties",
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "symbol": {
+                  "description": "Symbol for the enumerate",
+                  "type": "string"
+                }
+              }
+            },
+            "itemize": {
+              "description": "Itemize properties",
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "symbol": {
+                  "description": "Symbol for the itemize",
+                  "type": "string"
+                }
+              }
+            },
+            "toc": {
+              "oneOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "description": "Table of contents properties",
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "pageno": {
+                      "description": "Whether to display the page number",
+                      "type": "boolean"
+                    },
+                    "dotfill": {
+                      "description": "Whether to fill with dots",
+                      "type": "boolean"
+                    },
+                    "numbered": {
+                      "description": "Whether the table of contents is numbered",
+                      "type": "boolean"
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "FontSpecification": {
+      "type": "object",
+      "properties": {
+        "family": {
+          "description": "Font family",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "size": {
+          "description": "Font size (in absolute or relative units)",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "weight": {
+          "description": "Font weight",
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "style": {
+          "description": "Font style",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "features": {
+          "description": "Font features",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "ColorSpecification": {
+      "type": "string",
+      "pattern": "^(#[0-9a-fA-F]{6}|[a-zA-Z]+)$"
+    },
+    "DecorationSpecification": {
+      "type": "object",
+      "properties": {
+        "line": {
+          "description": "Type of line decoration",
+          "type": "string",
+          "enum": [
+            "underline",
+            "strikethrough",
+            "redacted",
+            "mark"
+          ]
+        },
+        "color": {
+          "description": "Color of the decoration",
+          "$ref": "#/$defs/ColorSpecification"
+        },
+        "thickness": {
+          "description": "Thickness of the decoration line (for underline and strikethrough)",
+          "type": "number"
+        },
+        "rough": {
+          "description": "Whether to use a rough decoration",
+          "type": "boolean"
+        },
+        "fillstyle": {
+          "description": "Fill style for the rough decoration",
+          "type": "string",
+          "enum": [
+            "hachure",
+            "solid",
+            "zigzag",
+            "cross-hatch",
+            "dashed",
+            "zigzag-line"
+          ]
+        }
+      }
+    },
+    "NumberingProperties": {
+      "type": "object",
+      "properties": {
+        "display": {
+          "description": "Format of the numbering",
+          "type": "string"
+        },
+        "before": {
+          "description": "Properties before the numbering",
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "text": {
+              "description": "Text before the numbering",
+              "type": "string"
+            },
+            "kern": {
+              "description": "Kerning before the numbering",
+              "type": "string"
+            }
+          }
+        },
+        "after": {
+          "description": "Properties after the numbering",
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "text": {
+              "description": "Text after the numbering",
+              "type": "string"
+            },
+            "kern": {
+              "description": "Kerning after the numbering",
+              "type": "string"
+            }
+          }
+        },
+        "standalone": {
+          "description": "Whether the numbering is standalone (for sectioning styles only)",
+          "type": "boolean"
+        }
+      }
+    },
+    "SpecialProperties": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "lines": {
+          "description": "Number of drop cap lines",
+          "type": "integer"
+        }
+      }
+    },
+    "ParagraphProperties": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "skip": {
+          "description": "Vertical glue space",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "indent": {
+          "description": "Whether to indent",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "vbreak": {
+          "description": "Whether page break is allowed",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        }
+      }
+    }
+  }
+}

--- a/schemas/stylefile.json
+++ b/schemas/stylefile.json
@@ -253,6 +253,18 @@
             "null"
           ]
         },
+        "adjust": {
+          "description": "Adjustment of the font size",
+          "oneOf": [
+              {
+                "type": "string",
+                "pattern": "^([0-9](\\.[0-9]+)?)?\\s*(ex-height|cap-height)$"
+              },
+              {
+                "type": "null"
+              }
+            ]
+        },
         "weight": {
           "description": "Font weight",
           "type": [


### PR DESCRIPTION
Normally not much to do, but let's check.

- feat: Switch to ex-height adjustment in default code style -> will need proper discussion in the release notes.
- The rest is mostly cosmetic