### PR TITLE
Licence change, removal of silex dependency

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,39 @@
+# Contributing guide
+
+Thank you for investing your time in contributing to our project. ❤️
+
+This repository is part of the _re·sil·ient_ ecosystem, with the main project being the [**resilient.sile**](https://github.com/Omikhleia/resilient.sile) collection of classes and packages.
+
+We are excited to have you on board and look forward to your contributions. This guide will help you understand how to contribute effectively and what we expect from you.
+
+## License grants for contributions
+
+### License grants for submitted code
+
+By submitting code, you agree to license your contribution under the same license as the project (the GPL-3.0 license), or any other license that is compatible with the GPL-3.0 license. This means that your code will be available for others to use, modify, and distribute under the same terms as the _re·sil·ient_ project itself.
+
+You also agree that the owner(s) and maintainer(s)-in-chief of the _re·sil·ient_ project may relicense, at their sole discretion, any part of the code under the same license as the SILE Typesetter, as long as the latter remains open source, for the purpose of up-streaming patches and features to the SILE project, when they are deemed useful in its larger context. In other words, while _re·sil·ient_ is not dual-licensed, the owner(s) and maintainer(s)-in-chief of the project may choose to relicense your contribution without seeking your permission, for up-streaming purposes only. This is to ensure that the features introduced in _re·sil·ient_ can be made available to the SILE Typesetter project, which is a separate project with its own owners and distributed under a different license (currently the MIT license, uncompatible with the GPL-3.0 license).
+
+The _re·sil·ient_ project owes a lot to the SILE Typesetter project, and on a case-by-case basis, we may choose to relicense components that would be useful to it, and that are not already part of it. This is a way to give back to the SILE community and ensure that the features we develop can benefit a wider audience.
+
+### License grants for submitted documentation
+
+By submitting documentation, you agree to license your contribution under the same license as the project (CC-BY-SA 2.0 or any other license that is compatible with the CC-BY-SA 2.0 license). This means that your documentation will be available for others to use, modify, and distribute under the same terms as the project itself.
+
+By documentation, we mean any text, images, or other content that you submit to the project, including but not limited to README files, user guides, and other in-code documentation content.
+
+## Issues first, Pull Requests later
+
+Always ensure your issue is not already reported before creating a new one. If you find an existing issue that matches your problem, please add any relevant information to that issue instead of creating a new one.
+
+Please refrain from submitting Pull Requests (PRs) before discussing your ideas in the Issues section. This will help us understand your intentions and provide feedback on your proposed changes.
+
+This is especially important for larger changes or new features, as we want to ensure that your work aligns with the project's goals and direction.
+
+## Code style
+
+- Use spaces instead of tabs for indentation.
+- Use 2 spaces for indentation.
+- Write clear and concise comments to explain complex code, and use LDoc-style comments for functions and classes.
+- Follow the existing code style and conventions in the project.
+- When modifying existing code, try to maintain the same style and structure as the surrounding code, and avoid introducing unnecessary changes.

--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,622 @@
-MIT License
 
-Copyright (c) 2022 Omikhleia
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+ Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+                            Preamble
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+  The GNU General Public License is a free, copyleft license for
+software and other kinds of works.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+the GNU General Public License is intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.  We, the Free Software Foundation, use the
+GNU General Public License for most of our software; it applies also to
+any other work released this way by its authors.  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  To protect your rights, we need to prevent others from denying you
+these rights or asking you to surrender the rights.  Therefore, you have
+certain responsibilities if you distribute copies of the software, or if
+you modify it: responsibilities to respect the freedom of others.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must pass on to the recipients the same
+freedoms that you received.  You must make sure that they, too, receive
+or can get the source code.  And you must show them these terms so they
+know their rights.
+
+  Developers that use the GNU GPL protect your rights with two steps:
+(1) assert copyright on the software, and (2) offer you this License
+giving you legal permission to copy, distribute and/or modify it.
+
+  For the developers' and authors' protection, the GPL clearly explains
+that there is no warranty for this free software.  For both users' and
+authors' sake, the GPL requires that modified versions be marked as
+changed, so that their problems will not be attributed erroneously to
+authors of previous versions.
+
+  Some devices are designed to deny users access to install or run
+modified versions of the software inside them, although the manufacturer
+can do so.  This is fundamentally incompatible with the aim of
+protecting users' freedom to change the software.  The systematic
+pattern of such abuse occurs in the area of products for individuals to
+use, which is precisely where it is most unacceptable.  Therefore, we
+have designed this version of the GPL to prohibit the practice for those
+products.  If such problems arise substantially in other domains, we
+stand ready to extend this provision to those domains in future versions
+of the GPL, as needed to protect the freedom of users.
+
+  Finally, every program is threatened constantly by software patents.
+States should not allow patents to restrict development and use of
+software on general-purpose computers, but in those that do, we wish to
+avoid the special danger that patents applied to a free program could
+make it effectively proprietary.  To prevent this, the GPL assures that
+patents cannot be used to render the program non-free.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Use with the GNU Affero General Public License.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU Affero General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the special requirements of the GNU Affero General Public License,
+section 13, concerning interaction through a network will apply to the
+combination as such.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS

--- a/README.md
+++ b/README.md
@@ -58,8 +58,6 @@ This collection also imports several modules also provided separately, would you
 - [Barcodes](https://github.com/Omikhleia/barcodes.sile) (for ISBNs, etc.)
 - [QR codes](https://github.com/Omikhleia/qrcode.sile)
 - [Couyards](https://github.com/Omikhleia/couyards.sile) (typographic ornaments)
-- [Printer options](https://github.com/Omikhleia/printoptions.sile) (image resolution tuning
-  and vector rasterization, would you want to use a professional printer or print-on-demand services)
 - [Textual graphics embedders](https://github.com/Omikhleia/embedders.sile) (support for Graphviz, Lilypond, &c)
 - [Markdown](https://github.com/Omikhleia/markdown.sile) (support for Markdown, Djot etc.)
 - [Pie charts](https://github.com/Omikhleia/piecharts.sile) (support for pie charts)

--- a/README.md
+++ b/README.md
@@ -60,7 +60,6 @@ This collection also imports several modules also provided separately, would you
 - [Couyards](https://github.com/Omikhleia/couyards.sile) (typographic ornaments)
 - [Printer options](https://github.com/Omikhleia/printoptions.sile) (image resolution tuning
   and vector rasterization, would you want to use a professional printer or print-on-demand services)
-- [Fancy table of contents](https://github.com/Omikhleia/fancytoc.sile) (an alternative two-level table of contents with nice curly braces)
 - [Textual graphics embedders](https://github.com/Omikhleia/embedders.sile) (support for Graphviz, Lilypond, &c)
 - [Markdown](https://github.com/Omikhleia/markdown.sile) (support for Markdown, Djot etc.)
 - [Pie charts](https://github.com/Omikhleia/piecharts.sile) (support for pie charts)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # resilient.sile
 
-[![license](https://img.shields.io/github/license/Omikhleia/resilient.sile?label=License)](LICENSE)
+[![License](https://img.shields.io/github/license/Omikhleia/resilient.sile?label=License)](LICENSE)
 [![Luacheck](https://img.shields.io/github/actions/workflow/status/Omikhleia/resilient.sile/luacheck.yml?branch=main&label=Luacheck&logo=Lua)](https://github.com/Omikhleia/resilient.sile/actions?workflow=Luacheck)
 [![Luarocks](https://img.shields.io/luarocks/v/Omikhleia/resilient.sile?label=Luarocks&logo=Lua)](https://luarocks.org/modules/Omikhleia/resilient.sile)
 
@@ -33,7 +33,7 @@ Did we say complete? Well, we lied a bit. For Markdown and Djot input, there is 
 
 ## Installation
 
-These packages require SILE v0.15 or upper (recommended: SILE v0.15.10 or upper).
+These packages require SILE v0.15.12.
 
 Installation relies on the **luarocks** package manager.
 See its installation instructions on the [LuaRocks](https://luarocks.org/) website.
@@ -79,7 +79,7 @@ The name is a pun on “SILE” (as, after all, the initial target was always on
 
 ## License
 
-All code is under the MIT License.
+The code in this repository is released under the GNU General Public License v3.0, (c) 2021-2025 Omikhleia.
 
 The documentation is under CC-BY-SA 2.0.
 

--- a/classes/resilient/base.lua
+++ b/classes/resilient/base.lua
@@ -2,11 +2,24 @@
 -- Base resilient class for SILE.
 -- Following the resilient styling paradigm.
 --
--- 2023, 2025 Didier Willis
--- License: MIT
---
 -- It provides a base class for document classes that want to use styles,
 -- and a few convenience methods hide the internals.
+--
+-- License: GPL-3.0-or-later
+--
+-- Copyright (C) 2023-2025 Didier Willis
+-- This program is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with this program.  If not, see <https://www.gnu.org/licenses/>.
 --
 require("silex")
 
@@ -57,7 +70,7 @@ end
 function class:declareOptions ()
   parent.declareOptions(self)
 
-  self:declareOption("resolution", function(_, value)
+  self:declareOption("resolution", function (_, value)
     if value then
       self.resolution = SU.cast("integer", value)
     end
@@ -75,6 +88,6 @@ end
 
 -- For overriding in any document subclass, as a convenient hook
 -- where to register all styles.
-function class.registerStyles (_) end
+function class:registerStyles () end
 
 return class

--- a/classes/resilient/base.lua
+++ b/classes/resilient/base.lua
@@ -21,9 +21,7 @@
 -- You should have received a copy of the GNU General Public License
 -- along with this program.  If not, see <https://www.gnu.org/licenses/>.
 --
-require("silex")
-
-local parent = require("classes.base")
+local parent = require("classes.resilient.override")
 local class = pl.class(parent)
 class._name = "resilient.base"
 class.styles = nil
@@ -31,46 +29,28 @@ class.styles = nil
 function class:_init (options)
   parent._init(self, options)
 
-  -- We do not use SILE's plain class, so do here the minimal compatibility
-  self:loadPackage("resilient.plain")
-  self:loadPackage("bidi")
-
-  -- An make us style-aware
   self:loadPackage("resilient.styles")
   self.styles = self.packages["resilient.styles"]
   self:registerStyles()
 end
 
-function class:declareOptions () -- Also from SILE's plain class
-  self:declareOption("direction", function (_, value)
-    if value then
-        SILE.documentState.direction = value
-        SILE.settings:set("font.direction", value, true)
-        for _, frame in pairs(self.defaultFrameset) do
-          if not frame.direction then
-              frame.direction = value
-          end
-        end
-    end
-    return SILE.documentState.direction
-  end)
-end
-
-local resilientAwareVariant = {
+local styleAwareVariant = {
   lists = "resilient.lists",
   verbatim = "resilient.verbatim",
+  tableofcontents = "resilient.tableofcontents",
+  footnotes = "resilient.footnotes",
 }
 
 function class:loadPackage (packname, options)
-  if resilientAwareVariant[packname] then
-    packname = resilientAwareVariant[packname]
-    SU.warn("Loading the resilient variant of package '" .. packname .. "'"
-    .. [[
+  if styleAwareVariant[packname] then
+    SU.debug("resilient", "Loading the resilient variant of package", packname, "=", styleAwareVariant[packname],
+    [[
 
 This should be compatible, but there might be differences such as hooks not
 being available, as the resilient version use styles instead.
-Please consider using resilient-compatible packages when available!
+Please consider using resilient-compatible style-aware packages when available!
 ]])
+  packname = styleAwareVariant[packname]
   end
   return parent.loadPackage(self, packname, options)
 end
@@ -85,25 +65,6 @@ end
 
 function class:hasStyle (name)
   return self.styles:hasStyle(name)
-end
-
-function class:declareOptions ()
-  parent.declareOptions(self)
-
-  self:declareOption("resolution", function (_, value)
-    if value then
-      self.resolution = SU.cast("integer", value)
-    end
-    return self.resolution
-  end)
-end
-
-function class:registerRawHandlers ()
-  parent.registerRawHandlers(self)
-end
-
-function class:registerCommands ()
-  parent.registerCommands(self)
 end
 
 -- For overriding in any document subclass, as a convenient hook

--- a/classes/resilient/base.lua
+++ b/classes/resilient/base.lua
@@ -23,7 +23,7 @@
 --
 require("silex")
 
-local parent = require("classes.plain")
+local parent = require("classes.base")
 local class = pl.class(parent)
 class._name = "resilient.base"
 class.styles = nil
@@ -31,9 +31,29 @@ class.styles = nil
 function class:_init (options)
   parent._init(self, options)
 
+  -- We do not use SILE's plain class, so do here the minimal compatibility
+  self:loadPackage("resilient.plain")
+  self:loadPackage("bidi")
+
+  -- An make us style-aware
   self:loadPackage("resilient.styles")
   self.styles = self.packages["resilient.styles"]
   self:registerStyles()
+end
+
+function class:declareOptions () -- Also from SILE's plain class
+  self:declareOption("direction", function (_, value)
+    if value then
+        SILE.documentState.direction = value
+        SILE.settings:set("font.direction", value, true)
+        for _, frame in pairs(self.defaultFrameset) do
+          if not frame.direction then
+              frame.direction = value
+          end
+        end
+    end
+    return SILE.documentState.direction
+  end)
 end
 
 local resilientAwareVariant = {

--- a/classes/resilient/base.lua
+++ b/classes/resilient/base.lua
@@ -34,6 +34,13 @@ function class:_init (options)
   self:registerStyles()
 end
 
+-- Some core or 3rd-party packages may load a non-style-aware variant of
+-- another package, and this would cause issues with the commands being
+-- redefined to the non-style-aware variant.
+-- E.g. in SILE 0.15.12, the "url" package loads the "verbatim" package
+-- (despite not using it, and this was later fixed).
+-- Let's assume we are compatible with those packages (though we cannot
+-- guarantee it), and always silently load the resilient variant instead.
 local styleAwareVariant = {
   lists = "resilient.lists",
   verbatim = "resilient.verbatim",
@@ -41,7 +48,7 @@ local styleAwareVariant = {
   footnotes = "resilient.footnotes",
 }
 
-function class:loadPackage (packname, options)
+function class:loadPackage (packname, options, reload)
   if styleAwareVariant[packname] then
     SU.debug("resilient", "Loading the resilient variant of package", packname, "=", styleAwareVariant[packname],
     [[
@@ -50,9 +57,10 @@ This should be compatible, but there might be differences such as hooks not
 being available, as the resilient version use styles instead.
 Please consider using resilient-compatible style-aware packages when available!
 ]])
-  packname = styleAwareVariant[packname]
+  SU.warn("Loading the resilient variant of package " .. packname .. " = " .. styleAwareVariant[packname])
+    packname = styleAwareVariant[packname]
   end
-  return parent.loadPackage(self, packname, options)
+  return parent.loadPackage(self, packname, options, reload)
 end
 
 function class:registerStyle (name, opts, styledef)

--- a/classes/resilient/book.lua
+++ b/classes/resilient/book.lua
@@ -106,15 +106,9 @@ function class:_init (options)
       }
     end)
   end
-  -- Our Djot/Markdown support provides an undocumented _FANCYTOC_ symbol.
-  -- The reason why it is undocumented is that module fancytoc.sile is not a
-  -- dependency of markdown.sile.
-  -- On the other hand, resilient.sile has all needed dependencies.
-  -- So eventually we'll remove the _FANCYTOC_ symbol from markdown.sile.
-  -- No issue with re-registering it here, and we'll be ready for that.
   mdc:registerSymbol("_FANCYTOC_", true, function (opts)
     return {
-      SU.ast.createCommand("use", { module = "packages.fancytoc" }),
+      SU.ast.createCommand("use", { module = "packages.resilient.fancytoc" }),
       SU.ast.createCommand("fancytableofcontents", opts),
     }
   end)

--- a/classes/resilient/book.lua
+++ b/classes/resilient/book.lua
@@ -2,16 +2,28 @@
 -- A new advanced book class for SILE.
 -- Following the resilient styling paradigm, and providing a more features.
 --
--- 2021-2025, Didier Willis
--- License: MIT
+-- License: GPL-3.0-or-later
+--
+-- Copyright (C) 2021-2025 Didier Willis
+-- This program is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with this program.  If not, see <https://www.gnu.org/licenses/>.
 --
 local base = require("classes.resilient.base")
 local class = pl.class(base)
 class._name = "resilient.book"
 
-local ast = require("silex.ast")
 local createCommand, subContent, extractFromTree
-        = ast.createCommand, ast.subContent, ast.extractFromTree
+        = SU.ast.createCommand, SU.ast.subContent, SU.ast.removeFromTree
 
 local layoutParser = require("resilient.layoutparser")
 

--- a/classes/resilient/book.lua
+++ b/classes/resilient/book.lua
@@ -22,9 +22,6 @@ local base = require("classes.resilient.base")
 local class = pl.class(base)
 class._name = "resilient.book"
 
-local createCommand, subContent, extractFromTree
-        = SU.ast.createCommand, SU.ast.subContent, SU.ast.removeFromTree
-
 local layoutParser = require("resilient.layoutparser")
 
 SILE.scratch.book = SILE.scratch.book or {}
@@ -80,7 +77,7 @@ function class:_init (options)
       return {}
     end
     return {
-      createCommand("printbibliography", opts)
+      SU.ast.createCommand("printbibliography", opts)
     }
   end)
   -- Our Djot/Markdown support already provides a _TOC_ symbol.
@@ -93,7 +90,7 @@ function class:_init (options)
   for _, sym in ipairs(extras) do
     mdc:registerSymbol("_" .. sym:upper() .. "_", true, function (opts)
       return {
-        createCommand(sym, opts)
+        SU.ast.createCommand(sym, opts)
       }
     end)
   end
@@ -105,8 +102,8 @@ function class:_init (options)
   -- No issue with re-registering it here, and we'll be ready for that.
   mdc:registerSymbol("_FANCYTOC_", true, function (opts)
     return {
-      createCommand("use", { module = "packages.fancytoc" }),
-      createCommand("fancytableofcontents", opts),
+      SU.ast.createCommand("use", { module = "packages.fancytoc" }),
+      SU.ast.createCommand("fancytableofcontents", opts),
     }
   end)
 
@@ -142,8 +139,8 @@ function class:_init (options)
       -- Typically, if folios use "old-style" numbers, 16 and 17 facing pages shall have
       -- aligned folios, but the 1 is smaller than the 6 and 7, the former ascends above,
       -- and the latter descends below the baseline).
-      createCommand("strut", { method = "rule"}),
-      createCommand("style:apply:number", {
+      SU.ast.createCommand("strut", { method = "rule"}),
+      SU.ast.createCommand("style:apply:number", {
         name = "folio-" .. DIVISIONNAME[division],
         text = SU.ast.contentToString(content),
       })
@@ -605,8 +602,8 @@ function class:registerCommands ()
   self:registerCommand("even-tracked-header", function (_, content)
     local headerContent = function ()
       SILE.call("style:apply:paragraph", { name = "header-even" }, {
-        createCommand("strut", { method = "rule"}),
-        subContent(content)
+        SU.ast.createCommand("strut", { method = "rule"}),
+        SU.ast.subContent(content)
       })
     end
     SILE.call("info", {
@@ -618,8 +615,8 @@ function class:registerCommands ()
   self:registerCommand("odd-tracked-header", function (_, content)
     local headerContent = function ()
       SILE.call("style:apply:paragraph", { name = "header-odd" }, {
-        createCommand("strut", { method = "rule"}),
-        subContent(content)
+        SU.ast.createCommand("strut", { method = "rule"}),
+        SU.ast.subContent(content)
       })
     end
     SILE.call("info", {
@@ -631,8 +628,8 @@ function class:registerCommands ()
   self:registerCommand("even-running-header", function (_, content)
     SILE.scratch.headers.even = function ()
       SILE.call("style:apply:paragraph", { name = "header-even" }, {
-        createCommand("strut", { method = "rule"}),
-        subContent(content)
+        SU.ast.createCommand("strut", { method = "rule"}),
+        SU.ast.subContent(content)
       })
     end
   end, "Text to appear on the top of even pages.")
@@ -640,8 +637,8 @@ function class:registerCommands ()
   self:registerCommand("odd-running-header", function (_, content)
     SILE.scratch.headers.odd = function ()
       SILE.call("style:apply:paragraph", { name = "header-odd" }, {
-        createCommand("strut", { method = "rule"}),
-        subContent(content)
+        SU.ast.createCommand("strut", { method = "rule"}),
+        SU.ast.subContent(content)
       })
     end
   end, "Text to appear on the top odd pages.")
@@ -817,7 +814,7 @@ function class:registerCommands ()
 
   self:registerCommand("captioned-figure", function (options, content)
     if type(content) ~= "table" then SU.error("Expected a table content in figure environment") end
-    local caption = extractFromTree(content, "caption")
+    local caption = SU.ast.removeFromTree(content, "caption")
 
     options.style = "figure-caption"
     SILE.call("style:apply:paragraph", { name = "figure" }, content)
@@ -832,7 +829,7 @@ function class:registerCommands ()
 
   self:registerCommand("captioned-table", function (options, content)
     if type(content) ~= "table" then SU.error("Expected a table content in table environment") end
-    local caption = extractFromTree(content, "caption")
+    local caption = SU.ast.removeFromTree(content, "caption")
 
     options.style = "table-caption"
     SILE.call("style:apply:paragraph", { name = "table" }, content)
@@ -847,7 +844,7 @@ function class:registerCommands ()
 
   self:registerCommand("captioned-listing", function (options, content)
     if type(content) ~= "table" then SU.error("Expected a table content in listing environment") end
-    local caption = extractFromTree(content, "caption")
+    local caption = SU.ast.removeFromTree(content, "caption")
 
     options.style = "listing-caption"
     SILE.call("style:apply:paragraph", { name = "listing" }, content)

--- a/classes/resilient/override.lua
+++ b/classes/resilient/override.lua
@@ -1,0 +1,192 @@
+--
+-- Base overrides on SILE's base class for use in resilient classes
+-- (as toplevel superclass).
+--
+-- License: GPL-3.0-or-later
+--
+-- Copyright (C) 2023-2025 Didier Willis
+-- This program is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with this program.  If not, see <https://www.gnu.org/licenses/>.
+--
+
+-- INPUTTERS
+-- This ensure our inputters are loaded, so one can \include files of the relevant format
+-- afterwards, without having to load the inputter first.
+
+SU.debug("resilient.override", "Loading extra inputters if available")
+pcall(function () local _ = SILE.inputters.silm end)
+pcall(function () local _ = SILE.inputters.markdown end)
+pcall(function () local _ = SILE.inputters.djot end)
+pcall(function () local _ = SILE.inputters.pandocast end)
+
+-- CANCELLATION OF MULTIPLE PACKAGE INSTANCIATION
+-- Packages such as resilient.style are stateful and freeze the styles at some point
+-- in their workflow.
+-- The multiple package instantiation model was introduced in SILE 0.13-0.14.
+-- I struggled too many times with this issue in August 2022 (initial effort porting
+-- my 0.12.5 packages to 0.14.x) and afterwards.
+-- See SILE issue 1531 for some details.
+-- I could never make any sense of this half-baked "feature", which introduces
+-- unintended side-effects and problems impossible to decently address,
+-- making the life of package and class developers real harder.
+-- Some of the issues were supposed to be fixed in SILE 0.15, but removing the hacks
+-- below still breaks (at least) package resilient.style...
+
+SILE.use = function (module, options)
+   local pack
+   if type(module) == "string" then
+      pack = require(module)
+   elseif type(module) == "table" then
+      pack = module
+   end
+   local name = pack._name
+   local class = SILE.documentState.documentClass -- luacheck: ignore
+   if not pack.type then
+      SU.error("Modules must declare their type")
+   elseif pack.type == "class" then
+      SILE.classes[name] = pack
+      if class then
+         SU.error("Cannot load a class after one is already instantiated")
+      end
+      SILE.scratch.class_from_uses = pack
+   elseif pack.type == "inputter" then
+      SILE.inputters[name] = pack
+      SILE.inputter = pack(options)
+   elseif pack.type == "outputter" then
+      SILE.outputters[name] = pack
+      SILE.outputter = pack(options)
+   elseif pack.type == "shaper" then
+      SILE.shapers[name] = pack
+      SILE.shaper = pack(options)
+   elseif pack.type == "typesetter" then
+      SILE.typesetters[name] = pack
+      SILE.typesetter = pack(options)
+   elseif pack.type == "pagebuilder" then
+      SILE.pagebuilders[name] = pack
+      SILE.pagebuilder = pack(options)
+   elseif pack.type == "package" then
+      SILE.packages[name] = pack
+      if class then
+         -- BEGIN SILEX/RESILIENT CANCEL MULTIPLE PACKAGE INSTANCIATION
+         if class.packages[name] then
+            return SU.debug("resilient.override", "\\use fork ignoring already loaded package:", name)
+         end
+         -- END SILEX/RESILIENT CANCEL MULTIPLE PACKAGE INSTANCIATION
+         class.packages[name] = pack(options)
+      else
+         table.insert(SILE.input.preambles, {
+            pack = pack,
+            options = options
+         })
+      end
+   end
+end
+
+-- BASE CLASS OVERLOAD
+-- We do a few things here:
+-- - We replace SILE's default typesetter with the SILEnt typesetter
+-- - Our classes do not use SILE's plain class, but implement minimal compatibility
+-- - We cancel multiple package instanciation, as some packages are stateful (see above)
+
+local base = require("classes.base")
+local class = pl.class(base)
+class._name = "resilient.override"
+
+function class:_init (options)
+   SU.debug("resilient.override", "Replacing SILE's default typesetter with the SILEnt typesetter")
+   SILE.typesetters.default = require("typesetters.silent")
+
+   base._init(self, options)
+
+   -- We do not use SILE's plain class, but implement minimal compatibility via packages
+   SU.debug("resilient.override", "Loading plain compatibility packages")
+   self:loadPackage("resilient.plain")
+   self:loadPackage("bidi")
+end
+
+function class:declareOptions ()
+   -- Also from SILE's plain class
+   self:declareOption("direction", function (_, value)
+      if value then
+         SILE.documentState.direction = value
+         SILE.settings:set("font.direction", value, true)
+         for _, frame in pairs(self.defaultFrameset) do
+            if not frame.direction then
+               frame.direction = value
+            end
+         end
+      end
+      return SILE.documentState.direction
+   end)
+   -- Specifically for resilient
+   self:declareOption("resolution", function (_, value)
+      if value then
+         self.resolution = SU.cast("integer", value)
+      end
+      return self.resolution
+   end)
+end
+
+function class:loadPackage (packname, options)
+   local pack = require(("packages.%s"):format(packname))
+   -- BEGIN SILEX/RESILIENT CANCEL MULTIPLE PACKAGE INSTANCIATION
+   -- I beg to disagree with SILE here.
+   if type(pack) == "table" and pack.type == "package" then -- new package
+      if self.packages[pack._name] then
+         return SU.debug("resilient.override", "Ignoring package already loaded in the class:", pack._name)
+      end
+   end
+   base.loadPackage(self, packname, options)
+end
+
+-- WARNING: not called as class method
+function class.newPar (typesetter)
+   local parindent = SILE.settings:get("current.parindent") or SILE.settings:get("document.parindent")
+   typesetter:pushGlue(parindent:absolute())
+   SILE.settings:set("current.parindent", nil)
+   -- BEGIN SILEX/RESILIENT HANGED LINES
+   --   (MOVED TO THE TYPESETTER)
+   -- END SILEX/RESILIENT HANGED LINES
+end
+
+-- WARNING: not called as class method
+function class.endPar (typesetter)
+   typesetter:pushVglue(SILE.settings:get("document.parskip"))
+  -- BEGIN SILEX/RESILIENT HANGED LINES
+  --   (MOVED TO THE TYPESETTER)
+  -- END SILEX/RESILIENT HANGED LINES
+end
+
+function class:finish ()
+   SILE.inputter:postamble()
+   -- SILE/RESILIENT: Original typesetter calls SILE.typesetter:endline() here.
+   -- We really need to clean up and clarify the typesetter's expectations....
+   SILE.call("vfill")
+   while not SILE.typesetter:isQueueEmpty() do
+      SILE.call("supereject")
+      SILE.typesetter:leaveHmode(true)
+      SILE.typesetter:buildPage()
+      if not SILE.typesetter:isQueueEmpty() then
+         SILE.typesetter:initNextFrame()
+      end
+   end
+   SILE.typesetter:runHooks("pageend") -- normally run by the typesetter
+   self:endPage()
+   if SILE.typesetter and not SILE.typesetter:isQueueEmpty() then
+      SU.error("Queues are not empty as expected after ending last page", true)
+   end
+   SILE.outputter:finish()
+   self:runHooks("finish")
+end
+
+return class

--- a/classes/resilient/resume.lua
+++ b/classes/resilient/resume.lua
@@ -1,21 +1,32 @@
 --
 -- A minimalist SILE class for a "resumé" (CV)
 -- Following the resilient styling paradigm.
---
--- 2021-2023, Didier Willis
--- License: MIT
---
 -- This is indeed very minimalist :)
+--
+-- License: GPL-3.0-or-later
+--
+-- Copyright (C) 2021-2025 Didier Willis
+-- This program is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with this program.  If not, see <https://www.gnu.org/licenses/>.
 --
 local base = require("classes.resilient.base")
 local class = pl.class(base)
 class._name = "resilient.resume"
 
-local ast = require("silex.ast")
 local createCommand, createStructuredCommand, subContent,
       extractFromTree, findInTree
-        = ast.createCommand, ast.createStructuredCommand, ast.subContent,
-          ast.extractFromTree, ast.findInTree
+        = SU.ast.createCommand, SU.ast.createStructuredCommand, SU.ast.subContent,
+          SU.ast.removeFromTree, SU.ast.findInTree
 
 SILE.scratch.resilient = SILE.scratch.resilient or {}
 SILE.scratch.resilient.resume = SILE.scratch.resilient.resume or {}

--- a/classes/resilient/resume.lua
+++ b/classes/resilient/resume.lua
@@ -23,11 +23,6 @@ local base = require("classes.resilient.base")
 local class = pl.class(base)
 class._name = "resilient.resume"
 
-local createCommand, createStructuredCommand, subContent,
-      extractFromTree, findInTree
-        = SU.ast.createCommand, SU.ast.createStructuredCommand, SU.ast.subContent,
-          SU.ast.removeFromTree, SU.ast.findInTree
-
 SILE.scratch.resilient = SILE.scratch.resilient or {}
 SILE.scratch.resilient.resume = SILE.scratch.resilient.resume or {}
 
@@ -137,7 +132,7 @@ function class:_init (options)
     SILE.call("raggedleft", {}, {
      content,
       "/",
-      createCommand("pageref", { marker = "resilient.resume:end" })
+      SU.ast.createCommand("pageref", { marker = "resilient.resume:end" })
     })
     SILE.call("eject") -- for vfill to be effective
   end)
@@ -248,22 +243,22 @@ end
 -- RESUME PROCESSING
 
 local function doEntry (rows, _, content)
-  local topic = extractFromTree(content, "topic")
-  local description = extractFromTree(content, "description")
-  local titleRow = createStructuredCommand("row", {}, {
-    createStructuredCommand("cell", { valign = "top", padding = "4pt 4pt 0 4pt" }, {
+  local topic = SU.ast.removeFromTree(content, "topic")
+  local description = SU.ast.removeFromTree(content, "description")
+  local titleRow = SU.ast.createStructuredCommand("row", {}, {
+    SU.ast.createStructuredCommand("cell", { valign = "top", padding = "4pt 4pt 0 4pt" }, {
       -- We are typesetting in a different style but want proper alignment
       -- With the other style, so strut tweaking:
-      createStructuredCommand("style:apply:paragraph", { name = "resume-topic" }, {
-        createStructuredCommand("style:apply", { name = "resume-description" }, {
-          createCommand("strut"),
+      SU.ast.createStructuredCommand("style:apply:paragraph", { name = "resume-topic" }, {
+        SU.ast.createStructuredCommand("style:apply", { name = "resume-description" }, {
+          SU.ast.createCommand("strut"),
         }),
         -- Then go ahead.
-        subContent(topic)
+        SU.ast.subContent(topic)
       })
     }),
-    createStructuredCommand("cell", { valign = "top", span = 2, padding = "4pt 4pt 0.33cm 0" }, {
-      createStructuredCommand("style:apply", { name = "resume-description" }, description)
+    SU.ast.createStructuredCommand("cell", { valign = "top", span = 2, padding = "4pt 4pt 0.33cm 0" }, {
+      SU.ast.createStructuredCommand("style:apply", { name = "resume-description" }, description)
     })
   })
   for i = 0, #content do
@@ -275,15 +270,15 @@ local function doEntry (rows, _, content)
 end
 
 local doSection = function (rows, _, content)
-  local title = extractFromTree(content, "title")
-  local titleRow = createStructuredCommand("row", {}, {
-    createStructuredCommand("cell", { valign = "bottom", padding = "4pt 4pt 0 4pt" }, {
-      createStructuredCommand("style:apply", { name = "resume-section" }, {
-        createCommand("hrule", { width = "100%fw", height= "1ex" })
+  local title = SU.ast.removeFromTree(content, "title")
+  local titleRow = SU.ast.createStructuredCommand("row", {}, {
+    SU.ast.createStructuredCommand("cell", { valign = "bottom", padding = "4pt 4pt 0 4pt" }, {
+      SU.ast.createStructuredCommand("style:apply", { name = "resume-section" }, {
+        SU.ast.createCommand("hrule", { width = "100%fw", height= "1ex" })
       })
     }),
-    createStructuredCommand("cell", { span = 2, padding = "4pt 4pt 0.33cm 0" }, {
-      createStructuredCommand("style:apply", { name = "resume-section" }, title)
+    SU.ast.createStructuredCommand("cell", { span = 2, padding = "4pt 4pt 0.33cm 0" }, {
+      SU.ast.createStructuredCommand("style:apply", { name = "resume-section" }, title)
     })
   })
   table.insert(rows, titleRow)
@@ -307,53 +302,53 @@ function class:registerCommands ()
   end, "Text to appear at the bottom of the page")
 
   self:registerCommand("resume", function (_  , content)
-    local firstname = extractFromTree(content, "firstname") or SU.error("firstname is mandatory")
-    local lastname = extractFromTree(content, "lastname") or SU.error("lastname is mandatory")
-    local picture = extractFromTree(content, "picture") or SU.error("picture is mandatory")
-    local contact = extractFromTree(content, "contact") or SU.error("contact is mandatory")
-    local jobtitle = extractFromTree(content, "jobtitle") or SU.error("jobtitle is mandatory")
-    local headline = extractFromTree(content, "headline") -- can be omitted
+    local firstname = SU.ast.removeFromTree(content, "firstname") or SU.error("firstname is mandatory")
+    local lastname = SU.ast.removeFromTree(content, "lastname") or SU.error("lastname is mandatory")
+    local picture = SU.ast.removeFromTree(content, "picture") or SU.error("picture is mandatory")
+    local contact = SU.ast.removeFromTree(content, "contact") or SU.error("contact is mandatory")
+    local jobtitle = SU.ast.removeFromTree(content, "jobtitle") or SU.error("jobtitle is mandatory")
+    local headline = SU.ast.removeFromTree(content, "headline") -- can be omitted
 
     SILE.call("cv-footer", {}, { contact })
     SILE.call("cv-header", {}, {
-      createStructuredCommand("style:apply:paragraph", { name = "resume-header" }, {
-        createStructuredCommand("style:apply", { name = "resume-firstname" }, { subContent(firstname) }),
+      SU.ast.createStructuredCommand("style:apply:paragraph", { name = "resume-header" }, {
+        SU.ast.createStructuredCommand("style:apply", { name = "resume-firstname" }, { SU.ast.subContent(firstname) }),
         " ",
-        createStructuredCommand("style:apply", { name = "resume-lastname" }, { subContent(lastname) })
+        SU.ast.createStructuredCommand("style:apply", { name = "resume-lastname" }, { SU.ast.subContent(lastname) })
       })
     })
 
     local rows = {}
 
-    local fullnameAndPictureRow = createStructuredCommand("row", {}, {
-      createStructuredCommand("cell", { border = "0 1pt 0 0", padding = "4pt 4pt 0 4pt", valign = "bottom" }, { function ()
+    local fullnameAndPictureRow = SU.ast.createStructuredCommand("row", {}, {
+      SU.ast.createStructuredCommand("cell", { border = "0 1pt 0 0", padding = "4pt 4pt 0 4pt", valign = "bottom" }, { function ()
           local w = SILE.types.measurement("100%fw"):absolute() - 7.2 -- padding and border
           SILE.call("parbox", { width = w, border = "0.6pt", padding = "3pt" }, function ()
             SILE.call("img", { width = "100%fw", src = picture.options.src })
           end)
         end
       }),
-      createStructuredCommand("cell", { span = 2, border = "0 1pt 0 0", padding = "4pt 2pt 4pt 0",  valign = "bottom" }, {
-        createStructuredCommand("style:apply:paragraph", { name = "resume-fullname" }, {
-          createStructuredCommand("style:apply", { name = "resume-firstname" }, { subContent(firstname) }),
+      SU.ast.createStructuredCommand("cell", { span = 2, border = "0 1pt 0 0", padding = "4pt 2pt 4pt 0",  valign = "bottom" }, {
+        SU.ast.createStructuredCommand("style:apply:paragraph", { name = "resume-fullname" }, {
+          SU.ast.createStructuredCommand("style:apply", { name = "resume-firstname" }, { SU.ast.subContent(firstname) }),
           " ",
-          createStructuredCommand("style:apply", { name = "resume-lastname" }, { subContent(lastname) })
+          SU.ast.createStructuredCommand("style:apply", { name = "resume-lastname" }, { SU.ast.subContent(lastname) })
          })
       })
     })
     table.insert(rows, fullnameAndPictureRow)
 
-    local jobtitleRow = createStructuredCommand("row", {}, {
-      createStructuredCommand("cell", { span = 3 }, {
-        createStructuredCommand("style:apply:paragraph", { name = "resume-jobtitle" }, jobtitle)
+    local jobtitleRow = SU.ast.createStructuredCommand("row", {}, {
+      SU.ast.createStructuredCommand("cell", { span = 3 }, {
+        SU.ast.createStructuredCommand("style:apply:paragraph", { name = "resume-jobtitle" }, jobtitle)
       })
     })
     table.insert(rows, jobtitleRow)
 
     -- NOTE: if headline is absent, no problem. We still insert a row, just for
     -- vertical spacing.
-    local headlineRow = createStructuredCommand("row", {}, {
-      createStructuredCommand("cell", { span = 3 }, { function ()
+    local headlineRow = SU.ast.createStructuredCommand("row", {}, {
+      SU.ast.createStructuredCommand("cell", { span = 3 }, { function ()
           SILE.call("center", {}, function ()
             SILE.call("parbox", { width = "80%fw" }, function()
               SILE.call("style:apply:paragraph", { name = "resume-headline" }, headline)
@@ -399,7 +394,7 @@ function class:registerCommands ()
     local rank = {}
     for i = 1, scale do
       rank[#rank + 1] = i <= value and charFromUnicode("U+25CF") or charFromUnicode("U+25CB")
-      rank[#rank + 1] = createCommand("kern", { width = "0.1em" })
+      rank[#rank + 1] = SU.ast.createCommand("kern", { width = "0.1em" })
     end
     SILE.call("style:apply", { name = "resume-dingbats" }, rank)
   end)
@@ -416,18 +411,18 @@ function class:registerCommands ()
   end)
 
   self:registerCommand("contact", function (_, content)
-    local street = findInTree(content, "street") or SU.error("street is mandatory")
-    local city = findInTree(content, "city") or SU.error("city is mandatory")
-    local phone = findInTree(content, "phone") or SU.error("phone is mandatory")
-    local email = findInTree(content, "email") or SU.error("email is mandatory")
+    local street = SU.ast.findInTree(content, "street") or SU.error("street is mandatory")
+    local city = SU.ast.findInTree(content, "city") or SU.error("city is mandatory")
+    local phone = SU.ast.findInTree(content, "phone") or SU.error("phone is mandatory")
+    local email = SU.ast.findInTree(content, "email") or SU.error("email is mandatory")
 
     SILE.call("style:apply:paragraph", { name = "resume-contact" }, {
-      createStructuredCommand("cv-icon-text", { symbol="U+1F4CD" }, { subContent(street) }),
-      createCommand("cv-bullet"),
-      subContent(city),
-      createCommand("par"),
+      SU.ast.createStructuredCommand("cv-icon-text", { symbol="U+1F4CD" }, { SU.ast.subContent(street) }),
+      SU.ast.createCommand("cv-bullet"),
+      SU.ast.subContent(city),
+      SU.ast.createCommand("par"),
       phone,
-      createCommand("cv-bullet"),
+      SU.ast.createCommand("cv-bullet"),
       email
     })
   end)

--- a/examples/lefevre-tuor-idril-styles.yml
+++ b/examples/lefevre-tuor-idril-styles.yml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Omikhleia/resilient.sile/v2.8.0/schemas/stylefile.json
+# $schema: https://raw.githubusercontent.com/Omikhleia/resilient.sile/v2.8.0/schemas/stylefile.json
 
 Author:
   style:
@@ -9,7 +11,6 @@ Author:
         indent: false
 
 blockquote:
-  origin: "resilient.book"
   style:
     font:
       size: "0.9583em"
@@ -21,19 +22,16 @@ blockquote:
         skip: "smallskip"
 
 code:
-  origin: "resilient.book"
   style:
     font:
       family: "Hack"
       size: "1.4ex"
 
 defn-base:
-  origin: "resilient.defn"
   style:
 
 defn-desc:
   inherit: "defn-base"
-  origin: "resilient.defn"
   style:
     paragraph:
       after:
@@ -43,7 +41,6 @@ defn-desc:
 
 defn-term:
   inherit: "defn-base"
-  origin: "resilient.defn"
   style:
     font:
       weight: 700
@@ -54,7 +51,6 @@ defn-term:
         skip: "smallskip"
 
 dropcap:
-  origin: "resilient.book"
   style:
     font:
       family: "Zallman Caps"
@@ -62,7 +58,6 @@ dropcap:
       lines: 2
 
 epigraph:
-  origin: "resilient.epigraph"
   style:
     font:
       size: "0.9em"
@@ -73,7 +68,6 @@ epigraph:
         skip: "medskip"
 
 epigraph-source:
-  origin: "resilient.epigraph"
   style:
     paragraph:
       align: "right"
@@ -83,7 +77,6 @@ epigraph-source:
 
 epigraph-source-norule:
   inherit: "epigraph-source"
-  origin: "resilient.epigraph"
   style:
     paragraph:
       before:
@@ -91,18 +84,15 @@ epigraph-source-norule:
 
 epigraph-source-rule:
   inherit: "epigraph-source"
-  origin: "resilient.epigraph"
   style:
 
 epigraph-text:
   inherit: "epigraph"
-  origin: "resilient.epigraph"
   style:
     paragraph:
       align: "justify"
 
 eqno:
-  origin: "resilient.book"
   style:
     numbering:
       after:
@@ -112,7 +102,6 @@ eqno:
       display: "arabic"
 
 figure:
-  origin: "resilient.book"
   style:
     paragraph:
       after:
@@ -123,7 +112,6 @@ figure:
         skip: "smallskip"
 
 figure-caption:
-  origin: "resilient.book"
   style:
     font:
       size: "0.95em"
@@ -148,12 +136,10 @@ figure-caption:
         toclevel: 5
 
 figure-caption-base-number:
-  origin: "resilient.book"
   style:
 
 figure-caption-main-number:
   inherit: "figure-caption-base-number"
-  origin: "resilient.book"
   style:
     font:
       features: "+smcp"
@@ -166,27 +152,23 @@ figure-caption-main-number:
 
 figure-caption-ref-number:
   inherit: "figure-caption-base-number"
-  origin: "resilient.book"
   style:
     numbering:
       before:
         text: "fig. "
 
 folio-backmatter:
-  origin: "resilient.book"
   style:
     numbering:
       display: "arabic"
 
 folio-base:
-  origin: "resilient.book"
   style:
     font:
       features: "+onum"
 
 folio-even:
   inherit: "folio-base"
-  origin: "resilient.book"
   style:
     paragraph:
       align: "left"
@@ -194,20 +176,17 @@ folio-even:
         indent: false
 
 folio-frontmatter:
-  origin: "resilient.book"
   style:
     numbering:
       display: "roman"
 
 folio-mainmatter:
-  origin: "resilient.book"
   style:
     numbering:
       display: "arabic"
 
 folio-odd:
   inherit: "folio-base"
-  origin: "resilient.book"
   style:
     paragraph:
       align: "right"
@@ -215,7 +194,6 @@ folio-odd:
         indent: false
 
 footnote:
-  origin: "resilient.footnotes"
   style:
     font:
       size: "0.75em"
@@ -223,7 +201,6 @@ footnote:
       display: "arabic"
 
 footnote-marker:
-  origin: "resilient.footnotes"
   style:
     numbering:
       after:
@@ -233,7 +210,6 @@ footnote-marker:
 
 footnote-marker-counter:
   inherit: "footnote-marker"
-  origin: "resilient.footnotes"
   style:
     numbering:
       after:
@@ -241,11 +217,9 @@ footnote-marker-counter:
 
 footnote-marker-symbol:
   inherit: "footnote-marker"
-  origin: "resilient.footnotes"
   style:
 
 footnote-reference:
-  origin: "resilient.footnotes"
   style:
     numbering:
       before:
@@ -255,16 +229,13 @@ footnote-reference:
 
 footnote-reference-counter:
   inherit: "footnote-reference"
-  origin: "resilient.footnotes"
   style:
 
 footnote-reference-symbol:
   inherit: "footnote-reference"
-  origin: "resilient.footnotes"
   style:
 
 header-base:
-  origin: "resilient.book"
   style:
     font:
       features: "+smcp"
@@ -278,16 +249,177 @@ header-base:
 
 header-even:
   inherit: "header-base"
-  origin: "resilient.book"
   style:
 
 header-odd:
   inherit: "header-base"
-  origin: "resilient.book"
   style:
 
+highlight-addition:
+  style:
+    color: "#7F6600"
+    decoration:
+      color: "#FFDE8A"
+      line: "mark"
+
+highlight-attribute:
+  style:
+    color: "#0000C0"
+
+highlight-bold:
+  style:
+    font:
+      weight: 400
+
+highlight-change:
+  style:
+    color: "#0000C0"
+    decoration:
+      color: "#B2D8FF"
+      line: "mark"
+
+highlight-class:
+  style:
+    color: "#C99000"
+
+highlight-command:
+  style:
+    color: "#7F0055"
+
+highlight-command.section:
+  style:
+    color: "#C99000"
+
+highlight-comment:
+  style:
+    color: "#8E908C"
+    font:
+      style: "italic"
+
+highlight-constant:
+  style:
+    color: "#116644"
+
+highlight-constant.builtin:
+  style:
+    color: "#F5871F"
+
+highlight-deletion:
+  style:
+    color: "#8B0000"
+    decoration:
+      color: "#F6B2B2"
+      line: "mark"
+
+highlight-embedded:
+  style:
+    color: "#4271AE"
+
+highlight-environment:
+  style:
+    color: "#C99000"
+
+highlight-environment.math:
+  style:
+    color: "#116644"
+
+highlight-error:
+  style:
+    color: "#8B0000"
+
+highlight-function:
+  style:
+    color: "#4271AE"
+
+highlight-function.builtin:
+  style:
+    color: "#4271AE"
+
+highlight-function.method:
+  style:
+    color: "#4271AE"
+
+highlight-heading:
+  style:
+    color: "#2A00FF"
+
+highlight-identifier:
+  style:
+    color: "#3F009B"
+
+highlight-italic:
+  style:
+    font:
+      style: "italic"
+
+highlight-keyword:
+  style:
+    color: "#7F0055"
+
+highlight-label:
+  style:
+    color: "#2A00FF"
+
+highlight-link:
+  style:
+    decoration:
+      line: "underline"
+
+highlight-list:
+  style:
+    color: "#116644"
+
+highlight-number:
+  style:
+    color: "#116644"
+
+highlight-operator:
+  style:
+    color: "#3E999F"
+
+highlight-preprocessor:
+  style:
+    color: "#4D4D4C"
+
+highlight-property:
+  style:
+    color: "#0000C0"
+
+highlight-reference:
+  style:
+    decoration:
+      line: "underline"
+
+highlight-regex:
+  style:
+    color: "#0000C0"
+
+highlight-string:
+  style:
+    color: "#3F7F5F"
+
+highlight-tag:
+  style:
+    color: "#7F0055"
+
+highlight-type:
+  style:
+    color: "#C99000"
+
+highlight-underline:
+  style:
+    decoration:
+      line: "underline"
+
+highlight-variable:
+  style:
+    color: "#0000C0"
+
+highlight-variable.builtin:
+  style:
+    color: "#C82829"
+
 listing:
-  origin: "resilient.book"
   style:
     paragraph:
       after:
@@ -297,7 +429,6 @@ listing:
         skip: "smallskip"
 
 listing-caption:
-  origin: "resilient.book"
   style:
     font:
       size: "0.95em"
@@ -322,12 +453,10 @@ listing-caption:
         toclevel: 7
 
 listing-caption-base-number:
-  origin: "resilient.book"
   style:
 
 listing-caption-main-number:
   inherit: "listing-caption-base-number"
-  origin: "resilient.book"
   style:
     font:
       features: "+smcp"
@@ -340,7 +469,6 @@ listing-caption-main-number:
 
 listing-caption-ref-number:
   inherit: "listing-caption-base-number"
-  origin: "resilient.book"
   style:
     numbering:
       before:
@@ -348,7 +476,6 @@ listing-caption-ref-number:
 
 lists-enumerate-alternate1:
   inherit: "lists-enumerate-base"
-  origin: "resilient.lists"
   style:
     numbering:
       after:
@@ -357,7 +484,6 @@ lists-enumerate-alternate1:
 
 lists-enumerate-alternate2:
   inherit: "lists-enumerate-base"
-  origin: "resilient.lists"
   style:
     numbering:
       after:
@@ -366,7 +492,6 @@ lists-enumerate-alternate2:
 
 lists-enumerate-alternate3:
   inherit: "lists-enumerate-base"
-  origin: "resilient.lists"
   style:
     numbering:
       after:
@@ -375,7 +500,6 @@ lists-enumerate-alternate3:
 
 lists-enumerate-alternate4:
   inherit: "lists-enumerate-base"
-  origin: "resilient.lists"
   style:
     font:
       style: "italic"
@@ -386,18 +510,15 @@ lists-enumerate-alternate4:
 
 lists-enumerate-alternate5:
   inherit: "lists-enumerate-base"
-  origin: "resilient.lists"
   style:
     enumerate:
       symbol: "U+2474"
 
 lists-enumerate-base:
-  origin: "resilient.lists"
   style:
 
 lists-enumerate1:
   inherit: "lists-enumerate-base"
-  origin: "resilient.lists"
   style:
     numbering:
       after:
@@ -406,7 +527,6 @@ lists-enumerate1:
 
 lists-enumerate2:
   inherit: "lists-enumerate-base"
-  origin: "resilient.lists"
   style:
     numbering:
       after:
@@ -415,7 +535,6 @@ lists-enumerate2:
 
 lists-enumerate3:
   inherit: "lists-enumerate-base"
-  origin: "resilient.lists"
   style:
     numbering:
       after:
@@ -424,7 +543,6 @@ lists-enumerate3:
 
 lists-enumerate4:
   inherit: "lists-enumerate-base"
-  origin: "resilient.lists"
   style:
     numbering:
       after:
@@ -433,7 +551,6 @@ lists-enumerate4:
 
 lists-enumerate5:
   inherit: "lists-enumerate-base"
-  origin: "resilient.lists"
   style:
     numbering:
       after:
@@ -444,94 +561,108 @@ lists-enumerate5:
 
 lists-itemize-alternate1:
   inherit: "lists-itemize-base"
-  origin: "resilient.lists"
   style:
     itemize:
       symbol: "—"
 
 lists-itemize-alternate2:
   inherit: "lists-itemize-base"
-  origin: "resilient.lists"
   style:
     itemize:
       symbol: "•"
 
 lists-itemize-alternate3:
   inherit: "lists-itemize-base"
-  origin: "resilient.lists"
   style:
     itemize:
       symbol: "◦"
 
 lists-itemize-alternate4:
   inherit: "lists-itemize-base"
-  origin: "resilient.lists"
   style:
     itemize:
       symbol: "–"
 
 lists-itemize-alternate5:
   inherit: "lists-itemize-base"
-  origin: "resilient.lists"
   style:
     itemize:
       symbol: "•"
 
 lists-itemize-alternate6:
   inherit: "lists-itemize-base"
-  origin: "resilient.lists"
   style:
     itemize:
       symbol: "◦"
 
 lists-itemize-base:
-  origin: "resilient.lists"
   style:
 
 lists-itemize1:
   inherit: "lists-itemize-base"
-  origin: "resilient.lists"
   style:
     itemize:
       symbol: "•"
 
 lists-itemize2:
   inherit: "lists-itemize-base"
-  origin: "resilient.lists"
   style:
     itemize:
       symbol: "◦"
 
 lists-itemize3:
   inherit: "lists-itemize-base"
-  origin: "resilient.lists"
   style:
     itemize:
       symbol: "–"
 
 lists-itemize4:
   inherit: "lists-itemize-base"
-  origin: "resilient.lists"
   style:
     itemize:
       symbol: "•"
 
 lists-itemize5:
   inherit: "lists-itemize-base"
-  origin: "resilient.lists"
   style:
     itemize:
       symbol: "◦"
 
 lists-itemize6:
   inherit: "lists-itemize-base"
-  origin: "resilient.lists"
   style:
     itemize:
       symbol: "–"
 
+sectioning-appendix:
+  inherit: "sectioning-chapter"
+  style:
+    sectioning:
+      numberstyle:
+        header: "sectioning-appendix-head-number"
+        main: "sectioning-appendix-main-number"
+        reference: "sectioning-appendix-ref-number"
+
+sectioning-appendix-head-number:
+  inherit: "sectioning-chapter-head-number"
+  style:
+
+sectioning-appendix-main-number:
+  inherit: "sectioning-chapter-main-number"
+  style:
+    numbering:
+      before:
+        text: "Appendix "
+      display: "ALPHA"
+
+sectioning-appendix-ref-number:
+  inherit: "sectioning-chapter-ref-number"
+  style:
+    numbering:
+      before:
+        text: "app. "
+
 sectioning-base:
-  origin: "resilient.book"
   style:
     font:
       family: "Libertinus Serif"
@@ -543,7 +674,6 @@ sectioning-base:
 
 sectioning-chapter:
   inherit: "sectioning-base"
-  origin: "resilient.book"
   style:
     font:
       size: "1.4em"
@@ -566,12 +696,10 @@ sectioning-chapter:
         toclevel: 1
 
 sectioning-chapter-base-number:
-  origin: "resilient.book"
   style:
 
 sectioning-chapter-head-number:
   inherit: "sectioning-chapter-base-number"
-  origin: "resilient.book"
   style:
     numbering:
       after:
@@ -580,7 +708,6 @@ sectioning-chapter-head-number:
 
 sectioning-chapter-main-number:
   inherit: "sectioning-chapter-base-number"
-  origin: "resilient.book"
   style:
     font:
       size: "0.9em"
@@ -593,14 +720,12 @@ sectioning-chapter-main-number:
 
 sectioning-chapter-ref-number:
   inherit: "sectioning-chapter-base-number"
-  origin: "resilient.book"
   style:
     numbering:
       before:
         text: "chap. "
 
 sectioning-other-number:
-  origin: "resilient.book"
   style:
     numbering:
       after:
@@ -609,7 +734,6 @@ sectioning-other-number:
 
 sectioning-part:
   inherit: "sectioning-base"
-  origin: "resilient.book"
   style:
     font:
       size: "1.6em"
@@ -634,14 +758,12 @@ sectioning-part:
         toclevel: 0
 
 sectioning-part-base-number:
-  origin: "resilient.book"
   style:
     numbering:
       display: "ROMAN"
 
 sectioning-part-head-number:
   inherit: "sectioning-part-base-number"
-  origin: "resilient.book"
   style:
     numbering:
       after:
@@ -650,7 +772,6 @@ sectioning-part-head-number:
 
 sectioning-part-main-number:
   inherit: "sectioning-part-base-number"
-  origin: "resilient.book"
   style:
     font:
       features: "+smcp"
@@ -661,7 +782,6 @@ sectioning-part-main-number:
 
 sectioning-part-ref-number:
   inherit: "sectioning-part-base-number"
-  origin: "resilient.book"
   style:
     numbering:
       before:
@@ -669,7 +789,6 @@ sectioning-part-ref-number:
 
 sectioning-section:
   inherit: "sectioning-base"
-  origin: "resilient.book"
   style:
     font:
       size: "1.2em"
@@ -694,7 +813,6 @@ sectioning-section:
 
 sectioning-subsection:
   inherit: "sectioning-base"
-  origin: "resilient.book"
   style:
     font:
       size: "1.1em"
@@ -718,7 +836,6 @@ sectioning-subsection:
 
 sectioning-subsubsection:
   inherit: "sectioning-base"
-  origin: "resilient.book"
   style:
     font:
       weight: 700
@@ -739,7 +856,6 @@ sectioning-subsubsection:
         toclevel: 4
 
 table:
-  origin: "resilient.book"
   style:
     paragraph:
       after:
@@ -749,7 +865,6 @@ table:
         indent: false
 
 table-caption:
-  origin: "resilient.book"
   style:
     font:
       size: "0.95em"
@@ -773,12 +888,10 @@ table-caption:
         toclevel: 6
 
 table-caption-base-number:
-  origin: "resilient.book"
   style:
 
 table-caption-main-number:
   inherit: "table-caption-base-number"
-  origin: "resilient.book"
   style:
     font:
       features: "+smcp"
@@ -791,23 +904,19 @@ table-caption-main-number:
 
 table-caption-ref-number:
   inherit: "table-caption-base-number"
-  origin: "resilient.book"
   style:
     numbering:
       before:
         text: "table "
 
 toc:
-  origin: "resilient.tableofcontents"
   style:
 
 toc-level-base:
-  origin: "resilient.tableofcontents"
   style:
 
 toc-level0:
   inherit: "toc-level-base"
-  origin: "resilient.tableofcontents"
   style:
     font:
       size: "1.15em"
@@ -825,7 +934,6 @@ toc-level0:
 
 toc-level1:
   inherit: "toc-level-base"
-  origin: "resilient.tableofcontents"
   style:
     font:
       size: "1.1em"
@@ -840,7 +948,6 @@ toc-level1:
 
 toc-level2:
   inherit: "toc-level-base"
-  origin: "resilient.tableofcontents"
   style:
     font:
       size: "1em"
@@ -853,7 +960,6 @@ toc-level2:
 
 toc-level3:
   inherit: "toc-level-base"
-  origin: "resilient.tableofcontents"
   style:
     paragraph:
       after:
@@ -865,7 +971,6 @@ toc-level3:
 
 toc-level4:
   inherit: "toc-level-base"
-  origin: "resilient.tableofcontents"
   style:
     paragraph:
       after:
@@ -877,7 +982,6 @@ toc-level4:
 
 toc-level5:
   inherit: "toc-level-base"
-  origin: "resilient.tableofcontents"
   style:
     paragraph:
       after:
@@ -889,7 +993,6 @@ toc-level5:
 
 toc-level6:
   inherit: "toc-level-base"
-  origin: "resilient.tableofcontents"
   style:
     paragraph:
       after:
@@ -901,7 +1004,6 @@ toc-level6:
 
 toc-level7:
   inherit: "toc-level-base"
-  origin: "resilient.tableofcontents"
   style:
     paragraph:
       before:
@@ -911,7 +1013,6 @@ toc-level7:
 
 toc-level8:
   inherit: "toc-level-base"
-  origin: "resilient.tableofcontents"
   style:
     paragraph:
       before:
@@ -921,7 +1022,6 @@ toc-level8:
 
 toc-level9:
   inherit: "toc-level-base"
-  origin: "resilient.tableofcontents"
   style:
     paragraph:
       before:
@@ -930,7 +1030,6 @@ toc-level9:
       pageno: false
 
 toc-number-base:
-  origin: "resilient.tableofcontents"
   style:
     numbering:
       after:
@@ -939,32 +1038,26 @@ toc-number-base:
 
 toc-number-level0:
   inherit: "toc-number-base"
-  origin: "resilient.tableofcontents"
   style:
 
 toc-number-level1:
   inherit: "toc-number-base"
-  origin: "resilient.tableofcontents"
   style:
 
 toc-number-level2:
   inherit: "toc-number-base"
-  origin: "resilient.tableofcontents"
   style:
 
 toc-number-level3:
   inherit: "toc-number-base"
-  origin: "resilient.tableofcontents"
   style:
 
 toc-number-level4:
   inherit: "toc-number-base"
-  origin: "resilient.tableofcontents"
   style:
 
 toc-number-level5:
   inherit: "toc-number-base"
-  origin: "resilient.tableofcontents"
   style:
     font:
       features: "+smcp"
@@ -977,7 +1070,6 @@ toc-number-level5:
 
 toc-number-level6:
   inherit: "toc-number-base"
-  origin: "resilient.tableofcontents"
   style:
     font:
       features: "+smcp"
@@ -990,32 +1082,26 @@ toc-number-level6:
 
 toc-number-level7:
   inherit: "toc-number-base"
-  origin: "resilient.tableofcontents"
   style:
 
 toc-number-level8:
   inherit: "toc-number-base"
-  origin: "resilient.tableofcontents"
   style:
 
 toc-number-level9:
   inherit: "toc-number-base"
-  origin: "resilient.tableofcontents"
   style:
 
 toc-pageno:
-  origin: "resilient.tableofcontents"
   style:
 
 url:
-  origin: "resilient.book"
   style:
     font:
       language: "und"
 
 verbatim:
   inherit: "code"
-  origin: "resilient.verbatim"
   style:
     paragraph:
       align: "obeylines"

--- a/examples/manual-classes/book.dj
+++ b/examples/manual-classes/book.dj
@@ -38,7 +38,7 @@ In addition to the class options provided by SILE, the class also supports the f
 
 The class supports the following standard sectioning commands, from the highest division level to the lowest: `\autodoc:command{\part}`{=sile}, `\autodoc:command{\chapter}`{=sile}, `\autodoc:command{\section}`{=sile}, `\autodoc:command{\subsection}`{=sile}, `\autodoc:command{\subsubsection}`{=sile}.
 
-All sectioning commands obey styles (relying on the **resilient.styles** and **resilient.sectioning** packages), which notably imply that they have a lot of customization possibilities.
+All sectioning commands obey styles (relying on the *resilient.styles* and *resilient.sectioning* packages), which notably imply that they have a lot of customization possibilities.
 In the following pages, the described behaviors apply to the default configuration and styling, out-of-the-box.
 
 All the sections accepts the `\autodoc:parameter{numbering=false}`{=sile} option, if you want them unnumbered, and the `\autodoc:parameter{toc=false}`{=sile} option, if you do not want them to appear in the table of contents.
@@ -151,7 +151,7 @@ The class also defines two commands for manipulating the page headers.
 The “tracked” variants ensure the content is tracked per page (using “info nodes”), which is usually what you want for section headers.
 The other versions do not introduce info nodes, are intended to be used with direct content (such as a document title) or content already tracked elsewhere.
 
-Page headers rely on the functionality provided by the **resilient.headers** package,
+Page headers rely on the functionality provided by the *resilient.headers* package,
 so the `\autodoc:command{\noheaders}`{=sile}, `\autodoc:command{\noheaderthispage}`{=sile} and `\autodoc:command{\headers}`{=sile} commands are available, as well as `\autodoc:command{\header:rule}`{=sile}.
 
 ## Block-indented quotes
@@ -189,11 +189,11 @@ Again, this can be changed on the sectioning command itself, or globally with ad
 
 ## Other features
 
-The footnotes are based on the **resilient.footnotes** package and therefore have the extra features proposed in this implementation, notably the `\autodoc:command{\footnote:rule}`{=sile} command and the possibility to specify an explicit `\autodoc:parameter{mark}`{=sile} on footnote calls.
+The footnotes are based on the *resilient.footnotes* package and therefore have the extra features proposed in this implementation, notably the `\autodoc:command{\footnote:rule}`{=sile} command and the possibility to specify an explicit `\autodoc:parameter{mark}`{=sile} on footnote calls.
 
-The table of contents relies on the **resilient.tableofcontents** package. One can therefore change many styling and appearance aspects to create a custom table of contents.
+The table of contents relies on the *resilient.tableofcontents* package. One can therefore change many styling and appearance aspects to create a custom table of contents.
 
-Cross-references are supported via the **labelrefs** package, henceforth the `\autodoc:command{\label}`{=sile}, `\autodoc:command{\ref}`{=sile} and `\autodoc:command{\pageref}`{=sile} commands are available.
+Cross-references are supported via the *labelrefs* package, henceforth the `\autodoc:command{\label}`{=sile}, `\autodoc:command{\ref}`{=sile} and `\autodoc:command{\pageref}`{=sile} commands are available.
 All sectioning commands accept the `marker` option to introduce a label at the appropriate place (e.g., the section title) in a convenient way.
 
 A few layout-related commands are also provided.

--- a/examples/manual-intro/installation.dj
+++ b/examples/manual-intro/installation.dj
@@ -29,10 +29,10 @@ Other than that, the installation should be straightforward, and _re·sil·ient_
 {#recommended-additional-software}
 ## Recommended additional software
 
-This module also notably installs, as dependencies, the following collections (so you don't have to install them separately):
-
+This collection also notably includes the following components:
+ 
  - the [*embedders.sile*](https://github.com/Omikhleia/embedders.sile) collection, a general framework for embedding images from textual representations, performing their on-the-fly conversion,
- - the [*printoptions.sile*](https://github.com/Omikhleia/embedders.sile) collection, a general framework for rasterizing vector images and rescaling raster images.
+ - the *printoptions* package, a general framework for rasterizing vector images and rescaling raster images.
 
 However, these require additional software to be installed on your host system, to invoke the necessary conversion commands.
 Depending on the features you plan to use, you may need to ensure the following software is installed.
@@ -44,10 +44,10 @@ All of these are optional if you don't plan to use the corresponding features.
     - *graphviz* for DOT graph rendering, if you plan to include graphs in your documents.
     - *ghostscript* for PDF image conversion.
 
- - Dependencies for *printoptions.sile* are only required if you plan to go to print with your documents, and your printer has specific requirements or expectations.[^printer-expectations]
+ - Dependencies for *printoptions* are only required if you plan to go to print with your documents, and your printer has specific requirements or expectations.[^printer-expectations]
 
-    - **inkscape** for SVG image conversion, if you plan to rasterize vector images in your documents.
-    - **graphicsmagick** for image conversion, if you plan to minimize the size of your raster images.
+    - *inkscape* for SVG image conversion, if you plan to rasterize vector images in your documents.
+    - *graphicsmagick* for image conversion, if you plan to minimize the size of your raster images.
 
 As with anything that relies on invoking external programs on your host system, please be aware of potential security concerns.
 Be cautious with the source of the elements you include in your documents!

--- a/examples/manual-masterdoc/masterdoc.dj
+++ b/examples/manual-masterdoc/masterdoc.dj
@@ -227,8 +227,8 @@ The `packages` object lists extra packages that SILE must use.
 It can be used to load add-on packages needed by your content but not already provided by the document class and its supporting packages.
 As far as the resilient collection is concerned, a few notable suggestions are listed below.
 
- - **resilient.poetry** for poetry typesetting.
- - **printoptions** for advanced print options & tools for professional printers.
+ - *resilient.poetry* for poetry typesetting.
+ - *printoptions* for advanced print options & tools for professional printers.
   
 {#masterdoc-content-basic}
 ## Up to the content

--- a/examples/manual-packages/packages.dj
+++ b/examples/manual-packages/packages.dj
@@ -142,11 +142,8 @@ This package is part of the *labelrefs.sile* collection.
 {#packages-fancytoc}
 ## Fancy alternative table of contents
 
-{custom-style=admon}
-This package is part of the *fancytoc.sile* collection.
-
 ``` =sile
-\package-documentation{fancytoc}
+\package-documentation{resilient.fancytoc}
 ```
 
 Here it is at work for the current document with default parameters.

--- a/examples/manual-packages/packages.dj
+++ b/examples/manual-packages/packages.dj
@@ -177,9 +177,6 @@ And here it is stating at level 1, i.e. chapters and sections.
 
 ## Printing options & tools for professional printers
 
-{custom-style=admon}
-This package is part of the *printoptions.sile* collection.
-
 ``` =sile
 \package-documentation{printoptions}
 ```

--- a/examples/manual-styling/advanced/toclevels.dj
+++ b/examples/manual-styling/advanced/toclevels.dj
@@ -11,8 +11,7 @@ consider:
 [^toc-fancy]: This section applies to the "standard" table of contents,
 as produced with the `\tableofcontents` command from the *resilient.tableofcontents*
 package.
-Specific implementations such as *fancytoc* may use their own
-styling rules.
+Specific implementations such as *resilient.fancytoc* may use their own styling rules.
 
 ### Global setup
 

--- a/examples/resilient-ecosystem.dot
+++ b/examples/resilient-ecosystem.dot
@@ -69,6 +69,7 @@ digraph omikhleia {
       defn [shape=component,style=filled,fillcolor=mintcream,label="resilient.defn"]
       verbatim [shape=component,style=filled,fillcolor=mintcream,label="resilient.verbatim"]
       liners [shape=component,style=filled,fillcolor=mintcream,label="resilient.liners"]
+      fancytoc [shape=component,style=filled,fillcolor=mintcream, label="resilient.fancytoc"]
 
       cbase -> styles
       pbase -> styles
@@ -91,6 +92,7 @@ digraph omikhleia {
       defn -> pbase
       verbatim -> pbase
       liners -> pbase
+      fancytoc -> pbase
     }
     subgraph cluster_resilient_ins {
       label = "inputters";
@@ -135,13 +137,6 @@ digraph omikhleia {
     markcmd -> embedders
     markcmd -> smartquotes
     markcmd -> highlighter
-  }
-
-  subgraph cluster_fancytoc {
-    label = "fancytoc.sile";
-
-    fancytoc [shape=component,style=filled,fillcolor=mintcream]
-    fancytoc -> styles
   }
 
   subgraph cluster_couyards {

--- a/examples/resilient-ecosystem.dot
+++ b/examples/resilient-ecosystem.dot
@@ -70,7 +70,8 @@ digraph omikhleia {
       verbatim [shape=component,style=filled,fillcolor=mintcream,label="resilient.verbatim"]
       liners [shape=component,style=filled,fillcolor=mintcream,label="resilient.liners"]
       fancytoc [shape=component,style=filled,fillcolor=mintcream, label="resilient.fancytoc"]
-
+      printoptions [shape=component,style=filled,fillcolor=mintcream]
+ 
       cbase -> styles
       pbase -> styles
       styles -> textsubsuper
@@ -150,12 +151,6 @@ digraph omikhleia {
     label = "barcodes.sile";
 
     barcodes [shape=component,style=filled,fillcolor=mintcream,label="barcodes.ean13"]
-  }
-
-subgraph cluster_printoptions {
-    label = "printoptions.sile";
-
-    printoptions [shape=component,style=filled,fillcolor=mintcream]
     silm -> barcodes
   }
 }

--- a/examples/resume-sample.sil
+++ b/examples/resume-sample.sil
@@ -104,7 +104,7 @@
     \begin{entry}
       \topic{1878–1881}
       \description{Collection of monographs: \em{On the Dating of Documents,
-        the Tracing of Foosteps & other assorted essays},
+        the Tracing of Footsteps & other assorted essays},
         translated into French by François le Villard.}
     \end{entry}
     \begin{entry}

--- a/inputters/silm.lua
+++ b/inputters/silm.lua
@@ -18,8 +18,6 @@
 --
 -- @module inputters.silm
 --
-local createCommand, createStructuredCommand = SU.ast.createCommand, SU.ast.createStructuredCommand
-
 SILE.registerCommand("has:book-title-support", function (_, content)
   -- Fairly lame command detection
   if SILE.Commands["book-title"] then
@@ -396,7 +394,7 @@ local knownPdfMetadata = {
 local function insertPdfMetadata (content, metadata)
   for key, value in pairs(metadata) do
     if knownPdfMetadata[key] then
-      content[#content+1] = createCommand("pdf:metadata", {
+      content[#content+1] = SU.ast.createCommand("pdf:metadata", {
         key = knownPdfMetadata[key],
         value = type(value) == "table" and table.concat(value, "; ") or value
       })
@@ -452,14 +450,14 @@ local function doLevel (content, entries, shiftHeadings, metaopts)
       spec = pl.tablex.union(metaopts, {
         src = entry,
         shift_headings = shiftHeadings })
-      content[#content+1] = createCommand("include", spec)
+      content[#content+1] = SU.ast.createCommand("include", spec)
     elseif entry.file then
       local fullopts = entry.options and pl.tablex.union(entry.options, metaopts) or metaopts
       spec = pl.tablex.union(fullopts, {
         src = entry.file,
         format = entry.format,
         shift_headings = shiftHeadings })
-      content[#content+1] = createCommand("include", spec)
+      content[#content+1] = SU.ast.createCommand("include", spec)
       if entry.content then
         doLevel(content, entry.content, shiftHeadings + 1, metaopts)
       end
@@ -468,12 +466,12 @@ local function doLevel (content, entries, shiftHeadings, metaopts)
         doLevel(content, entry.chapters, shiftHeadings + 1, metaopts)
       end
       if entry.appendices then
-        content[#content+1] = createCommand("appendix")
+        content[#content+1] = SU.ast.createCommand("appendix")
         doLevel(content, entry.appendices, shiftHeadings + 1, metaopts)
       end
     elseif entry.caption then
       local command = Levels[shiftHeadings + 2] or SU.error("Invalid master document (too many nested levels)")
-      content[#content+1] = createCommand(command, {}, entry.caption)
+      content[#content+1] = SU.ast.createCommand(command, {}, entry.caption)
       if entry.content then
         doLevel(content, entry.content, shiftHeadings + 1, metaopts)
       end
@@ -482,7 +480,7 @@ local function doLevel (content, entries, shiftHeadings, metaopts)
         doLevel(content, entry.chapters, shiftHeadings + 1, metaopts)
       end
       if entry.appendices then
-        content[#content+1] = createCommand("appendix")
+        content[#content+1] = SU.ast.createCommand("appendix")
         doLevel(content, entry.appendices, shiftHeadings + 1, metaopts)
       end
     elseif entry.content then
@@ -499,7 +497,7 @@ local function doDivisionContent (content, entry, shiftHeadings, metaopts)
       doLevel(content, entry.chapters, shiftHeadings, metaopts)
     end
     if entry.appendices then
-      content[#content+1] = createCommand("appendix")
+      content[#content+1] = SU.ast.createCommand("appendix")
       doLevel(content, entry.appendices, shiftHeadings, metaopts)
     end
   end
@@ -507,15 +505,15 @@ end
 
 local function doDivision (content, entry, shiftHeadings, metaopts)
   if entry.frontmatter then
-    content[#content+1] = createCommand("frontmatter")
+    content[#content+1] = SU.ast.createCommand("frontmatter")
     doDivisionContent(content, entry.frontmatter, shiftHeadings, metaopts)
   end
   if entry.mainmatter then
-    content[#content+1] = createCommand("mainmatter")
+    content[#content+1] = SU.ast.createCommand("mainmatter")
     doDivisionContent(content, entry.mainmatter, shiftHeadings, metaopts)
   end
   if entry.backmatter then
-    content[#content+1] = createCommand("backmatter")
+    content[#content+1] = SU.ast.createCommand("backmatter")
     doDivisionContent(content, entry.backmatter, shiftHeadings, metaopts)
   end
 end
@@ -531,13 +529,13 @@ local function doBackCoverContent (entry, metaopts)
     content = {}
   elseif type(entry) == "string" then
     spec = pl.tablex.union(metaopts, { src = entry })
-    content = createCommand("include", spec)
+    content = SU.ast.createCommand("include", spec)
   elseif entry.file then
     local fullopts = entry.options and pl.tablex.union(entry.options, metaopts) or metaopts
     spec = pl.tablex.union(fullopts, {
       src = entry.file,
       format = entry.format })
-    content = createCommand("include", spec)
+    content = SU.ast.createCommand("include", spec)
   else
     SU.error("Invalid master document (invalid cover content)")
   end
@@ -589,20 +587,20 @@ function inputter:parse (doc)
     -- Document global settings
     if master.font then
       if type(master.font.family) == "table" then
-        content[#content+1] = createCommand("use", {
+        content[#content+1] = SU.ast.createCommand("use", {
           module = "packages.font-fallback"
         })
-        content[#content+1] = createCommand("font", {
+        content[#content+1] = SU.ast.createCommand("font", {
           family = master.font.family[1],
           size = master.font.size
         })
         for i = 2, #master.font.family do
-          content[#content+1] = createCommand("font:add-fallback", {
+          content[#content+1] = SU.ast.createCommand("font:add-fallback", {
             family = master.font.family[i],
           })
         end
       else
-        content[#content+1] = createCommand("font", {
+        content[#content+1] = SU.ast.createCommand("font", {
           family = master.font.family,
           size = master.font.size
         })
@@ -613,7 +611,7 @@ function inputter:parse (doc)
     -- the class (e.g. style overrides in the case of resilient classes)
     -- Not sure how to behave with legacy classes though...
     if master.language then
-      content[#content+1] = createCommand("language", {
+      content[#content+1] = SU.ast.createCommand("language", {
         main = master.language
       })
     end
@@ -628,7 +626,7 @@ function inputter:parse (doc)
 
   if packages then
     for _, pkg in ipairs(packages) do
-      content[#content+1] = createCommand("use", {
+      content[#content+1] = SU.ast.createCommand("use", {
         module = "packages." .. pkg
       })
     end
@@ -638,38 +636,38 @@ function inputter:parse (doc)
     local settings = sile.settings or {}
     if settings then
       for k, v in pairs(settings) do
-        content[#content+1] = createCommand("set", {
+        content[#content+1] = SU.ast.createCommand("set", {
           parameter = k,
           value = v
         })
       end
     end
     if SU.boolean(self.options.cropmarks, false) then
-      content[#content+1] = createCommand("use", {
+      content[#content+1] = SU.ast.createCommand("use", {
         module = "packages.cropmarks"
       })
-      content[#content+1] = createCommand("cropmarks:setup")
+      content[#content+1] = SU.ast.createCommand("cropmarks:setup")
     end
     if metadata.title then
-      content[#content+1] = createCommand("has:book-title-support", {}, { metadata.title })
+      content[#content+1] = SU.ast.createCommand("has:book-title-support", {}, { metadata.title })
     end
     if master.bibliography then
       local bibfiles = master.bibliography.files
       if type(bibfiles) == "string" then
         bibfiles = { bibfiles }
       end
-      content[#content+1] = createCommand("use", {
+      content[#content+1] = SU.ast.createCommand("use", {
         module = "packages.bibtex"
       })
       if #bibfiles > 0 then
         local lang = master.bibliography.language or master.language or "en-US"
         local style = master.bibliography.style or "chicago-author-date"
-        content[#content+1] = createCommand("bibliographystyle", {
+        content[#content+1] = SU.ast.createCommand("bibliographystyle", {
           style = style,
           lang = lang
         })
         for _, bibfile in ipairs(bibfiles) do
-          content[#content+1] = createCommand("loadbibliography", {
+          content[#content+1] = SU.ast.createCommand("loadbibliography", {
             file = bibfile
           })
         end
@@ -691,14 +689,14 @@ function inputter:parse (doc)
   local enabledCover = isRoot and SU.boolean(self.options.cover, bookmatter.enabled)
 
   if enabledBook or enabledCover then
-    content[#content+1] = createCommand("use", {
+    content[#content+1] = SU.ast.createCommand("use", {
       module = "packages.resilient.bookmatters"
     })
   end
 
   if enabledCover and bookmatter.cover then
     local cover = bookmatter.cover.front
-    content[#content+1] = createCommand("bookmatters:front-cover", {
+    content[#content+1] = SU.ast.createCommand("bookmatters:front-cover", {
       image = cover and cover.image or bookmatter.cover.image,
       background = cover and cover.background or bookmatter.cover.background,
       template = cover and cover.template,
@@ -707,12 +705,12 @@ function inputter:parse (doc)
   end
 
   if enabledBook then
-    content[#content+1] = createCommand("bookmatters:template", {
+    content[#content+1] = SU.ast.createCommand("bookmatters:template", {
       recto = bookmatter.halftitle.recto or "halftitle-recto",
       verso = bookmatter.halftitle.verso or "halftitle-verso",
       metadata = metadataOptions
     })
-    content[#content+1] =  createCommand("bookmatters:template", {
+    content[#content+1] =  SU.ast.createCommand("bookmatters:template", {
       recto = bookmatter.title.recto or "title-recto",
       verso = bookmatter.title.verso or "title-verso",
       metadata = metadataOptions
@@ -738,7 +736,7 @@ function inputter:parse (doc)
   end
 
   if enabledBook then
-    content[#content+1] = createCommand("bookmatters:template", {
+    content[#content+1] = SU.ast.createCommand("bookmatters:template", {
       recto = bookmatter.endpaper.recto or "endpaper-recto",
       verso = bookmatter.endpaper.verso or "endpaper-verso",
       metadata = metadataOptions
@@ -748,7 +746,7 @@ function inputter:parse (doc)
     local cover = bookmatter.cover.back
     local background = cover and cover.background or bookmatter.cover.background
     local coverContent = cover and cover.content or nil
-    content[#content+1] = createCommand("bookmatters:back-cover", {
+    content[#content+1] = SU.ast.createCommand("bookmatters:back-cover", {
       image = cover and cover.image or bookmatter.cover.image,
       background = background,
       bgcontent = cover and cover["content-background"] or background,
@@ -775,7 +773,7 @@ function inputter:parse (doc)
     } or {}
 
   local tree = {
-    createStructuredCommand("document", classopts, content),
+    SU.ast.createStructuredCommand("document", classopts, content),
   }
   return tree
 end

--- a/inputters/silm.lua
+++ b/inputters/silm.lua
@@ -1,10 +1,24 @@
 --- Some YAML master file inputter for SILE
 --
--- @copyright License: MIT (c) 2023, 2025 Omikhleia, Didier Willis
+-- License: GPL-3.0-or-later
+--
+-- Copyright (C) 2023-2025 Didier Willis
+-- This program is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with this program.  If not, see <https://www.gnu.org/licenses/>.
+--
 -- @module inputters.silm
 --
-local ast = require("silex.ast")
-local createCommand, createStructuredCommand = ast.createCommand, ast.createStructuredCommand
+local createCommand, createStructuredCommand = SU.ast.createCommand, SU.ast.createStructuredCommand
 
 SILE.registerCommand("has:book-title-support", function (_, content)
   -- Fairly lame command detection

--- a/packages/autodoc-resilient/init.lua
+++ b/packages/autodoc-resilient/init.lua
@@ -1,17 +1,28 @@
 --
 -- Documentation tooling for package designers.
--- (c) SILE for the original version
--- (c) 2023 Omikhleia for the "resilient" version override.
--- License: MIT
+--
+-- License: GPL-3.0-or-later
+--
+-- Copyright (C) 2023-2025 Didier Willis
+-- This program is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with this program.  If not, see <https://www.gnu.org/licenses/>.
 --
 -- CAVEAT:
 -- This is a modified version of the standard 'autodoc' package,
 -- so that it works with the 'resilient' module,
--- with a rather OPINIONATED change. See HACKS comments below,
--- and the "silex.sile" module.
+-- with a rather OPINIONATED change. See HACKS comments below.
 --
-local ast = require("silex.ast")
-local createCommand, subContent = ast.createCommand, ast.subContent
+local createCommand, subContent = SU.ast.createCommand, SU.ast.subContent
 
 local base = require("packages.base")
 
@@ -125,7 +136,7 @@ function package:_init (options)
   end
 end
 
-function package.declareSettings (_)
+function package:declareSettings ()
   SILE.settings:declare({
     parameter = "autodoc.highlighting",
     default = false,
@@ -136,7 +147,7 @@ end
 
 function package:registerRawHandlers ()
 
-  self.class:registerRawHandler("autodoc:codeblock", function(options, content)
+  self:registerRawHandler("autodoc:codeblock", function(options, content)
     SILE.call("autodoc:codeblock", options, { content[1] }) -- Still issues with SU.ast.contentToString() witb raw content
   end)
 

--- a/packages/autodoc-resilient/init.lua
+++ b/packages/autodoc-resilient/init.lua
@@ -22,10 +22,7 @@
 -- so that it works with the 'resilient' module,
 -- with a rather OPINIONATED change. See HACKS comments below.
 --
-local createCommand, subContent = SU.ast.createCommand, SU.ast.subContent
-
 local base = require("packages.base")
-
 local package = pl.class(base)
 package._name = "autodoc-resilient"
 
@@ -41,7 +38,7 @@ local theme = {
 local colorWrapper = function (ctype, content)
   local color = SILE.scratch.autodoc.theme[ctype]
   if color and SILE.settings:get("autodoc.highlighting") and SILE.Commands["color"] then
-    return { createCommand("color", { color = color }, subContent(content)) }
+    return { SU.ast.createCommand("color", { color = color }, SU.ast.subContent(content)) }
   else
     return content
   end
@@ -74,7 +71,7 @@ local function astToDisplay (options, content)
         seenCommandWithoutArg = false
       end
       if tree:sub(1, 1) == "<" and tree:sub(-1) == ">" then
-        result[#result+1] = createCommand("autodoc:internal:bracketed", {}, tree:sub(2, -2))
+        result[#result+1] = SU.ast.createCommand("autodoc:internal:bracketed", {}, tree:sub(2, -2))
       else
         result[#result+1] = tree
       end
@@ -84,7 +81,7 @@ local function astToDisplay (options, content)
         SU.error("Unexpected command '"..tree.command.."'")
       end
       result[#result+1] = "\\"
-      result[#result+1] = createCommand("autodoc:code:style", { type = "command" }, tree.command)
+      result[#result+1] = SU.ast.createCommand("autodoc:code:style", { type = "command" }, tree.command)
       local sortedOpts = {}
       for k, _ in pairs(tree.options) do table.insert(sortedOpts, k) end
       table.sort(sortedOpts, optionSorter)
@@ -92,17 +89,17 @@ local function astToDisplay (options, content)
         result[#result+1] = "["
         for iOpt, option in ipairs(sortedOpts) do
           result[#result+1] = {
-            createCommand("autodoc:code:style", { type = "parameter" }, option),
+            SU.ast.createCommand("autodoc:code:style", { type = "parameter" }, option),
             "=",
-            createCommand("penalty", { penalty = 100 }), -- Quite decent to break here if need be.
-            createCommand("autodoc:value", {}, tree.options[option]),
+            SU.ast.createCommand("penalty", { penalty = 100 }), -- Quite decent to break here if need be.
+            SU.ast.createCommand("autodoc:value", {}, tree.options[option]),
             (iOpt == #sortedOpts) and "]" or ", "
           }
         end
       end
       if (#tree >= 1) then
         result[#result+1] = {
-          createCommand("penalty", { penalty = 200 }), -- Less than optimal break.
+          SU.ast.createCommand("penalty", { penalty = 200 }), -- Less than optimal break.
           "{",
           astToDisplay(options, tree),
           "}"
@@ -246,7 +243,7 @@ function package:registerCommands ()
   self:registerCommand("autodoc:internal:bracketed", function (_, content)
     SILE.typesetter:typeset("⟨")
     SILE.call("autodoc:code:style", { type = "bracketed" }, {
-      createCommand("em", {}, subContent(content))
+      SU.ast.createCommand("em", {}, SU.ast.subContent(content))
     })
     SILE.call("kern", { width = "0.1em" }) -- fake italic correction.
     SILE.typesetter:typeset("⟩")
@@ -288,11 +285,11 @@ function package:registerCommands ()
     end
     if #parts < 1 or #parts > 2 then SU.error("Unexpected parameter '"..param.."'") end
     SILE.call("autodoc:code:style", { type = "ast" }, {
-      createCommand("autodoc:code:style", { type = "parameter" }, parts[1]),
+      SU.ast.createCommand("autodoc:code:style", { type = "parameter" }, parts[1]),
       (#parts == 2) and {
         "=",
-        createCommand("penalty", { penalty = 100 }, nil), -- Quite decent to break here if need be.
-        createCommand("autodoc:value", {}, parts[2])
+        SU.ast.createCommand("penalty", { penalty = 100 }, nil), -- Quite decent to break here if need be.
+        SU.ast.createCommand("autodoc:value", {}, parts[2])
       } or nil
     })
   end, "Outputs a nicely presented parameter, possibly with a value.")

--- a/packages/printoptions/init.lua
+++ b/packages/printoptions/init.lua
@@ -1,0 +1,328 @@
+--
+-- Print options for professional printers
+--
+-- Requires: Inkscape and GraphicsMagick to be available on the host system.
+-- Reminders: GraphicsMagick also needs Ghostscript for PDF images
+-- (it delegates to it).
+--
+-- License: GPL-3.0-or-later
+--
+-- Copyright (C) 2022-2025 Didier Willis
+-- This program is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with this program.  If not, see <https://www.gnu.org/licenses/>.
+--
+local base = require("packages.base")
+
+local package = pl.class(base)
+package._name = "printoptions"
+
+function package:declareSettings ()
+  SILE.settings:declare({
+    parameter = "printoptions.resolution",
+    type = "integer or nil",
+    default = nil,
+    help = "If set, defines the target image resolution in DPI (dots per inch)"
+  })
+
+  SILE.settings:declare({
+    parameter = "printoptions.vector.rasterize",
+    type = "boolean",
+    default = true,
+    help = "When true and resolution is set, SVG vectors are rasterized."
+  })
+
+  SILE.settings:declare({
+    parameter = "printoptions.image.flatten",
+    type = "boolean",
+    default = false,
+    help = "When true and resolution is set, images are flattened (transparency removed)."
+  })
+
+  SILE.settings:declare({
+    parameter = "printoptions.image.grayscale",
+    type = "boolean",
+    default = true,
+    help = "When true and resolution is set, images are converted to grayscale."
+  })
+
+  SILE.settings:declare({
+    parameter = "printoptions.image.tolerance",
+    type = "number",
+    default = 0.85,
+    help = "Warning threshold for under-resolved images (percentage)."
+  })
+end
+
+local function handlePath (filename)
+  local basename = pl.path.basename(filename):match("(.+)%..+$")
+  local ext = pl.path.extension(filename)
+  if not basename or not ext then
+    SU.error("Cannot split path and extension in "..filename)
+  end
+
+  local dir = pl.path.join(pl.path.dirname(SILE.masterFilename), "converted")
+  if not pl.path.exists(dir) then
+    pl.path.mkdir(dir)
+  end
+  return pl.path.join(dir, basename), ext
+end
+
+local function imageResolutionConverter (filename, widthInPx, resolution, pageno)
+  local basename, ext = handlePath(filename)
+  local flatten = SILE.settings:get("printoptions.image.flatten")
+  local grayscale = SILE.settings:get("printoptions.image.grayscale")
+
+  local rescale = true
+  local width, _, xres = SILE.outputter:getImageSize(filename, pageno or 1)
+  local actualWidthInPx
+  if not xres then
+    -- This may happen with PDF files used as images, for instance.
+    SU.debug("printoptions", "Image doesn't have a known resolution", filename)
+    actualWidthInPx = width
+  else
+    actualWidthInPx = width * xres / 72
+  end
+  if actualWidthInPx <= widthInPx then
+    -- The image is already smaller than the target width.
+    rescale = false
+    -- Warn if the resolution is too low.
+    local actualResolution = math.floor(actualWidthInPx * resolution / widthInPx)
+    SU.debug("printoptions", "No resampling needed for", filename,
+      actualWidthInPx.."px", "for target", widthInPx.."px")
+    local threshold = SILE.settings:get("printoptions.image.tolerance")
+    if actualResolution <= threshold * resolution then
+      SU.warn("Image " .. filename .. " has a low resolution (" .. actualResolution .. " DPI)")
+    end
+  end
+
+  if not (rescale or flatten or grayscale) then
+    -- No need to convert the image.
+    SU.debug("printoptions", "No conversion needed for", filename)
+    return filename
+  end
+
+  local source = filename
+  if pageno then
+    -- Use specified page if provided (e.g. for PDF).
+    source = filename .. "[" .. (pageno - 1) .. "]" -- Graphicsmagick page numbers start at 0.
+    basename = pageno and basename .. "-p" .. pageno
+  end
+
+  local targetFilename = basename .. "-".. widthInPx .. "-" .. resolution
+  if flatten then
+    targetFilename = targetFilename .. "-flat"
+  end
+  if grayscale then
+    targetFilename = targetFilename .. "-gray"
+  end
+  targetFilename = targetFilename .. ext
+
+  local sourceTime = pl.path.getmtime(filename)
+  if sourceTime == nil then
+    SU.debug("printoptions", "Source file not found", filename)
+    return nil
+  end
+
+  local targetTime = pl.path.getmtime(targetFilename)
+  if targetTime ~= nil and targetTime > sourceTime then
+    SU.debug("printoptions", "Source file already converted", filename, "=", targetFilename)
+    return targetFilename
+  end
+
+  local command = {
+    "gm convert",
+      source ,
+      "-units PixelsPerInch",
+      -- disable antialiasing (best effort)
+      "+antialias",
+      "-filter point",
+  }
+  if rescale then
+    pl.tablex.insertvalues(command, {
+      -- resize
+      "-resize "..widthInPx.."x\\>",
+      "-density "..resolution,
+    })
+  end
+  if flatten then
+    pl.tablex.insertvalues(command, {
+      "-background white",
+      "-flatten",
+    })
+  end
+  if grayscale then
+    pl.tablex.insertvalues(command, {
+      "-colorspace GRAY",
+    })
+  end
+  command[#command + 1] = targetFilename
+  command = table.concat(command, " ")
+
+  SU.debug("printoptions", "Command:", command)
+  local result = os.execute(command)
+  if type(result) ~= "boolean" then result = (result == 0) end
+  if result then
+    SU.debug("printoptions", "Converted", filename, "to", targetFilename)
+    return targetFilename
+  else
+    return nil
+  end
+end
+
+local function svgRasterizer (filename, widthInPx, _)
+  local basename, ext = handlePath(filename)
+  if ext ~= ".svg" then SU.error("Expected SVG file for "..filename) end
+  local wpx = widthInPx * 2 -- See further below
+  local targetFilename = basename .. "-svg-"..wpx..".png"
+
+  local sourceTime = pl.path.getmtime(filename)
+  if sourceTime == nil then
+    SU.debug("printoptions", "Source file not found", filename)
+    return nil
+  end
+
+  local targetTime = pl.path.getmtime(targetFilename)
+  if targetTime ~= nil and targetTime > sourceTime then
+    SU.debug("printoptions", "Source file already converted", filename)
+    return targetFilename
+  end
+
+  -- Inkscape is better than imagemagick's convert at converting a SVG...
+  -- But it handles badly the resolution...
+  -- Anyway, we'll just convert to PNG and let the outputter resize the image.
+  local toSvg = table.concat({
+    "inkscape",
+    filename,
+    "-w ".. wpx, -- FIXME. I could not find a proper way to disable antialiasing
+                 -- So target twice the actual size, and the image conversion to
+                 -- resolution will also downsize without antialiasing.
+                 -- This is far from perfect, but minimizes the antialiasing a bit...
+    "-o",
+    targetFilename,
+  }, " ")
+  local result = os.execute(toSvg)
+  if type(result) ~= "boolean" then result = (result == 0) end
+  if result then
+    SU.debug("printoptions", "Converted ", filename, "to", targetFilename)
+    return targetFilename
+  else
+    return nil
+  end
+end
+
+local drawSVG = function (filename, svgdata, width, height, density)
+  -- FIXME/CAVEAT: We are reimplementing the whole logic from _drawSVG in the
+  -- "svg" package, but the latter might be wrong:
+  -- See https://github.com/sile-typesetter/sile/pull/1517
+  local svg = require("svg")
+  local svgfigure, svgwidth, svgheight = svg.svg_to_ps(svgdata, density)
+  SU.debug("svg", string.format("PS: %s\n", svgfigure))
+  local scalefactor = 1
+  if width and height then
+    -- local aspect = svgwidth / svgheight
+    SU.error("SILE cannot yet change SVG aspect ratios, specify either width or height but not both")
+  elseif width then
+    scalefactor = width:tonumber() / svgwidth
+  elseif height then
+    scalefactor = height:tonumber() / svgheight
+  end
+  width = SILE.types.measurement(svgwidth * scalefactor)
+  height = SILE.types.measurement(svgheight * scalefactor)
+  scalefactor = scalefactor * density / 72
+
+  local resolution = SILE.settings:get("printoptions.resolution")
+  local rasterize = SILE.settings:get("printoptions.vector.rasterize")
+  if resolution and resolution > 0 and rasterize then
+    local targetWidthInPx = math.ceil(SU.cast("number", width) * resolution / 72)
+    local converted = svgRasterizer(filename, targetWidthInPx, resolution)
+    if converted then
+      SILE.call("img", { src = converted, width = width })
+      return -- We are done replacing the SVG by a raster image
+    end
+    SU.warn("Resolution failure for "..filename..", using original image")
+  end
+
+  SILE.typesetter:pushHbox({
+    value = nil,
+    height = height,
+    width = width,
+    depth = 0,
+    outputYourself = function (self, typesetter)
+      SILE.outputter:drawSVG(svgfigure, typesetter.frame.state.cursorX, typesetter.frame.state.cursorY, self.width, self.height, scalefactor)
+      typesetter.frame:advanceWritingDirection(self.width)
+    end
+  })
+end
+
+function package:_init (pkgoptions)
+  base._init(self, pkgoptions)
+  self:loadPackage("image")
+  -- We do this to enforce loading the \svg command now.
+  -- so our version here can override it.
+  self:loadPackage("svg")
+  self:registerCommand("svg", function (options, _)
+    local src = SU.required(options, "src", "filename")
+    local filename = SILE.resolveFile(src) or SU.error("Couldn't find file "..src)
+    local width = options.width and SU.cast("measurement", options.width):absolute() or nil
+    local height = options.height and SU.cast("measurement", options.height):absolute() or nil
+    local density = options.density or 72
+    local svgfile = io.open(filename)
+    local svgdata = svgfile:read("*all")
+    drawSVG(filename, svgdata, width, height, density)
+  end)
+
+  local outputter = SILE.outputter.drawImage -- for override
+  SILE.outputter.drawImage = function (outputterSelf, filename, x, y, width, height, pageno)
+    local resolution = SILE.settings:get("printoptions.resolution")
+    if resolution and resolution > 0 then
+      SU.debug("printoptions", "Conversion to", resolution, "DPI for", filename)
+      local targetWidthInPx = math.ceil(SU.cast("number", width) * resolution / 72)
+      local converted = imageResolutionConverter(filename, targetWidthInPx, resolution, pageno)
+      if converted then
+        outputter(outputterSelf, converted, x, y, width, height)
+        return -- We are done replacing the original image by its resampled version.
+      end
+      SU.warn("Resolution failure for "..filename..", using original image")
+    end
+    outputter(outputterSelf, filename, x, y, width, height, pageno)
+  end
+end
+
+package.documentation = [[\begin{document}
+The \autodoc:package{printoptions} package provides a few settings that allow tuning image resolution and vector rasterization, as often requested by professional printers and print-on-demand services.
+
+The \autodoc:setting{printoptions.resolution} setting, when set to an integer value, defines the expected image resolution in DPI (dots per inch).
+It could be set to 300 or 600 for final offset print or, say, to 150 or lower for a low-resolution PDF for reviewers and proofreaders.
+Images are resampled to the target resolution (if they have a higher resolution).
+
+If the \autodoc:setting{printoptions.image.grayscale} setting is true (its default value), resampled images are also converted to grayscale.
+
+Under-resolved images are reported as warnings, if their resolution is below a threshold defined by the \autodoc:setting{printoptions.image.tolerance} (defaulting to 0.85, i.e. 85\% of the target resolution).
+
+The \autodoc:setting{printoptions.vector.rasterize} setting defaults to true.
+If a target image resolution is defined and this setting is left enabled, then vector images are rasterized.
+It currently applies to SVG files, redefining the \autodoc:command[check=false]{\svg} command.
+
+Converted images are all placed in a \code{converted} folder besides the master file.
+Be cautious not having images with the same base filename in different folders, to avoid conflicts!
+
+The package requires Inkscape, GraphicsMagick and Ghostscript to be available on your system.
+As with anything that relies on invoking external programs on your host system, please be aware of potential security concerns.
+Be very cautious with the source of the elements you include in your documents!
+
+Moreover, if the \autodoc:setting{printoptions.image.flatten} setting is turned to true (its default being false), not only images are resampled, but they are also flattened with a white background.
+You probably do not want to enable this setting for production, but it might be handy for checking things before going to print.
+(Most professional printers require the whole PDF to be flattened without transparency, which is not addressed here; but the assumption is that you might check what could happen if transparency is improperly managed by your printer and/or you have layered contents incorrectly ordered.)
+\end{document}]]
+
+return package

--- a/packages/resilient/abbr/init.lua
+++ b/packages/resilient/abbr/init.lua
@@ -18,7 +18,6 @@
 -- along with this program.  If not, see <https://www.gnu.org/licenses/>.
 --
 local base = require("packages.base")
-
 local package = pl.class(base)
 package._name = "resilient.abbr"
 

--- a/packages/resilient/abbr/init.lua
+++ b/packages/resilient/abbr/init.lua
@@ -1,8 +1,21 @@
 --
 -- Some common shorthands and abbreviations for SILE.
 --
--- 2021-2023, Didier Willis
--- License: MIT
+-- License: GPL-3.0-or-later
+--
+-- Copyright (C) 2021-2025 Didier Willis
+-- This program is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with this program.  If not, see <https://www.gnu.org/licenses/>.
 --
 local base = require("packages.base")
 
@@ -11,7 +24,7 @@ package._name = "resilient.abbr"
 
 function package:_init (options)
   base._init(self, options)
-  self.class:loadPackage("textsubsuper")
+  self:loadPackage("textsubsuper")
 end
 
 function package:registerCommands ()

--- a/packages/resilient/base.lua
+++ b/packages/resilient/base.lua
@@ -1,11 +1,24 @@
 --
 -- Resilient base for style-enabled packages for SILE
 --
--- 2023, 2025, Didier Willis
--- License: MIT
---
 -- It provides a base class for packages that want to use styles,
 -- and a few convenience methods hide the internals.
+--
+-- License: GPL-3.0-or-later
+--
+-- Copyright (C) 2023-2025 Didier Willis
+-- This program is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with this program.  If not, see <https://www.gnu.org/licenses/>.
 --
 require("silex")
 local base = require("packages.base")
@@ -17,7 +30,7 @@ package.styles = nil
 function package:_init (options)
   base._init(self, options)
 
-  self.class:loadPackage("resilient.styles")
+  self:loadPackage("resilient.styles")
   self.styles = self.class.packages["resilient.styles"]
   self:registerStyles()
 end
@@ -36,6 +49,6 @@ end
 
 -- For overriding in any package subclass, as a convenient hook
 -- where to register all styles.
-function package.registerStyles (_) end
+function package:registerStyles () end
 
 return package

--- a/packages/resilient/base.lua
+++ b/packages/resilient/base.lua
@@ -22,7 +22,6 @@
 --
 require("silex")
 local base = require("packages.base")
-
 local package = pl.class(base)
 package._name = "resilient.base"
 package.styles = nil

--- a/packages/resilient/base.lua
+++ b/packages/resilient/base.lua
@@ -20,7 +20,6 @@
 -- You should have received a copy of the GNU General Public License
 -- along with this program.  If not, see <https://www.gnu.org/licenses/>.
 --
-require("silex")
 local base = require("packages.base")
 local package = pl.class(base)
 package._name = "resilient.base"

--- a/packages/resilient/bible/tei/init.lua
+++ b/packages/resilient/bible/tei/init.lua
@@ -3,19 +3,31 @@
 -- from wulfila.be (TEI Gothica).
 -- Following the resilient styling paradigm.
 --
--- 2022, 2023, Didier Willis
--- License: MIT
---
 -- HIGHLY EXPERIMENTAL
 --
+-- License: GPL-3.0-or-later
+--
+-- Copyright (C) 2022-2025 Didier Willis
+-- This program is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with this program.  If not, see <https://www.gnu.org/licenses/>.
+--
 local luautf8 = require("lua-utf8")
-local ast = require("silex.ast")
 local createCommand,
       processAsStructure, trimSubContent,
       findInTree
-        = ast.createCommand,
-          ast.processAsStructure, ast.trimSubContent,
-          ast.findInTree
+        = SU.ast.createCommand,
+          SU.ast.processAsStructure, SU.ast.trimSubContent,
+          SU.ast.findInTree
 local loadkit = require("loadkit")
 local loader = loadkit.make_loader("png")
 
@@ -34,7 +46,7 @@ function package:_init (_)
   end)
 end
 
-function package.outputCollatedNotes (_)
+function package:outputCollatedNotes ()
   SILE.typesetNaturally(SILE.getFrame("margins"), function ()
     local refs = SILE.scratch.info.thispage.witnesses
     if not refs then return end

--- a/packages/resilient/bible/usx/init.lua
+++ b/packages/resilient/bible/usx/init.lua
@@ -20,11 +20,6 @@
 -- You should have received a copy of the GNU General Public License
 -- along with this program.  If not, see <https://www.gnu.org/licenses/>.
 --
-local createCommand,
-      processAsStructure, trimSubContent
-        = SU.ast.createCommand,
-          SU.ast.processAsStructure, SU.ast.trimSubContent
-
 local base = require("packages.resilient.base")
 local package = pl.class(base)
 package._name = "resilient.bible.usx"
@@ -273,14 +268,14 @@ function package:registerCommands()
 
   self:registerCommand("usx", function(_, content)
     SILE.call("running-headers", {}, {
-      createCommand("range-reference")
+      SU.ast.createCommand("range-reference")
     })
-    processAsStructure(content)
+    SU.ast.processAsStructure(content)
   end)
 
   self:registerCommand("book", function(options, content)
     SILE.call("save-book-title", {}, { options.code })
-    processAsStructure(content)
+    SU.ast.processAsStructure(content)
   end)
 
   self:registerCommand("chapter", function(options, _)
@@ -320,7 +315,7 @@ function package:registerCommands()
     -- END HACK
 
     SILE.call("style:apply:paragraph", { discardable = true, name = "usx-para-" .. options.style },
-      trimSubContent(hackedContent)
+      SU.ast.trimSubContent(hackedContent)
     )
   end)
 
@@ -384,7 +379,7 @@ function package:registerCommands()
       ref = ref
     }, function()
       SILE.call("style:apply:number", { name = "usx-noteno-innote", text = count })
-      processAsStructure(content)
+      SU.ast.processAsStructure(content)
     end)
   end)
 

--- a/packages/resilient/bible/usx/init.lua
+++ b/packages/resilient/bible/usx/init.lua
@@ -2,16 +2,28 @@
 -- USX (XML bible format) support for SILE.
 -- Following the resilient styling paradigm.
 --
--- 2023, Didier Willis
--- License: MIT
---
 -- EXPERIMENTAL POSSIBLY INCOMPLETE
 --
-local ast = require("silex.ast")
+-- License: GPL-3.0-or-later
+--
+-- Copyright (C) 2023-2025 Didier Willis
+-- This program is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with this program.  If not, see <https://www.gnu.org/licenses/>.
+--
 local createCommand,
       processAsStructure, trimSubContent
-        = ast.createCommand,
-          ast.processAsStructure, ast.trimSubContent
+        = SU.ast.createCommand,
+          SU.ast.processAsStructure, SU.ast.trimSubContent
 
 local base = require("packages.resilient.base")
 local package = pl.class(base)
@@ -26,7 +38,7 @@ function package:_init(_)
   end)
 end
 
-function package.outputCollatedNotes (_)
+function package:outputCollatedNotes ()
   SILE.typesetNaturally(SILE.getFrame("margins"), function ()
     SILE.settings:pushState()
     SILE.settings:toplevelState()

--- a/packages/resilient/bookmatters/init.lua
+++ b/packages/resilient/bookmatters/init.lua
@@ -7,11 +7,23 @@
 -- It is used (mostly) by the "master document".
 -- API is subject to change.
 --
--- 2023, Didier Willis
--- License: MIT
+-- License: GPL-3.0-or-later
 --
-local ast = require("silex.ast")
-local createCommand = ast.createCommand
+-- Copyright (C) 2023-2025 Didier Willis
+-- This program is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with this program.  If not, see <https://www.gnu.org/licenses/>.
+--
+local createCommand = SU.ast.createCommand
 local layoutParser = require("resilient.layoutparser")
 local loadkit = require("loadkit")
 local templateLoader = loadkit.make_loader("djt")

--- a/packages/resilient/bookmatters/init.lua
+++ b/packages/resilient/bookmatters/init.lua
@@ -23,13 +23,11 @@
 -- You should have received a copy of the GNU General Public License
 -- along with this program.  If not, see <https://www.gnu.org/licenses/>.
 --
-local createCommand = SU.ast.createCommand
 local layoutParser = require("resilient.layoutparser")
 local loadkit = require("loadkit")
 local templateLoader = loadkit.make_loader("djt")
 
 local base = require("packages.resilient.base")
-
 local package = pl.class(base)
 package._name = "resilient.bookmatters"
 
@@ -106,7 +104,7 @@ local function contrastColor(color)
   if not color.r then
     -- Not going to bother with other color schemes for now...
     SU.error([[Background color for back cover must be in RGB.
-Feel free to propose a PR do the maintainer if you want it otherwise]])
+Feel free to propose a PR to the maintainer if you want it otherwise]])
   end
   return weightedColorDistanceIn3D(color) < 130 and "white" or "black"
 end
@@ -210,7 +208,7 @@ function package:registerCommands ()
       SILE.call("skip", { height = offset })
       SILE.call("kern", { width = SILE.types.node.hfillglue() })
       SILE.call("framebox", { fillcolor = "white", padding = pad1, borderwidth = 0 }, {
-        createCommand("ean13", { code = metadata["meta:isbn"] }),
+        SU.ast.createCommand("ean13", { code = metadata["meta:isbn"] }),
       })
       SILE.call("kern", { width = offset })
     end

--- a/packages/resilient/defn/init.lua
+++ b/packages/resilient/defn/init.lua
@@ -19,10 +19,6 @@
 -- You should have received a copy of the GNU General Public License
 -- along with this program.  If not, see <https://www.gnu.org/licenses/>.
 --
-local extractFromTree = SU.ast.removeFromTree
-
-local base = require("packages.resilient.base")
-
 local trimLeft = function (str)
   return str:gsub("^%s*", "")
 end
@@ -35,6 +31,7 @@ local trim = function (str)
   return trimRight(trimLeft(str))
 end
 
+local base = require("packages.resilient.base")
 local package = pl.class(base)
 package._name = "resilient.defn"
 
@@ -84,8 +81,8 @@ function package:registerCommands ()
   end, "Definition block (internal)")
 
   self:registerCommand("defn", function (options, content)
-    local term = extractFromTree(content, "term")
-    local desc = extractFromTree(content, "desc")
+    local term = SU.ast.removeFromTree(content, "term")
+    local desc = SU.ast.removeFromTree(content, "desc")
     if not term then
       SU.error("Missing term in definition")
     end

--- a/packages/resilient/defn/init.lua
+++ b/packages/resilient/defn/init.lua
@@ -3,11 +3,23 @@
 -- Very minimal implementation for Djot/Markdown needs, with styling support.
 -- Following the resilient styling paradigm.
 --
--- 2023, 2025 Didier Willis
--- License: MIT
+-- License: GPL-3.0-or-later
 --
-local ast = require("silex.ast")
-local extractFromTree = ast.extractFromTree
+-- Copyright (C) 2023-2025 Didier Willis
+-- This program is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with this program.  If not, see <https://www.gnu.org/licenses/>.
+--
+local extractFromTree = SU.ast.removeFromTree
 
 local base = require("packages.resilient.base")
 
@@ -30,7 +42,7 @@ function package:_init (options)
   base._init(self, options)
 end
 
-function package.declareSettings (_)
+function package:declareSettings ()
 
   SILE.settings:declare({
     parameter = "defn.variant",

--- a/packages/resilient/epigraph/init.lua
+++ b/packages/resilient/epigraph/init.lua
@@ -19,12 +19,8 @@
 -- along with this program.  If not, see <https://www.gnu.org/licenses/>.
 --
 local base = require("packages.resilient.base")
-
 local package = pl.class(base)
 package._name = "resilient.epigraph"
-
-local createStructuredCommand, subContent, extractFromTree
-        = SU.ast.createStructuredCommand, SU.ast.subContent, SU.ast.removeFromTree
 
 function package:_init (options)
   base._init(self, options)
@@ -72,7 +68,7 @@ function package:registerCommands ()
       local framew = SILE.typesetter.frame:width()
       local epigraphw = width:absolute()
       local skip = framew - epigraphw - margin
-      local source = extractFromTree(content, "source")
+      local source = SU.ast.removeFromTree(content, "source")
       SILE.typesetter:leaveHmode()
 
       local sty = self:resolveStyle("epigraph")
@@ -91,8 +87,8 @@ function package:registerCommands ()
 
       SILE.settings:set("document.parindent", parindent)
       SILE.call("style:apply:paragraph", { name = "epigraph-text" }, {
-        subContent(content),
-        createStructuredCommand("epigraph:internal:source", {
+        SU.ast.subContent(content),
+        SU.ast.createStructuredCommand("epigraph:internal:source", {
           width = epigraphw,
           rule = options.rule
         }, source),

--- a/packages/resilient/epigraph/init.lua
+++ b/packages/resilient/epigraph/init.lua
@@ -2,26 +2,38 @@
 -- An epigraph package for SILE.
 -- Following the resilient styling paradigm.
 --
--- 2021-2023, Didier Willis
--- License: MIT
+-- License: GPL-3.0-or-later
+--
+-- Copyright (C) 2021-2025 Didier Willis
+-- This program is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with this program.  If not, see <https://www.gnu.org/licenses/>.
 --
 local base = require("packages.resilient.base")
 
 local package = pl.class(base)
 package._name = "resilient.epigraph"
 
-local ast = require("silex.ast")
 local createStructuredCommand, subContent, extractFromTree
-        = ast.createStructuredCommand, ast.subContent, ast.extractFromTree
+        = SU.ast.createStructuredCommand, SU.ast.subContent, SU.ast.removeFromTree
 
 function package:_init (options)
   base._init(self, options)
 
-  self.class:loadPackage("raiselower")
-  self.class:loadPackage("rules")
+  self:loadPackage("raiselower")
+  self:loadPackage("rules")
 end
 
-function package.declareSettings (_)
+function package:declareSettings ()
   SILE.settings:declare({
     parameter = "epigraph.width",
     type = "measurement",

--- a/packages/resilient/fancytoc/init.lua
+++ b/packages/resilient/fancytoc/init.lua
@@ -1,0 +1,189 @@
+--
+-- Fancy table of contents.
+-- Only processes 2 levels, e.g. parts (level 0) and chapters (level 1)
+-- and display them as some braced content.
+--
+-- License: GPL-3.0-or-later
+--
+-- Copyright (C) 2022-2025 Didier Willis
+-- This program is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with this program.  If not, see <https://www.gnu.org/licenses/>.
+--
+local base = require("packages.resilient.base")
+local package = pl.class(base)
+package._name = "resilient.fancytoc"
+
+function package:_init (options)
+  base._init(self, options)
+
+  self:loadPackage("framebox")
+  self:loadPackage("parbox")
+  self:loadPackage("leaders")
+end
+
+local function linkWrapper (dest, func)
+  if dest and SILE.Commands["pdf:link"] then
+    SILE.call("pdf:link", { dest = dest }, func)
+  else
+    func()
+  end
+end
+
+local function getMinLevel (toc)
+  local min = function (a, b) return a.level <= b.level and a or b end
+  local smallest = pl.tablex.reduce(min, toc)
+  return smallest.level
+end
+
+local function cancelFragile (func)
+    -- Temporarilly kill footnotes and labels (fragile)
+    local oldFt = SILE.Commands["footnote"]
+    SILE.Commands["footnote"] = function () end
+    local oldLbl = SILE.Commands["label"]
+    SILE.Commands["label"] = function () end
+
+    func()
+
+    SILE.Commands["footnote"] = oldFt
+    SILE.Commands["label"] = oldLbl
+end
+
+function package:findToc (packages)
+  if self._toc then return self._toc end -- memoized
+
+  for packname, pack in pairs(packages) do
+    if pack.readToc then
+      SU.debug("fancytoc", "Found loadToc method in "..packname)
+      self._toc = self.class.packages[packname]:readToc()
+      return self._toc
+    end
+  end
+  SU.error("Package fancytoc needs a table of contents, but it does not seem a package exposing one is loaded.")
+end
+
+function package:registerCommands ()
+  self:registerCommand("fancytableofcontents", function (options, _)
+    local linking = SU.boolean(options.linking, true)
+
+    local toc = self:findToc(self.class.packages)
+    if toc == false then
+      SILE.call("tableofcontents:notocmessage")
+      return
+    end
+
+    local start = SU.cast("integer", options.start or getMinLevel(toc))
+
+    local root = {}
+    for i = 1, #toc do
+      local item = toc[i]
+      local level = item.level
+      if level == start then
+        root[#root + 1] = { item = item, children = {} }
+      elseif level == start + 1 then
+        local current = root[#root]
+        if current then
+          current.children[#current.children +1] = item
+        end
+      end
+    end
+
+    SILE.settings:temporarily(function()
+      SILE.settings:set("current.parindent", SILE.types.node.glue())
+      SILE.settings:set("document.parindent", SILE.types.node.glue())
+
+      cancelFragile(function ()
+        -- Quick and dirty for now...
+        -- TODO: We have the link only on pages, but would want it eventually on titles
+        -- too, but this requires multi-line link support.
+        for _, v in ipairs(root) do
+          SILE.call("medskip")
+          if #v.children > 0 then
+            SILE.call("parbox", { valign = "middle", width = "20%lw" }, function ()
+              SILE.settings:set("document.parindent", SILE.types.node.glue())
+              SILE.call("raggedright", {}, function ()
+                SILE.call("fancytoc:level1", { style = "fancytoc-level1" }, v.item.label)
+              end)
+            end)
+            SILE.call("hfill")
+            SILE.call("bracebox", { bracewidth = "0.8em"}, function()
+              SILE.call("parbox", { valign = "middle", width = "75%lw" }, function ()
+                SILE.settings:set("document.parindent", SILE.types.node.glue())
+                for _, c in ipairs(v.children) do
+                  SILE.call("parbox", { valign = "top", strut = "rule", minimize = true, width = "80%lw" }, function ()
+                    SILE.settings:set("document.lskip", SILE.types.length("1em"))
+                    SILE.settings:set("document.rskip", SILE.types.node.hfillglue())
+                    SILE.settings:set("document.parindent", SILE.types.length("-0.5em"))
+                    SILE.call("fancytoc:level2", { style = "fancytoc-level2" }, c.label)
+                  end)
+                  SILE.call("dotfill")
+                  linkWrapper(linking and c.link, function ()
+                    SILE.call("fancytoc:pageno", { style = "fancytoc-pageno" }, { c.pageno })
+                  end)
+                  SILE.call("par")
+                end
+              end)
+            end)
+          else
+            SILE.call("parbox", { valign = "top", width = "20%lw" }, function ()
+              SILE.settings:set("document.parindent", SILE.types.node.glue())
+              SILE.call("raggedright", {}, function ()
+                SILE.call("fancytoc:level1", { style = "fancytoc-level1" }, v.item.label)
+              end)
+            end)
+            SILE.call("dotfill")
+            linkWrapper(linking and v.item.link, function ()
+                SILE.call("fancytoc:pageno", { style = "fancytoc-pageno" }, { v.item.pageno })
+            end)
+          end
+          SILE.call("par")
+        end
+      end)
+    end)
+  end, "Output a fancy table of contents.")
+
+  self:registerCommand("fancytoc:level1", function (options, content)
+    SILE.call("style:apply", { name = options.style }, content)
+  end)
+
+  self:registerCommand("fancytoc:level2", function (options, content)
+    SILE.call("style:apply", { name = options.style }, content)
+  end)
+
+  self:registerCommand("fancytoc:pageno", function (options, content)
+    SILE.call("style:apply", { name = options.style }, content)
+  end)
+end
+
+function package:registerStyles ()
+  self:registerStyle("fancytoc-base", {}, {})
+  self:registerStyle("fancytoc-pageno", { inherit = "fancytoc-base" }, { font = { features = "+onum" } })
+  self:registerStyle("fancytoc-level1", { inherit = "fancytoc-base" }, { font = { features = "+smcp" } })
+  self:registerStyle("fancytoc-level2", { inherit = "fancytoc-base" }, {})
+end
+
+package.documentation = [[\begin{document}
+The \autodoc:package{resilient.fancytoc} package defines a \autodoc:command{\fancytableofcontents} command which processes only two levels of a table of contents (by default, starting at the smallest available level).
+They are displayed in a sort of fancy table of contents, side by side, with a curly brace introducing the second level items for a given first level entry.
+
+The default starting level may be overriden with \autodoc:parameter{start=<level>}, so you may actually use it for two other consecutive levels of your choice.
+
+If the \autodoc:package{pdf} package is loaded before using sectioning commands, entries in the table of contents will be active links to the relevant sections.
+To disable the latter behavior, pass \autodoc:parameter{linking=false} to the \autodoc:command{\fancytableofcontents} command.
+
+The elements are styled with \code{fancytoc-level1}, \code{fancytoc-level2} and \code{fancytoc-pageno} (all deriving, by default, from a common \code{fancytoc-base} style).
+
+The package does \em{not} create a table of contents.
+It rather assumes some adequate package (such as \autodoc:package{resilient.tableofcontents}) was previously loaded for that purpose, exposing a \code{readToc} method to retrieve the table of contents.
+\end{document}]]
+
+return package

--- a/packages/resilient/footnotes/init.lua
+++ b/packages/resilient/footnotes/init.lua
@@ -2,8 +2,21 @@
 -- Re-implementation of the footnotes package for SILE.
 -- Following the resilient styling paradigm.
 --
--- 2021-2023, Didier Willis
--- License: MIT
+-- License: GPL-3.0-or-later
+--
+-- Copyright (C) 2021-2025 Didier Willis
+-- This program is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with this program.  If not, see <https://www.gnu.org/licenses/>.
 --
 local base = require("packages.resilient.base")
 
@@ -15,10 +28,10 @@ local utils = require("resilient.utils")
 function package:_init (options)
   base._init(self, options)
 
-  self.class:loadPackage("rebox") -- used by footnote:rule
-  self.class:loadPackage("rules") -- used by footnote:rule
-  self.class:loadPackage("counters") -- used for counter formatting
-  self.class:loadPackage("insertions")
+  self:loadPackage("rebox") -- used by footnote:rule
+  self:loadPackage("rules") -- used by footnote:rule
+  self:loadPackage("counters") -- used for counter formatting
+  self:loadPackage("insertions")
 
   -- N.B. Kept starting at 1, with post-incrementation done in the footnote
   -- command, as this was the original footnote package did, although it's

--- a/packages/resilient/footnotes/init.lua
+++ b/packages/resilient/footnotes/init.lua
@@ -19,7 +19,6 @@
 -- along with this program.  If not, see <https://www.gnu.org/licenses/>.
 --
 local base = require("packages.resilient.base")
-
 local package = pl.class(base)
 package._name = "resilient.footnotes"
 

--- a/packages/resilient/headers/init.lua
+++ b/packages/resilient/headers/init.lua
@@ -19,7 +19,6 @@
 -- along with this program.  If not, see <https://www.gnu.org/licenses/>.
 --
 local base = require("packages.base")
-
 local package = pl.class(base)
 package._name = "resilient.headers"
 

--- a/packages/resilient/headers/init.lua
+++ b/packages/resilient/headers/init.lua
@@ -2,8 +2,21 @@
 -- headers package for book-like classes for SILE.
 -- Core logic for activating/deactivating headers- and handling their output.
 --
--- 2021-2022, Didier Willis
--- License: MIT
+-- License: GPL-3.0-or-later
+--
+-- Copyright (C) 2021-2025 Didier Willis
+-- This program is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with this program.  If not, see <https://www.gnu.org/licenses/>.
 --
 local base = require("packages.base")
 
@@ -44,7 +57,7 @@ function package:registerCommands ()
   end, "Command to set a header rule.")
 end
 
-function package.outputHeader (_, headerContent, frame)
+function package:outputHeader (headerContent, frame)
   if not frame then frame = "header" end
   if SILE.scratch.headers.off then
     if SILE.scratch.headers.off == 2 then

--- a/packages/resilient/liners/init.lua
+++ b/packages/resilient/liners/init.lua
@@ -24,7 +24,6 @@
 -- along with this program.  If not, see <https://www.gnu.org/licenses/>.
 --
 local base = require("packages.base")
-
 local package = pl.class(base)
 package._name = "resilient.liners"
 

--- a/packages/resilient/liners/init.lua
+++ b/packages/resilient/liners/init.lua
@@ -4,11 +4,24 @@
 -- Rough drawing is supported, using the low level API from the "framebox" package,
 -- which is a dependency of the resilient collection.
 --
--- 2024, Didier Willis
--- License: MIT
---
 -- FIXME TODO: Pretty repetitive code, could be refactored...
 -- But early abstraction is often a bad idea, so let's wait for more use cases.
+--
+-- License: GPL-3.0-or-later
+--
+-- Copyright (C) 2024-2025 Didier Willis
+-- This program is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with this program.  If not, see <https://www.gnu.org/licenses/>.
 --
 local base = require("packages.base")
 
@@ -105,7 +118,6 @@ function package:registerCommands ()
     )
   end, "Underlines some content")
 
-
   self:registerCommand("resilient:liner:strikethrough", function (options, content)
     local yStrikeoutPosition, yStrikeoutSize = getStrikethroughParameters()
     local isRough = SU.boolean(options.rough, false)
@@ -177,7 +189,7 @@ function package:registerCommands ()
         local Y = typesetter.frame.state.cursorY
 
         local painter = PathRenderer(isRough and RoughPainter())
-        local w = (outputWidth):tonumber()
+        local w = outputWidth:tonumber()
         local path = painter:rectangle(0, 0, w, H + D, paintOptions)
 
         SILE.outputter:drawSVG(path,
@@ -215,7 +227,7 @@ function package:registerCommands ()
         local Y = typesetter.frame.state.cursorY
 
         local painter = PathRenderer(isRough and RoughPainter())
-        local w = (outputWidth):tonumber()
+        local w = outputWidth:tonumber()
         local path = painter:rectangle(0, 0, w, H + D, paintOptions)
 
         SILE.outputter:drawSVG(path,

--- a/packages/resilient/lists/init.lua
+++ b/packages/resilient/lists/init.lua
@@ -6,8 +6,21 @@
 -- with (expectedly) the same user API but with additiona features and styling
 -- methods.
 --
--- 2021-2023, Didier Willis
--- License: MIT
+-- License: GPL-3.0-or-later
+--
+-- Copyright (C) 2021-2025 Didier Willis
+-- This program is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with this program.  If not, see <https://www.gnu.org/licenses/>.
 --
 -- NOTE: Though not described explicitly in the documentation, the package supports
 -- two nesting techniques:
@@ -266,10 +279,10 @@ end
 
 function package:_init (options)
   base._init(self, options)
-  self.class:loadPackage("counters")
+  self:loadPackage("counters")
 end
 
-function package.declareSettings (_)
+function package:declareSettings ()
 
   SILE.settings:declare({
     parameter = "lists.current.enumerate.depth",

--- a/packages/resilient/lists/init.lua
+++ b/packages/resilient/lists/init.lua
@@ -52,7 +52,6 @@
 -- second technique.
 --
 local base = require("packages.resilient.base")
-
 local package = pl.class(base)
 package._name = "resilient.lists"
 

--- a/packages/resilient/plain/init.lua
+++ b/packages/resilient/plain/init.lua
@@ -1,0 +1,320 @@
+--
+-- Some minimal subset of common "Plain TeX"-like commands.
+-- Extracted from SILE's plain class and moved into a package.
+--
+local base = require("packages.base")
+local package = pl.class(base)
+package._name = "resilient.plain"
+
+local skips = {
+  small = "3pt plus 1pt minus 1pt",
+  med = "6pt plus 2pt minus 2pt",
+  big = "12pt plus 4pt minus 4pt",
+}
+
+function package:_init (options)
+  base._init(self, options)
+end
+
+function package:declareSettings ()
+  for k, v in pairs(skips) do
+    SILE.settings:declare({
+      parameter = "plain." .. k .. "skipamount",
+      type = "vglue",
+      default = SILE.types.node.vglue(v),
+      help = "The amount of a \\" .. k .. "skip",
+    })
+  end
+end
+
+function package:registerCommands ()
+  self:registerCommand("noindent", function (_, content)
+    if #SILE.typesetter.state.nodes ~= 0 then
+      SU.warn([[
+        \noindent was called after paragraph content has already been processed
+
+        This will not result in avoiding the current paragraph being indented. This
+        function must be called before any content belonging to the paragraph is
+        processed. If the intent was to suppress indentation of a following paragraph,
+        first explicitly close the current paragraph. From an input document this is
+        typically done with an empty line between paragraphs, but calling the \par
+        command explicitly or from Lua code running SILE.call("par") will end
+        the current paragraph.
+      ]])
+    end
+    SILE.settings:set("current.parindent", SILE.types.node.glue())
+    SILE.process(content)
+  end, "Do not add an indent to the start of this paragraph")
+
+  self:registerCommand("neverindent", function (_, content)
+    SILE.settings:set("current.parindent", SILE.types.node.glue())
+    SILE.settings:set("document.parindent", SILE.types.node.glue())
+    SILE.process(content)
+  end, "Turn off all indentation")
+
+  self:registerCommand("indent", function (_, content)
+    SILE.settings:set("current.parindent", SILE.settings:get("document.parindent"))
+    SILE.process(content)
+  end, "Do add an indent to the start of this paragraph, even if previously told otherwise")
+
+  for k, _ in pairs(skips) do
+    self:registerCommand(k .. "skip", function (_, _)
+      SILE.typesetter:leaveHmode()
+      SILE.typesetter:pushExplicitVglue(SILE.settings:get("plain." .. k .. "skipamount"))
+    end, "Skip vertically by a " .. k .. " amount")
+  end
+
+  self:registerCommand("hfill", function (_, _)
+    SILE.typesetter:pushExplicitGlue(SILE.types.node.hfillglue())
+  end, "Add a huge horizontal glue")
+
+  self:registerCommand("vfill", function (_, _)
+    SILE.typesetter:leaveHmode()
+    SILE.typesetter:pushExplicitVglue(SILE.types.node.vfillglue())
+  end, "Add huge vertical glue")
+
+  self:registerCommand("hss", function (_, _)
+    SILE.typesetter:pushGlue(SILE.types.node.hssglue())
+    table.insert(SILE.typesetter.state.nodes, SILE.types.node.zerohbox())
+  end, "Add glue which stretches and shrinks horizontally (good for centering)")
+
+  self:registerCommand("vss", function (_, _)
+    SILE.typesetter:pushExplicitVglue(SILE.types.node.vssglue())
+  end, "Add glue which stretches and shrinks vertically")
+
+  local _thinspacewidth = SILE.types.measurement(0.16667, "em")
+
+  self:registerCommand("thinspace", function (_, _)
+    SILE.call("glue", { width = _thinspacewidth })
+  end)
+
+  self:registerCommand("negthinspace", function (_, _)
+    SILE.call("glue", { width = -_thinspacewidth })
+  end)
+
+  self:registerCommand("enspace", function (_, _)
+    SILE.call("glue", { width = SILE.types.measurement(1, "en") })
+  end)
+
+  self:registerCommand("enskip", function (_, _)
+    SILE.call("enspace")
+  end)
+
+  local _quadwidth = SILE.types.measurement(1, "em")
+
+  self:registerCommand("quad", function (_, _)
+    SILE.call("glue", { width = _quadwidth })
+  end)
+
+  self:registerCommand("qquad", function (_, _)
+    SILE.call("glue", { width = _quadwidth * 2 })
+  end)
+
+  self:registerCommand("slash", function (_, _)
+    SILE.typesetter:typeset("/")
+    SILE.call("penalty", { penalty = 50 })
+  end)
+
+  self:registerCommand("break", function (_, _)
+    SILE.call("penalty", { penalty = -10000 })
+  end, "Requests a frame break (if in vertical mode) or a line break (if in horizontal mode)")
+
+  self:registerCommand("cr", function (_, _)
+    SILE.call("hfill")
+    SILE.call("break")
+  end, "Fills a line with a stretchable glue and then requests a line break")
+
+  -- Despite their name, in older versions, \framebreak and \pagebreak worked badly in horizontal
+  -- mode. The former was a linebreak, and the latter did nothing. That was surely not intended.
+  -- There are many ways, though to assume what's wrong or what the user's intent ought to be.
+  -- We now warn, and terminate the paragraph, but to all extents this might be a wrong approach to
+  -- reconsider at some point.
+
+  self:registerCommand("framebreak", function (_, _)
+    if not SILE.typesetter:vmode() then
+      SU.warn([[
+        \\framebreak was not intended to work in horizontal mode
+
+        Behavior may change in future versions.
+      ]])
+    end
+    SILE.call("penalty", { penalty = -10000, vertical = true })
+  end, "Requests a frame break (switching to vertical mode if needed)")
+
+  self:registerCommand("pagebreak", function (_, _)
+    if not SILE.typesetter:vmode() then
+      SU.warn([[
+        \\pagebreak was not intended to work in horizontal mode
+
+        Behavior may change in future versions.
+      ]])
+    end
+    SILE.call("penalty", { penalty = -20000, vertical = true })
+  end, "Requests a non-negotiable page break (switching to vertical mode if needed)")
+
+  self:registerCommand("nobreak", function (_, _)
+    SILE.call("penalty", { penalty = 10000 })
+  end, "Inhibits a frame break (if in vertical mode) or a line break (if in horizontal mode)")
+
+  self:registerCommand("novbreak", function (_, _)
+    SILE.call("penalty", { penalty = 10000, vertical = true })
+  end, "Inhibits a frame break (switching to vertical mode if needed)")
+
+  self:registerCommand("allowbreak", function (_, _)
+    SILE.call("penalty", { penalty = 0 })
+  end, "Allows a page break (if in vertical mode) or a line break (if in horizontal mode) at a point would not be considered as suitable for breaking")
+
+  -- NOTE: TeX's "\goodbreak" does a \par first, so always switches to vertical mode.
+  -- SILE differs here, allowing it both within a paragraph (line breaking) and between
+  -- paragraphs (page breaking).
+  self:registerCommand("goodbreak", function (_, _)
+    SILE.call("penalty", { penalty = -500 })
+  end, "Indicates a good potential point to break a frame (if in vertical mode) or a line (if in horizontal mode")
+
+  self:registerCommand("eject", function (_, _)
+    SILE.call("vfill")
+    SILE.call("break")
+  end, "Fills the page with stretchable vglue and then request a page break")
+
+  self:registerCommand("supereject", function (_, _)
+    SILE.call("vfill")
+    SILE.call("penalty", { penalty = -20000 })
+  end, "Fills the page with stretchable vglue and then requests a non-negotiable page break")
+
+  self:registerCommand("em", function (_, content)
+    local style = SILE.settings:get("font.style")
+    local toggle = (style and style:lower() == "italic") and "Regular" or "Italic"
+    SILE.call("font", { style = toggle }, content)
+  end, "Emphasizes its contents by switching the font style to italic (or back to regular if already italic)")
+
+  self:registerCommand("strong", function (_, content)
+    SILE.call("font", { weight = 700 }, content)
+  end, "Sets the font weight to bold (700)")
+
+  self:registerCommand("nohyphenation", function (_, content)
+    SILE.call("font", { language = "und" }, content)
+  end)
+
+  self:registerCommand("center", function (_, content)
+    if #SILE.typesetter.state.nodes ~= 0 then
+      SU.warn([[
+        \\center environment started after other nodes in a paragraph
+
+        Content may not be centered as expected.
+      ]])
+    end
+    SILE.settings:temporarily(function ()
+      local lskip = SILE.settings:get("document.lskip") or SILE.types.node.glue()
+      local rskip = SILE.settings:get("document.rskip") or SILE.types.node.glue()
+      SILE.settings:set("document.parindent", SILE.types.node.glue())
+      SILE.settings:set("current.parindent", SILE.types.node.glue())
+      SILE.settings:set("document.lskip", SILE.types.node.hfillglue(lskip.width.length))
+      SILE.settings:set("document.rskip", SILE.types.node.hfillglue(rskip.width.length))
+      SILE.settings:set("typesetter.parfillskip", SILE.types.node.glue())
+      SILE.settings:set("document.spaceskip", SILE.types.length("1spc", 0, 0))
+      SILE.process(content)
+      SILE.call("par")
+    end)
+  end, "Typeset its contents in a centered block (keeping margins).")
+
+  self:registerCommand("raggedright", function (_, content)
+    SILE.settings:temporarily(function ()
+      local lskip = SILE.settings:get("document.lskip") or SILE.types.node.glue()
+      local rskip = SILE.settings:get("document.rskip") or SILE.types.node.glue()
+      SILE.settings:set("document.lskip", SILE.types.node.glue(lskip.width.length))
+      SILE.settings:set("document.rskip", SILE.types.node.hfillglue(rskip.width.length))
+      SILE.settings:set("typesetter.parfillskip", SILE.types.node.glue())
+      SILE.settings:set("document.spaceskip", SILE.types.length("1spc", 0, 0))
+      SILE.process(content)
+      SILE.call("par")
+    end)
+  end, "Typeset its contents in a left aligned block (keeping margins).")
+
+  self:registerCommand("raggedleft", function (_, content)
+    SILE.settings:temporarily(function ()
+      local lskip = SILE.settings:get("document.lskip") or SILE.types.node.glue()
+      local rskip = SILE.settings:get("document.rskip") or SILE.types.node.glue()
+      SILE.settings:set("document.lskip", SILE.types.node.hfillglue(lskip.width.length))
+      SILE.settings:set("document.rskip", SILE.types.node.glue(rskip.width.length))
+      SILE.settings:set("typesetter.parfillskip", SILE.types.node.glue())
+      SILE.settings:set("document.spaceskip", SILE.types.length("1spc", 0, 0))
+      SILE.process(content)
+      SILE.call("par")
+    end)
+  end, "Typeset its contents in a right aligned block (keeping margins).")
+
+  self:registerCommand("justified", function (_, content)
+    SILE.settings:temporarily(function ()
+      local lskip = SILE.settings:get("document.lskip") or SILE.types.node.glue()
+      local rskip = SILE.settings:get("document.rskip") or SILE.types.node.glue()
+      -- Keep the fixed part of the margins for nesting but remove the stretchability.
+      SILE.settings:set("document.lskip", SILE.types.node.glue(lskip.width.length))
+      SILE.settings:set("document.rskip", SILE.types.node.glue(rskip.width.length))
+      -- Reset parfillskip to its default value, in case the surrounding context
+      -- is ragged and cancelled it.
+      SILE.settings:set("typesetter.parfillskip", nil, false, true)
+      SILE.settings:set("document.spaceskip", nil)
+      SILE.process(content)
+      SILE.call("par")
+    end)
+  end, "Typeset its contents in a justified block (keeping margins).")
+
+  self:registerCommand("ragged", function (options, content)
+    -- Fairly dubious command for compatibility
+    local l = SU.boolean(options.left, false)
+    local r = SU.boolean(options.right, false)
+    if l and r then
+      SILE.call("center", {}, content)
+    elseif r then
+      SILE.call("raggedleft", {}, content)
+    elseif l then
+      SILE.call("raggedright", {}, content)
+    else
+      SILE.call("justified", {}, content)
+    end
+  end)
+
+  self:registerCommand("sloppy", function (_, _)
+    SILE.settings:set("linebreak.tolerance", 9999)
+  end)
+
+  self:registerCommand("awful", function (_, _)
+    SILE.settings:set("linebreak.tolerance", 10000)
+  end)
+
+  self:registerCommand("hbox", function (_, content)
+    local hbox, hlist = SILE.typesetter:makeHbox(content)
+    SILE.typesetter:pushHbox(hbox)
+    if #hlist > 0 then
+      SU.warn([[
+        \\hbox has migrating content
+
+        Ignored for now, but likely to break in future versions.
+      ]])
+      -- Ugly shim:
+      -- One day we ought to do SILE.typesetter:pushHlist(hlist) here, so as to push
+      -- back the migrating contents from within the hbox'ed content.
+      -- However, old Lua code assumed the hbox to be returned, and sometimes removed it
+      -- from the typesetter queue (for measuring, etc.), assuming it was the last
+      -- element in the queue...
+    end
+    return hbox
+  end, "Compiles all the enclosed horizontal-mode material into a single hbox")
+
+  self:registerCommand("vbox", function (options, content)
+    local vbox
+    SILE.settings:temporarily(function ()
+      if options.width then
+        SILE.settings:set("typesetter.breakwidth", SILE.types.length(options.width))
+      end
+      SILE.typesetter:pushState()
+      SILE.process(content)
+      SILE.typesetter:leaveHmode(1)
+      vbox = SILE.pagebuilder:collateVboxes(SILE.typesetter.state.outputQueue)
+      SILE.typesetter:popState()
+    end)
+    return vbox
+  end, "Compiles all the enclosed material into a single vbox")
+end
+
+return package

--- a/packages/resilient/poetry/init.lua
+++ b/packages/resilient/poetry/init.lua
@@ -2,11 +2,23 @@
 -- A poetry package for SILE.
 -- Following the resilient styling paradigm.
 --
--- 2021, 2023 Didier Willis
--- License: MIT
+-- License: GPL-3.0-or-later
 --
-local ast = require("silex.ast")
-local createStructuredCommand = ast.createStructuredCommand
+-- Copyright (C) 2021-2025 Didier Willis
+-- This program is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with this program.  If not, see <https://www.gnu.org/licenses/>.
+--
+local createStructuredCommand = SU.ast.createStructuredCommand
 local LOG10 = math.log(10)
 
 local base = require("packages.resilient.base")
@@ -16,9 +28,9 @@ package._name = "resilient.poetry"
 
 function package:_init (options)
   base._init(self, options)
-  self.class:loadPackage("rebox")
-  self.class:loadPackage("raiselower")
-  self.class:loadPackage("inputfilter")
+  self:loadPackage("rebox")
+  self:loadPackage("raiselower")
+  self:loadPackage("inputfilter")
 end
 
 function package:registerCommands ()
@@ -291,7 +303,7 @@ function package:registerCommands ()
 
 end
 
-function package.declareSettings (_)
+function package:declareSettings ()
   SILE.settings:declare({
     parameter = "resilient.poetry.offset",
     type = "length",

--- a/packages/resilient/poetry/init.lua
+++ b/packages/resilient/poetry/init.lua
@@ -18,11 +18,9 @@
 -- You should have received a copy of the GNU General Public License
 -- along with this program.  If not, see <https://www.gnu.org/licenses/>.
 --
-local createStructuredCommand = SU.ast.createStructuredCommand
 local LOG10 = math.log(10)
 
 local base = require("packages.resilient.base")
-
 local package = pl.class(base)
 package._name = "resilient.poetry"
 
@@ -255,7 +253,7 @@ function package:registerCommands ()
     local prosody = SU.boolean(options.prosody, false)
     local style = prosody and "prosody" or "poetry"
     SILE.call("style:apply:paragraph", { name = style }, {
-      createStructuredCommand("resilient.poetry:poetry", options, content)
+      SU.ast.createStructuredCommand("resilient.poetry:poetry", options, content)
     })
   end, "A styled poetry environment")
 

--- a/packages/resilient/sectioning/init.lua
+++ b/packages/resilient/sectioning/init.lua
@@ -3,21 +3,33 @@
 -- Following the resilient styling paradigm.
 -- It is nn extension of the "styles" package and the sectioning paradigm.
 --
--- 2021-2023, Didier Willis
--- License: MIT
+-- License: GPL-3.0-or-later
+--
+-- Copyright (C) 2021-2025 Didier Willis
+-- This program is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with this program.  If not, see <https://www.gnu.org/licenses/>.
 --
 local base = require("packages.resilient.base")
 
-local ast = require("silex.ast")
 local createCommand, subContent
-        = ast.createCommand, ast.subContent
+        = SU.ast.createCommand, SU.ast.subContent
 
 local package = pl.class(base)
 package._name = "resilient.sectioning"
 
 function package:_init (options)
   base._init(self, options)
-  self.class:loadPackage("counters")
+  self:loadPackage("counters")
 end
 
 local function hasContentInCurrentPage()

--- a/packages/resilient/sectioning/init.lua
+++ b/packages/resilient/sectioning/init.lua
@@ -20,10 +20,6 @@
 -- along with this program.  If not, see <https://www.gnu.org/licenses/>.
 --
 local base = require("packages.resilient.base")
-
-local createCommand, subContent
-        = SU.ast.createCommand, SU.ast.subContent
-
 local package = pl.class(base)
 package._name = "resilient.sectioning"
 
@@ -161,11 +157,11 @@ function package:registerCommands ()
           and nameIfNotNull(sty.sectioning.numberstyle.header)
       if numbering and numsty then
         titleHookContent = {
-          createCommand("style:apply:number", { name = numsty, text = number }),
-          subContent(content)
+          SU.ast.createCommand("style:apply:number", { name = numsty, text = number }),
+          SU.ast.subContent(content)
         }
       else
-        titleHookContent = subContent(content)
+        titleHookContent = SU.ast.subContent(content)
       end
       -- HACK HOOK - BAD DESIGN WORKAROUND
       -- https://github.com/Omikhleia/resilient.sile/issues/43
@@ -202,24 +198,24 @@ function package:registerCommands ()
     if toclevel and toc then
       self:registerCommand("sectioning:hack:toc", function ()
         SILE.call("tocentry", { level = toclevel, number = number, bookmark = bookmark },
-          subContent(content))
+          SU.ast.subContent(content))
       end)
-      titleContent[#titleContent + 1] = createCommand("sectioning:hack:toc")
+      titleContent[#titleContent + 1] = SU.ast.createCommand("sectioning:hack:toc")
     end
 
     -- Show section number (if numbering is true AND a main style is defined)
     if numbering then
       if numStyName then
         titleContent[#titleContent + 1] =
-          createCommand("style:apply:number", { name = numStyName, text = number })
+          SU.ast.createCommand("style:apply:number", { name = numStyName, text = number })
         if SU.boolean(numSty.numbering and numSty.numbering.standalone, false) then
           titleContent[#titleContent + 1] =
-            createCommand("hardbreak")
+            SU.ast.createCommand("hardbreak")
         end
       end
     end
     -- Section (title) content
-    titleContent[#titleContent + 1] = subContent(content)
+    titleContent[#titleContent + 1] = SU.ast.subContent(content)
 
     -- Cross-reference label
     -- If the \label command is defined, assume a cross-reference package
@@ -227,7 +223,7 @@ function package:registerCommands ()
     -- than having to put it in the section title content, or just after the section
     -- (with the risk of impacting indent/noindent and novbreak decisions here)
     if marker and SILE.Commands["label"] then
-      titleContent[#titleContent + 1] = createCommand("label", { marker = marker })
+      titleContent[#titleContent + 1] = SU.ast.createCommand("label", { marker = marker })
     end
     -- Running headers
     -- See HACK HOOK above
@@ -235,7 +231,7 @@ function package:registerCommands ()
       -- As for labels, underlying info nodes will interact with indents/breaks, so we
       -- also try to get them in the title. But we do not want the main style to
       -- be applied to them, so we hid them in a short-term command...
-      titleContent[#titleContent + 1] = createCommand("sectioning:hack:hook")
+      titleContent[#titleContent + 1] = SU.ast.createCommand("sectioning:hack:hook")
     end
     SILE.call("style:apply:paragraph", { name = name }, titleContent)
   end, "Apply sectioning")

--- a/packages/resilient/styles/init.lua
+++ b/packages/resilient/styles/init.lua
@@ -18,13 +18,10 @@
 -- along with this program.  If not, see <https://www.gnu.org/licenses/>.
 --
 local base = require("packages.base")
-
 local package = pl.class(base)
 package._name = "resilient.styles"
 
 local utils = require("resilient.utils")
-local createCommand, subContent
-        = SU.ast.createCommand, SU.ast.subContent
 
 function package:_init (options)
   base._init(self, options)
@@ -332,7 +329,7 @@ function package:registerCommands ()
         if not positionCommand then
           SU.error("Invalid style position '"..positionValue.."'")
         end
-        content = createCommand(positionCommand, {}, content)
+        content = SU.ast.createCommand(positionCommand, {}, content)
       end
       local caseValue = propertyValueIfNotNull(style.properties.case)
       if caseValue and caseValue ~= "normal" then
@@ -340,7 +337,7 @@ function package:registerCommands ()
         if not caseCommand then
           SU.error("Invalid style case '" .. caseValue .. "'")
         end
-        content = createCommand(caseCommand, {}, content)
+        content = SU.ast.createCommand(caseCommand, {}, content)
       end
     end
     if style.decoration then
@@ -350,15 +347,15 @@ function package:registerCommands ()
         if not lineCommand then
           SU.error("Invalid style decoration line '" .. lineValue .. "'")
         end
-        content = createCommand(lineCommand, shallowNonNullOptions(style.decoration), content)
+        content = SU.ast.createCommand(lineCommand, shallowNonNullOptions(style.decoration), content)
       end
     end
     local colorValue = propertyValueIfNotNull(style.color)
     if colorValue then
-      content = createCommand("color", { color = colorValue }, content)
+      content = SU.ast.createCommand("color", { color = colorValue }, content)
     end
     if style.font and SU.boolean(options.font, true) then
-      content = createCommand("style:font", style.font, content)
+      content = SU.ast.createCommand("style:font", style.font, content)
     end
     return content
   end
@@ -371,7 +368,7 @@ function package:registerCommands ()
     if type(content) == "table" then
       if content.command or content.id then
         -- We want to skip the calling content key values (id, command, etc.)
-        return subContent(content)
+        return SU.ast.subContent(content)
       end
       return content
     end
@@ -388,7 +385,7 @@ function package:registerCommands ()
 
   local characterStyleFontOnly = function (style, content)
     if style.font then
-      content = createCommand("style:font", style.font, content)
+      content = SU.ast.createCommand("style:font", style.font, content)
     end
     return content
   end
@@ -406,9 +403,9 @@ function package:registerCommands ()
         -- correct even on the last paragraph. But the color introduces hboxes so
         -- must be applied last, no to cause havoc with the noindent/indent and
         -- centering etc. environments
-        local recontent = createCommand(alignCommand, {}, {
+        local recontent = SU.ast.createCommand(alignCommand, {}, {
           characterStyleNoFont(style, content),
-          not breakafter and createCommand("novbreak") or nil
+          not breakafter and SU.ast.createCommand("novbreak") or nil
         })
         if style.font then
           recontent = characterStyleFontOnly(style, recontent)

--- a/packages/resilient/styles/init.lua
+++ b/packages/resilient/styles/init.lua
@@ -1,7 +1,21 @@
 --
 -- A style package for SILE
--- License: MIT
--- 2021-2025, Didier Willis
+--
+-- License: GPL-3.0-or-later
+--
+-- Copyright (C) 2021-2025 Didier Willis
+-- This program is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with this program.  If not, see <https://www.gnu.org/licenses/>.
 --
 local base = require("packages.base")
 
@@ -9,16 +23,15 @@ local package = pl.class(base)
 package._name = "resilient.styles"
 
 local utils = require("resilient.utils")
-local ast = require("silex.ast")
 local createCommand, subContent
-        = ast.createCommand, ast.subContent
+        = SU.ast.createCommand, SU.ast.subContent
 
 function package:_init (options)
   base._init(self, options)
 
-  self.class:loadPackage("textsubsuper")
-  self.class:loadPackage("textcase")
-  self.class:loadPackage("resilient.liners")
+  self:loadPackage("textsubsuper")
+  self:loadPackage("textcase")
+  self:loadPackage("resilient.liners")
 
   self.class:registerHook("finish", self.writeStyles)
 
@@ -199,7 +212,7 @@ SILE.scratch.styles = {
 -- optional origin allows tracking e.g which package declared that style and just used for debugging
 -- after styles are 'frozen', we can still define new styles but not override
 -- existing styles.
-function package.defineStyle (_, name, opts, styledef, origin)
+function package:defineStyle (name, opts, styledef, origin)
   if SILE.scratch.styles.state.locked then
     if SILE.scratch.styles.specs[name] then
       return SU.debug("resilient.styles", "Styles are now frozen: ignoring redefinition for", name, "from", origin)
@@ -263,7 +276,7 @@ local function readOnly (t)
   return proxy
 end
 
-function package.freezeStyles (_)
+function package:freezeStyles ()
   SILE.scratch.styles.state.locked = true
   SILE.scratch.styles.state = readOnly(SILE.scratch.styles.state)
   SU.debug("resilient.styles", "Freezing styles")

--- a/packages/resilient/tableofcontents/init.lua
+++ b/packages/resilient/tableofcontents/init.lua
@@ -20,9 +20,6 @@
 -- along with this program.  If not, see <https://www.gnu.org/licenses/>.
 --
 local base = require("packages.resilient.base")
-local createCommand, createStructuredCommand, subContent
-        = SU.ast.createCommand, SU.ast.createStructuredCommand, SU.ast.subContent
-
 local package = pl.class(base)
 package._name = "resilient.tableofcontents"
 
@@ -177,12 +174,12 @@ function package:registerCommands ()
     for i = 1, #toc do
       local item = toc[i]
       if item.level >= start and item.level <= start + depth then
-        tocItems[#tocItems + 1] = createCommand("tableofcontents:item", {
+        tocItems[#tocItems + 1] = SU.ast.createCommand("tableofcontents:item", {
           level = item.level,
           pageno = item.pageno,
           number = item.number,
           link = linking and item.link
-        }, subContent(item.label))
+        }, SU.ast.subContent(item.label))
       end
     end
     SILE.call("style:apply:paragraph", { name = "toc" }, tocItems)
@@ -219,7 +216,7 @@ function package:registerCommands ()
     SILE.call("info", {
       category = "toc",
       value = {
-        label = subContent(SU.ast.stripContentPos(content)),
+        label = SU.ast.subContent(SU.ast.stripContentPos(content)),
         level = (options.level or 1),
         number = options.number,
         link = dest
@@ -230,7 +227,7 @@ function package:registerCommands ()
   local linkWrapper = function (dest, content)
     if dest and SILE.Commands["pdf:link"] then
       return {
-        createStructuredCommand("pdf:link", { dest = dest }, content)
+        SU.ast.createStructuredCommand("pdf:link", { dest = dest }, content)
       }
     end
     return content
@@ -254,15 +251,15 @@ function package:registerCommands ()
       SILE.settings:set("typesetter.parfillskip", SILE.types.node.glue())
       local itemContent = {}
       if options.number then
-        itemContent[#itemContent + 1] = createCommand("tableofcontents:levelnumber", {
+        itemContent[#itemContent + 1] = SU.ast.createCommand("tableofcontents:levelnumber", {
           level = level,
           text = options.number
         })
       end
-      itemContent[#itemContent + 1] = subContent(content)
-      itemContent[#itemContent + 1] = createCommand(hasFiller and "dotfill" or "hfill")
+      itemContent[#itemContent + 1] = SU.ast.subContent(content)
+      itemContent[#itemContent + 1] = SU.ast.createCommand(hasFiller and "dotfill" or "hfill")
       if hasPageno then
-        itemContent[#itemContent + 1] = createCommand("style:apply", {
+        itemContent[#itemContent + 1] = SU.ast.createCommand("style:apply", {
           name = "toc-pageno"
         }, {options.pageno})
       end

--- a/packages/resilient/tableofcontents/init.lua
+++ b/packages/resilient/tableofcontents/init.lua
@@ -3,13 +3,25 @@
 -- Following the resilient styling paradigm.
 -- Hooks are removed and replaced by styles, allowing for a fully customizable TOC
 --
--- 2021-2023, 2025 Didier Willis
--- License: MIT
+-- License: GPL-3.0-or-later
+--
+-- Copyright (C) 2021-2025 Didier Willis
+-- This program is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with this program.  If not, see <https://www.gnu.org/licenses/>.
 --
 local base = require("packages.resilient.base")
-local ast = require("silex.ast")
 local createCommand, createStructuredCommand, subContent
-        = ast.createCommand, ast.createStructuredCommand, ast.subContent
+        = SU.ast.createCommand, SU.ast.createStructuredCommand, SU.ast.subContent
 
 local package = pl.class(base)
 package._name = "resilient.tableofcontents"
@@ -20,8 +32,8 @@ function package:_init (options)
   base._init(self, options)
   SILE.scratch.tableofcontents = SILE.scratch.tableofcontents or {}
   SILE.scratch._tableofcontents = SILE.scratch._tableofcontents or {}
-  self.class:loadPackage("infonode")
-  self.class:loadPackage("leaders")
+  self:loadPackage("infonode")
+  self:loadPackage("leaders")
   if not SILE.scratch.tableofcontents then
     SILE.scratch.tableofcontents = {}
   end
@@ -39,7 +51,7 @@ function package:moveTocNodes ()
   end
 end
 
-function package.writeToc (_)
+function package:writeToc ()
   local tocdata = pl.pretty.write(SILE.scratch.tableofcontents)
   local tocfile, err = io.open(SILE.masterFilename .. '.toc', "w")
   if not tocfile then return SU.error(err) end
@@ -51,7 +63,7 @@ function package.writeToc (_)
   end
 end
 
-function package.readToc (_)
+function package:readToc ()
   if SILE.scratch._tableofcontents and #SILE.scratch._tableofcontents > 0 then
     -- already loaded
     return SILE.scratch._tableofcontents

--- a/packages/resilient/verbatim/init.lua
+++ b/packages/resilient/verbatim/init.lua
@@ -19,7 +19,6 @@
 -- along with this program.  If not, see <https://www.gnu.org/licenses/>.
 --
 local base = require("packages.resilient.base")
-
 local package = pl.class(base)
 package._name = "resilient.verbatim"
 

--- a/packages/resilient/verbatim/init.lua
+++ b/packages/resilient/verbatim/init.lua
@@ -2,8 +2,21 @@
 -- Re-implementation of the verbatim package for SILE
 -- Following the resilient styling paradigm.
 --
--- 2023,-2025, Didier Willis
--- License: MIT
+-- License: GPL-3.0-or-later
+--
+-- Copyright (C) 2023-2025 Didier Willis
+-- This program is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with this program.  If not, see <https://www.gnu.org/licenses/>.
 --
 local base = require("packages.resilient.base")
 
@@ -12,7 +25,7 @@ package._name = "resilient.verbatim"
 
 function package:registerCommands ()
 
-  -- Unchanged from the original implementation, as bad as it is.
+  -- Unchanged from the original implementation.
   self:registerCommand("verbatim:font", function (options, content)
     SU.warn([[The verbatim:font command is not expected to be used in the resilient context.
 

--- a/resilient/adapters/frameset.lua
+++ b/resilient/adapters/frameset.lua
@@ -2,13 +2,26 @@
 -- Lightweight frameset parser/solver.
 -- Aimed at resolving a master frameset so as to render it graphically, etc.
 --
--- 2023, Didier Willis
--- License: MIT
---
 -- Logic mostly stolen from SILE's core, but the frames and frameParser there
 -- rely on several side effects and global variables...
 -- I extracted and refactored the minimal code for solving frame specifications
 -- independently, so as to be able to resolve a full master layout and draw it.
+--
+-- License: GPL-3.0-or-later
+--
+-- Copyright (C) 2023-2025 Didier Willis
+-- This program is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with this program.  If not, see <https://www.gnu.org/licenses/>.
 --
 local cassowary = require("cassowary")
 local lpeg = require("lpeg")

--- a/resilient/layoutparser.lua
+++ b/resilient/layoutparser.lua
@@ -1,9 +1,21 @@
 --
 -- Parser for layout class options
--- 2023 Didier Willis
--- License: MIT
 --
--- A bit quick and dirty.
+-- License: GPL-3.0-or-later
+--
+-- Copyright (C) 2023-2025 Didier Willis
+-- This program is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with this program.  If not, see <https://www.gnu.org/licenses/>.
 --
 local lpeg = require("lpeg")
 local P, C, V = lpeg.P, lpeg.C, lpeg.V

--- a/resilient/layouts/base.lua
+++ b/resilient/layouts/base.lua
@@ -1,8 +1,21 @@
 --
 -- Base layout class (a.k.a. default/none)
 --
--- 2022-2023, Didier Willis
--- License: MIT
+-- License: GPL-3.0-or-later
+--
+-- Copyright (C) 2022-2025 Didier Willis
+-- This program is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with this program.  If not, see <https://www.gnu.org/licenses/>.
 --
 local layout = pl.class()
 
@@ -62,7 +75,7 @@ function layout:textblock (isOdd)
   }
 end
 
-function layout.content (_, _)
+function layout:content (_)
   return {
     left = "left(textblock)",
     right = "right(textblock)",
@@ -71,7 +84,7 @@ function layout.content (_, _)
   }
 end
 
-function layout.footnotes (_, _)
+function layout:footnotes (_)
   return {
     left = "left(textblock)",
     right = "right(textblock)",
@@ -109,7 +122,7 @@ function layout:header (_)
   }
 end
 
-function layout.margins (_, odd)
+function layout:margins (odd)
   return {
     left = odd and "right(textblock) + 2.5%pw" or "left(page) + 0.5in",
     right= odd and "right(page) - 0.5in" or "left(textblock) - 2.5%pw",

--- a/resilient/layouts/canonical.lua
+++ b/resilient/layouts/canonical.lua
@@ -1,9 +1,6 @@
 --
 -- Jan Tschichold's canonical page layout.
 --
--- 2022-2023, Didier Willis
--- License: MIT
---
 -- Sources:
 -- Jan TSCHICHOLD, The Form of the Book: Essays on the Morality of Good Design,
 -- Hartley & Marks, Vancouver 1991.
@@ -11,6 +8,22 @@
 --
 -- Other references:
 -- Claudio BECCARI, Package canoniclayout, 2022 (https://www.ctan.org/pkg/canoniclayout)
+--
+-- License: GPL-3.0-or-later
+--
+-- Copyright (C) 2022-2025 Didier Willis
+-- This program is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with this program.  If not, see <https://www.gnu.org/licenses/>.
 --
 local base = require("resilient.layouts.base")
 local canonical = pl.class(base)

--- a/resilient/layouts/division.lua
+++ b/resilient/layouts/division.lua
@@ -1,9 +1,6 @@
 --
 -- Division-based layouts
 --
--- 2022-2023, Didier Willis
--- License: MIT
---
 -- Sources:
 -- Alain HURTGIG, http://www.alain.les-hurtig.org/varia/empagement.html
 -- Jan TSCHICHOLD, Livre et typographie, Éditions Allia, Paris, 1994.
@@ -11,6 +8,22 @@
 --   Division by 9: Method proposed by Villard de Honnecourt (13th century).
 -- Olivier RANDIER's general method: Olivier RANDIER, Mail to the Typographie
 -- mailing-list, April 8, 2002.
+--
+-- License: GPL-3.0-or-later
+--
+-- Copyright (C) 2022-2025 Didier Willis
+-- This program is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with this program.  If not, see <https://www.gnu.org/licenses/>.
 --
 local base = require("resilient.layouts.base")
 local division = pl.class(base)

--- a/resilient/layouts/frenchcanon.lua
+++ b/resilient/layouts/frenchcanon.lua
@@ -1,9 +1,6 @@
 --
 -- French "Canon des Ateliers" page layout.
 --
--- 2022-2023, Didier Willis
--- License: MIT
---
 -- Sources:
 -- Pierre DUPLAN & Roger JAUNEAU, Maquette et mise en page, Éditions du Moniteur,
 -- Paris, 1986.
@@ -14,6 +11,22 @@
 --   http://www.numdam.org/item/CG_2003___42_4_0.pdf
 --     i.e. Markus Kohm, Étude comparative de différents modèles d’empagement,
 --   Cahiers GUTenberg no. 42 (2003), p. 4-25
+--
+-- License: GPL-3.0-or-later
+--
+-- Copyright (C) 2022-2025 Didier Willis
+-- This program is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with this program.  If not, see <https://www.gnu.org/licenses/>.
 --
 local base = require("resilient.layouts.base")
 local frenchcannon = pl.class(base)
@@ -30,6 +43,7 @@ local rules = {
   halt =   3,
   valt =   4
 }
+
 function frenchcannon:_init (options)
   base._init(self, options)
   local N = qualities[options.quality or "regular"]

--- a/resilient/layouts/geometry.lua
+++ b/resilient/layouts/geometry.lua
@@ -1,9 +1,21 @@
 --
 -- Geometry page layout (explicit dimensions).
 --
--- 2023, Didier Willis
--- License: MIT
+-- License: GPL-3.0-or-later
 --
+-- Copyright (C) 2023-2025 Didier Willis
+-- This program is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with this program.  If not, see <https://www.gnu.org/licenses/>.
 --
 local base = require("resilient.layouts.base")
 local geometry = pl.class(base)

--- a/resilient/layouts/marginal.lua
+++ b/resilient/layouts/marginal.lua
@@ -1,8 +1,21 @@
 --
 -- Division-based layout with wide margin for annotations.
 --
--- 2022-2023, Didier Willis
--- License: MIT
+-- License: GPL-3.0-or-later
+--
+-- Copyright (C) 2022-2025 Didier Willis
+-- This program is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with this program.  If not, see <https://www.gnu.org/licenses/>.
 --
 local base = require("resilient.layouts.base")
 local marginal = pl.class(base)

--- a/resilient/utils.lua
+++ b/resilient/utils.lua
@@ -1,19 +1,35 @@
 --
 -- Common utilities for RESILIENT
 --
--- 2023 Didier Willis
--- License: MIT
+-- License: GPL-3.0-or-later
+--
+-- Copyright (C) 2023-2025 Didier Willis
+-- This program is free software: you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation, either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with this program.  If not, see <https://www.gnu.org/licenses/>.
 --
 
--- Measure an inter-word space (which, depending on settings, might be variable
+--- Measure an inter-word space (which, depending on settings, might be variable
 -- and thus have stretch/shrink).
+-- @treturn length interwordSpace
 local function interwordSpace()
   return SILE.shaper:measureSpace(SILE.font.loadDefaults({}))
 end
 
--- Cast a kern length (e.g. in styles), also supporting the special "iwsp"
+--- Cast a kern length (e.g. in styles), also supporting the special "iwsp"
 -- pseudo unit for interword space.
-local function castKern(kern)
+-- @tparam string|length kern The kern value to cast
+-- @treturn length The kern value as a length
+local function castKern (kern)
   if type(kern) == "string" then
     local value, rest = kern:match("^(%d*)iwsp[ ]*(.*)$")
     if value then
@@ -26,10 +42,13 @@ local function castKern(kern)
   return SU.cast("length", kern)
 end
 
--- Merge two tables.
--- It turns out that pl.tablex.union does not recurse into the table,
+--- Merge two tables.
+-- It turns out that pl.tablex.union() does not recurse into the table,
 -- so let's do it the proper way.
--- N.B. modifies t1 (and t2 wins on "leaves" existing in both)
+-- N.B. modifies t1 (and t2 wins on "leaves" existing in both tables)
+-- @tparam table t1 The first table
+-- @tparam table t2 The second table
+-- @treturn table The merged table
 local function recursiveTableMerge(t1, t2)
   for k, v in pairs(t2) do
     if (type(v) == "table") and (type(t1[k]) == "table") then

--- a/rockspecs/resilient.sile-3.0.0-1.rockspec
+++ b/rockspecs/resilient.sile-3.0.0-1.rockspec
@@ -20,7 +20,6 @@ dependencies = {
    "couyards.sile >= 1.0.0",
    "embedders.sile >= 1.0.0",
    "labelrefs.sile >= 0.1.0",
-   "printoptions.sile >= 1.2.0",
    "piecharts.sile >= 2.0.0",
    "ptable.sile >= 4.0.0",
    "qrcode.sile >= 2.0.0",
@@ -58,11 +57,12 @@ build = {
     ["sile.packages.resilient.bible.usx"]       = "packages/resilient/bible/usx/init.lua",
     ["sile.packages.resilient.bible.tei"]       = "packages/resilient/bible/tei/init.lua",
 
-    ["sile.packages.autodoc-resilient"] = "packages/autodoc-resilient/init.lua",
+    ["sile.packages.autodoc-resilient"]    = "packages/autodoc-resilient/init.lua",
+    ["sile.packages.printoptions"]         = "packages/printoptions/init.lua",
 
     ["sile.resilient.utils"] = "resilient/utils.lua",
-    ["sile.resilient.layoutparser"] = "resilient/layoutparser.lua",
 
+    ["sile.resilient.layoutparser"]        = "resilient/layoutparser.lua",
     ["sile.resilient.layouts.base"]        = "resilient/layouts/base.lua",
 
     ["sile.resilient.layouts.canonical"]   = "resilient/layouts/canonical.lua",

--- a/rockspecs/resilient.sile-3.0.0-1.rockspec
+++ b/rockspecs/resilient.sile-3.0.0-1.rockspec
@@ -1,8 +1,9 @@
 rockspec_format = "3.0"
 package = "resilient.sile"
-version = "dev-1"
+version = "3.0.0-1"
 source = {
   url = "git+https://github.com/Omikhleia/resilient.sile.git",
+  tag = "v3.0.0",
 }
 description = {
   summary = "Advanced book classes and tools for the SILE typesetting system.",
@@ -15,18 +16,18 @@ description = {
 }
 dependencies = {
    "lua >= 5.1",
-   "barcodes.sile",
-   "couyards.sile",
-   "embedders.sile",
-   "fancytoc.sile",
-   "labelrefs.sile",
-   "printoptions.sile",
-   "piecharts.sile",
-   "ptable.sile",
-   "qrcode.sile",
-   "textsubsuper.sile",
-   "markdown.sile",
-   "silex.sile",
+   "barcodes.sile >= 2.0.0",
+   "couyards.sile >= 1.0.0",
+   "embedders.sile >= 1.0.0",
+   "fancytoc.sile >= 1.1.0",
+   "labelrefs.sile >= 0.1.0",
+   "printoptions.sile >= 1.2.0",
+   "piecharts.sile >= 2.0.0",
+   "ptable.sile >= 4.0.0",
+   "qrcode.sile >= 2.0.0",
+   "textsubsuper.sile >= 2.0.0",
+   "markdown.sile >= 2.4.0",
+   "silex.sile >= 0.9.0, < 1.0",
 }
 build = {
   type = "builtin",

--- a/rockspecs/resilient.sile-3.0.0-1.rockspec
+++ b/rockspecs/resilient.sile-3.0.0-1.rockspec
@@ -26,15 +26,17 @@ dependencies = {
    "qrcode.sile >= 2.0.0",
    "textsubsuper.sile >= 2.0.0",
    "markdown.sile >= 2.4.0",
-   "silex.sile >= 0.9.0, < 1.0",
 }
 build = {
   type = "builtin",
   modules = {
-    ["sile.classes.resilient.base"]    = "classes/resilient/base.lua",
+    ["sile.classes.resilient.override"]  = "classes/resilient/override.lua",
+    ["sile.classes.resilient.base"]      = "classes/resilient/base.lua",
 
-    ["sile.classes.resilient.book"]    = "classes/resilient/book.lua",
-    ["sile.classes.resilient.resume"]  = "classes/resilient/resume.lua",
+    ["sile.classes.resilient.book"]      = "classes/resilient/book.lua",
+    ["sile.classes.resilient.resume"]    = "classes/resilient/resume.lua",
+
+    ["sile.typesetters.silent"]          = "typesetters/silent.lua",
 
     ["sile.packages.resilient.base"]            = "packages/resilient/base.lua",
 

--- a/rockspecs/resilient.sile-3.0.0-1.rockspec
+++ b/rockspecs/resilient.sile-3.0.0-1.rockspec
@@ -19,7 +19,6 @@ dependencies = {
    "barcodes.sile >= 2.0.0",
    "couyards.sile >= 1.0.0",
    "embedders.sile >= 1.0.0",
-   "fancytoc.sile >= 1.1.0",
    "labelrefs.sile >= 0.1.0",
    "printoptions.sile >= 1.2.0",
    "piecharts.sile >= 2.0.0",
@@ -52,6 +51,7 @@ build = {
     ["sile.packages.resilient.verbatim"]        = "packages/resilient/verbatim/init.lua",
     ["sile.packages.resilient.defn"]            = "packages/resilient/defn/init.lua",
     ["sile.packages.resilient.liners"]          = "packages/resilient/liners/init.lua",
+    ["sile.packages.resilient.fancytoc"]        = "packages/resilient/fancytoc/init.lua",
 
     ["sile.packages.resilient.bible.usx"]       = "packages/resilient/bible/usx/init.lua",
     ["sile.packages.resilient.bible.tei"]       = "packages/resilient/bible/tei/init.lua",

--- a/rockspecs/resilient.sile-dev-1.rockspec
+++ b/rockspecs/resilient.sile-dev-1.rockspec
@@ -19,7 +19,6 @@ dependencies = {
    "couyards.sile",
    "embedders.sile",
    "labelrefs.sile",
-   "printoptions.sile",
    "piecharts.sile",
    "ptable.sile",
    "qrcode.sile",
@@ -57,11 +56,12 @@ build = {
     ["sile.packages.resilient.bible.usx"]       = "packages/resilient/bible/usx/init.lua",
     ["sile.packages.resilient.bible.tei"]       = "packages/resilient/bible/tei/init.lua",
 
-    ["sile.packages.autodoc-resilient"] = "packages/autodoc-resilient/init.lua",
+    ["sile.packages.autodoc-resilient"]    = "packages/autodoc-resilient/init.lua",
+    ["sile.packages.printoptions"]         = "packages/printoptions/init.lua",
 
     ["sile.resilient.utils"] = "resilient/utils.lua",
-    ["sile.resilient.layoutparser"] = "resilient/layoutparser.lua",
 
+    ["sile.resilient.layoutparser"]        = "resilient/layoutparser.lua",
     ["sile.resilient.layouts.base"]        = "resilient/layouts/base.lua",
 
     ["sile.resilient.layouts.canonical"]   = "resilient/layouts/canonical.lua",

--- a/rockspecs/resilient.sile-dev-1.rockspec
+++ b/rockspecs/resilient.sile-dev-1.rockspec
@@ -18,7 +18,6 @@ dependencies = {
    "barcodes.sile",
    "couyards.sile",
    "embedders.sile",
-   "fancytoc.sile",
    "labelrefs.sile",
    "printoptions.sile",
    "piecharts.sile",
@@ -51,6 +50,7 @@ build = {
     ["sile.packages.resilient.verbatim"]        = "packages/resilient/verbatim/init.lua",
     ["sile.packages.resilient.defn"]            = "packages/resilient/defn/init.lua",
     ["sile.packages.resilient.liners"]          = "packages/resilient/liners/init.lua",
+    ["sile.packages.resilient.fancytoc"]        = "packages/resilient/fancytoc/init.lua",
 
     ["sile.packages.resilient.bible.usx"]       = "packages/resilient/bible/usx/init.lua",
     ["sile.packages.resilient.bible.tei"]       = "packages/resilient/bible/tei/init.lua",

--- a/rockspecs/resilient.sile-dev-1.rockspec
+++ b/rockspecs/resilient.sile-dev-1.rockspec
@@ -25,15 +25,17 @@ dependencies = {
    "qrcode.sile",
    "textsubsuper.sile",
    "markdown.sile",
-   "silex.sile",
 }
 build = {
   type = "builtin",
   modules = {
-    ["sile.classes.resilient.base"]    = "classes/resilient/base.lua",
+    ["sile.classes.resilient.override"]  = "classes/resilient/override.lua",
+    ["sile.classes.resilient.base"]      = "classes/resilient/base.lua",
 
-    ["sile.classes.resilient.book"]    = "classes/resilient/book.lua",
-    ["sile.classes.resilient.resume"]  = "classes/resilient/resume.lua",
+    ["sile.classes.resilient.book"]      = "classes/resilient/book.lua",
+    ["sile.classes.resilient.resume"]    = "classes/resilient/resume.lua",
+
+    ["sile.typesetters.silent"]          = "typesetters/silent.lua",
 
     ["sile.packages.resilient.base"]            = "packages/resilient/base.lua",
 

--- a/typesetters/silent.lua
+++ b/typesetters/silent.lua
@@ -1,0 +1,1656 @@
+--- New typesetter (default/base) class for SILE/RESILIENT
+--
+-- WARNING: With sile·x modifications
+-- FIXME: Brutal monkey patching of SILE's typesetter class
+-- We'll eventually need to refactor this in a cleaner way.
+--
+-- @module typesetters.base
+--
+
+local typesetter = pl.class()
+typesetter.type = "typesetter"
+typesetter._name = "base"
+
+-- This is the default typesetter. You are, of course, welcome to create your own.
+local awful_bad = 1073741823
+local inf_bad = 10000
+-- local eject_penalty = -inf_bad
+local supereject_penalty = 2 * -inf_bad
+-- local deplorable = 100000
+
+-- Local helper class to compare pairs of margins
+local _margins = pl.class({
+   lskip = SILE.types.node.glue(),
+   rskip = SILE.types.node.glue(),
+
+   _init = function (self, lskip, rskip)
+      self.lskip, self.rskip = lskip, rskip
+   end,
+
+   __eq = function (self, other)
+      return self.lskip.width == other.lskip.width and self.rskip.width == other.rskip.width
+   end,
+})
+
+local warned = false
+
+function typesetter:init (frame)
+   SU.deprecated("std.object", "pl.class", "0.13.0", "0.14.0", warned and "" or [[
+      The typesetter instance inheritance system for instances has been refactored
+      using a different object model. Your instance was created and initialized
+      using the object copy syntax from the stdlib model. It has been shimmed for
+      you using the new Penlight model, but this may lead to unexpected behavior.
+      Please update your code to use the new Penlight based inheritance model.
+   ]])
+   warned = true
+   self:_init(frame)
+end
+
+--- Constructor
+-- @param frame A initial frame to attach the typesetter to.
+function typesetter:_init (frame)
+   self:declareSettings()
+   self.hooks = {}
+   self.breadcrumbs = SU.breadcrumbs()
+
+   self.frame = nil
+   self.stateQueue = {}
+   self:initFrame(frame)
+   self:initState()
+   -- In case people use stdlib prototype syntax off of the instantiated typesetter...
+   getmetatable(self).__call = self.init
+   return self
+end
+
+--- Declare new setting types
+function typesetter.declareSettings (_)
+   -- Settings common to any typesetter instance.
+   -- These shouldn't be re-declared and overwritten/reset in the typesetter
+   -- constructor (see issue https://github.com/sile-typesetter/sile/issues/1708).
+   -- On the other hand, it's fairly acceptable to have them made global:
+   -- Any derived typesetter, whatever its implementation, should likely provide
+   -- some logic for them (= widows, orphans, spacing, etc.)
+
+   SILE.settings:declare({
+      parameter = "typesetter.widowpenalty",
+      type = "integer",
+      default = 3000,
+      help = "Penalty to be applied to widow lines (at the start of a paragraph)",
+   })
+
+   SILE.settings:declare({
+      parameter = "typesetter.parseppattern",
+      type = "string or integer",
+      default = "\r?\n[\r\n]+",
+      help = "Lua pattern used to separate paragraphs",
+   })
+
+   SILE.settings:declare({
+      parameter = "typesetter.obeyspaces",
+      type = "boolean or nil",
+      default = nil,
+      help = "Whether to ignore paragraph initial spaces",
+   })
+
+   SILE.settings:declare({
+      parameter = "typesetter.brokenpenalty",
+      type = "integer",
+      default = 100,
+      help = "Penalty to be applied to broken (hyphenated) lines",
+   })
+
+   SILE.settings:declare({
+      parameter = "typesetter.orphanpenalty",
+      type = "integer",
+      default = 3000,
+      help = "Penalty to be applied to orphan lines (at the end of a paragraph)",
+   })
+
+   SILE.settings:declare({
+      parameter = "typesetter.parfillskip",
+      type = "glue",
+      default = SILE.types.node.glue("0pt plus 10000pt"),
+      help = "Glue added at the end of a paragraph",
+   })
+
+   SILE.settings:declare({
+      parameter = "document.letterspaceglue",
+      type = "glue or nil",
+      default = nil,
+      help = "Glue added between tokens",
+   })
+
+   SILE.settings:declare({
+      parameter = "typesetter.underfulltolerance",
+      type = "length or nil",
+      default = SILE.types.length("1em"),
+      help = "Amount a page can be underfull without warning",
+   })
+
+   SILE.settings:declare({
+      parameter = "typesetter.overfulltolerance",
+      type = "length or nil",
+      default = SILE.types.length("5pt"),
+      help = "Amount a page can be overfull without warning",
+   })
+
+   SILE.settings:declare({
+      parameter = "typesetter.breakwidth",
+      type = "measurement or nil",
+      default = nil,
+      help = "Width to break lines at",
+   })
+
+   SILE.settings:declare({
+      parameter = "typesetter.italicCorrection",
+      type = "boolean",
+      default = false,
+      help = "Whether italic correction is activated or not",
+   })
+
+   SILE.settings:declare({
+      parameter = "typesetter.italicCorrection.punctuation",
+      type = "boolean",
+      default = true,
+      help = "Whether italic correction is compensated on special punctuation spaces (e.g. in French)",
+   })
+
+   SILE.settings:declare({
+      parameter = "typesetter.softHyphen",
+      type = "boolean",
+      default = true,
+      help = "When true, soft hyphens are rendered as discretionary breaks, otherwise they are ignored",
+   })
+
+   SILE.settings:declare({
+      parameter = "typesetter.softHyphenWarning",
+      type = "boolean",
+      default = false,
+      help = "When true, a warning is issued when a soft hyphen is encountered",
+   })
+
+   SILE.settings:declare({
+      parameter = "typesetter.fixedSpacingAfterInitialEmdash",
+      type = "boolean",
+      default = true,
+      help = "When true, em-dash starting a paragraph is considered as a speaker change in a dialogue",
+   })
+end
+
+function typesetter:initState ()
+   self.state = {
+      nodes = {},
+      outputQueue = {},
+      lastBadness = awful_bad,
+      liners = {},
+   }
+end
+
+function typesetter:initFrame (frame)
+   if frame then
+      self.frame = frame
+      self.frame:init(self)
+   end
+end
+
+function typesetter.getMargins ()
+   return _margins(SILE.settings:get("document.lskip"), SILE.settings:get("document.rskip"))
+end
+
+function typesetter.setMargins (_, margins)
+   SILE.settings:set("document.lskip", margins.lskip)
+   SILE.settings:set("document.rskip", margins.rskip)
+end
+
+function typesetter:pushState ()
+   self.stateQueue[#self.stateQueue + 1] = self.state
+   self:initState()
+end
+
+function typesetter:popState (ncount)
+   local offset = ncount and #self.stateQueue - ncount or nil
+   self.state = table.remove(self.stateQueue, offset)
+   if not self.state then
+      SU.error("Typesetter state queue empty")
+   end
+end
+
+function typesetter:isQueueEmpty ()
+   if not self.state then
+      return nil
+   end
+   return #self.state.nodes == 0 and #self.state.outputQueue == 0
+end
+
+function typesetter:vmode ()
+   return #self.state.nodes == 0
+end
+
+function typesetter:debugState ()
+   print("\n---\nI am in " .. (self:vmode() and "vertical" or "horizontal") .. " mode")
+   print("Writing into " .. tostring(self.frame))
+   print("Recent contributions: ")
+   for i = 1, #self.state.nodes do
+      io.stderr:write(self.state.nodes[i] .. " ")
+   end
+   print("\nVertical list: ")
+   for i = 1, #self.state.outputQueue do
+      print("  " .. self.state.outputQueue[i])
+   end
+end
+
+-- Boxy stuff
+function typesetter:pushHorizontal (node)
+   self:initline()
+   self.state.nodes[#self.state.nodes + 1] = node
+   return node
+end
+
+function typesetter:pushVertical (vbox)
+   self.state.outputQueue[#self.state.outputQueue + 1] = vbox
+   return vbox
+end
+
+function typesetter:pushHbox (spec)
+   local ntype = SU.type(spec)
+   local node = (ntype == "hbox" or ntype == "zerohbox") and spec or SILE.types.node.hbox(spec)
+   return self:pushHorizontal(node)
+end
+
+function typesetter:pushUnshaped (spec)
+   local node = SU.type(spec) == "unshaped" and spec or SILE.types.node.unshaped(spec)
+   return self:pushHorizontal(node)
+end
+
+function typesetter:pushGlue (spec)
+   local node = SU.type(spec) == "glue" and spec or SILE.types.node.glue(spec)
+   return self:pushHorizontal(node)
+end
+
+function typesetter:pushExplicitGlue (spec)
+   local node = SU.type(spec) == "glue" and spec or SILE.types.node.glue(spec)
+   node.explicit = true
+   node.discardable = false
+   return self:pushHorizontal(node)
+end
+
+function typesetter:pushPenalty (spec)
+   local node = SU.type(spec) == "penalty" and spec or SILE.types.node.penalty(spec)
+   return self:pushHorizontal(node)
+end
+
+function typesetter:pushMigratingMaterial (material)
+   local node = SILE.types.node.migrating({ material = material })
+   return self:pushHorizontal(node)
+end
+
+function typesetter:pushVbox (spec)
+   local node = SU.type(spec) == "vbox" and spec or SILE.types.node.vbox(spec)
+   return self:pushVertical(node)
+end
+
+function typesetter:pushVglue (spec)
+   local node = SU.type(spec) == "vglue" and spec or SILE.types.node.vglue(spec)
+   return self:pushVertical(node)
+end
+
+function typesetter:pushExplicitVglue (spec)
+   local node = SU.type(spec) == "vglue" and spec or SILE.types.node.vglue(spec)
+   node.explicit = true
+   node.discardable = false
+   return self:pushVertical(node)
+end
+
+function typesetter:pushVpenalty (spec)
+   local node = SU.type(spec) == "penalty" and spec or SILE.types.node.penalty(spec)
+   return self:pushVertical(node)
+end
+
+-- Actual typesetting functions
+function typesetter:typeset (text)
+   text = tostring(text)
+   if text:match("^%\r?\n$") then
+      return
+   end
+   local pId = SILE.traceStack:pushText(text)
+   local parsepattern = SILE.settings:get("typesetter.parseppattern")
+   -- NOTE: Big assumption on how to guess were are in "obeylines" mode.
+   -- See https://github.com/sile-typesetter/sile/issues/2128
+   local obeylines = parsepattern == "\n"
+
+   local seenParaContent = true
+   for token in SU.gtoke(text, parsepattern) do
+      if token.separator then
+         if obeylines and not seenParaContent then
+            -- In obeylines mode, each standalone line must be kept.
+            -- The zerohbox is not discardable, so it will be kept in the output,
+            -- and the baseline skip will do the rest.
+            self:pushHorizontal(SILE.types.node.zerohbox())
+         else
+            seenParaContent = false
+         end
+         self:endline()
+      else
+         seenParaContent = true
+         if SILE.settings:get("typesetter.softHyphen") then
+            local warnedshy = false
+            for token2 in SU.gtoke(token.string, luautf8.char(0x00AD)) do
+               if token2.separator then -- soft hyphen support
+                  local discretionary = SILE.types.node.discretionary({})
+                  local hbox = SILE.typesetter:makeHbox({ SILE.settings:get("font.hyphenchar") })
+                  discretionary.prebreak = { hbox }
+                  table.insert(SILE.typesetter.state.nodes, discretionary)
+                  if not warnedshy and SILE.settings:get("typesetter.softHyphenWarning") then
+                     SU.warn("Soft hyphen encountered and replaced with discretionary")
+                  end
+                  warnedshy = true
+               else
+                  self:setpar(token2.string)
+               end
+            end
+         else
+            if
+               SILE.settings:get("typesetter.softHyphenWarning") and luautf8.match(token.string, luautf8.char(0x00AD))
+            then
+               SU.warn("Soft hyphen encountered and ignored")
+            end
+            text = luautf8.gsub(token.string, luautf8.char(0x00AD), "")
+            self:setpar(text)
+         end
+      end
+   end
+   SILE.traceStack:pop(pId)
+end
+
+function typesetter:initline ()
+   if self.state.hmodeOnly then
+      return
+   end -- https://github.com/sile-typesetter/sile/issues/1718
+   if #self.state.nodes == 0 then
+      table.insert(self.state.nodes, SILE.types.node.zerohbox())
+      SILE.documentState.documentClass.newPar(self)
+   end
+end
+
+function typesetter:endline ()
+   self:leaveHmode()
+   SILE.documentState.documentClass.endPar(self)
+end
+
+-- Just compute once, to avoid unicode characters in source code.
+local speakerChangePattern = "^"
+   .. luautf8.char(0x2014) -- emdash
+   .. "[ "
+   .. luautf8.char(0x00A0)
+   .. luautf8.char(0x202F) -- regular space or NBSP or NNBSP
+   .. "]+"
+local speakerChangeReplacement = luautf8.char(0x2014) .. " "
+
+-- Special unshaped node subclass to handle space after a speaker change in dialogues
+-- introduced by an em-dash.
+local speakerChangeNode = pl.class(SILE.types.node.unshaped)
+function speakerChangeNode:shape ()
+   local node = self._base.shape(self)
+   local spc = node[2]
+   if spc and spc.is_glue then
+      -- Switch the variable space glue to a fixed kern
+      node[2] = SILE.types.node.kern({ width = spc.width.length })
+      node[2].parent = self.parent
+   else
+      -- Should not occur:
+      -- How could it possibly be shaped differently?
+      SU.warn("Speaker change logic met an unexpected case, this might be a bug")
+   end
+   return node
+end
+
+-- Takes string, writes onto self.state.nodes
+function typesetter:setpar (text)
+   text = text:gsub("\r?\n", " "):gsub("\t", " ")
+   if #self.state.nodes == 0 then
+      if not SILE.settings:get("typesetter.obeyspaces") then
+         text = text:gsub("^%s+", "")
+      end
+      self:initline()
+
+      if
+         SILE.settings:get("typesetter.fixedSpacingAfterInitialEmdash")
+         and not SILE.settings:get("typesetter.obeyspaces")
+      then
+         local speakerChange = false
+         local dialogue = luautf8.gsub(text, speakerChangePattern, function ()
+            speakerChange = true
+            return speakerChangeReplacement
+         end)
+         if speakerChange then
+            local node = speakerChangeNode({ text = dialogue, options = SILE.font.loadDefaults({}) })
+            self:pushHorizontal(node)
+            return -- done here: speaker change space handling is done after nnode shaping
+         end
+      end
+   end
+   if #text > 0 then
+      self:pushUnshaped({ text = text, options = SILE.font.loadDefaults({}) })
+   end
+end
+
+function typesetter:breakIntoLines (nodelist, breakWidth)
+   self:shapeAllNodes(nodelist)
+
+   -- BEGIN SILEX HANGED LINES
+   -- NOTE: There's some scope confusion between what should be settings and
+   -- current typesetter states. It might take time to be properly
+   -- addressed.
+   -- INTENT: Hanged lines are tracked (counted) so as to propagate the
+   -- remaining offset to the next paragraph.
+   local hangIndent = SILE.settings:get("current.hangIndent")
+   self.state.hangAfter = SILE.settings:get("current.hangAfter")
+   SILE.settings:set("linebreak.hangIndent", hangIndent or 0)
+   SILE.settings:set("linebreak.hangAfter", self.state.hangAfter)
+   -- END SILEX HANGED LINES
+
+   local breakpoints = SILE.linebreak:doBreak(nodelist, breakWidth)
+   local lines = self:breakpointsToLines(breakpoints)
+
+   -- BEGIN SILEX HANGED LINES
+   if self.state.hangAfter == 0 then
+      SILE.settings:set("current.hangIndent", nil)
+      SILE.settings:set("current.hangAfter", nil)
+   else
+      SILE.settings:set("current.hangAfter", self.state.hangAfter)
+   end
+   return lines
+   -- END SILEX HANGED LINES
+end
+
+--- Extract the last shaped item from a node list.
+-- @tparam table nodelist A list of nodes.
+-- @treturn table The last shaped item.
+-- @treturn boolean Whether the list contains a glue after the last shaped item.
+-- @treturn number|nil The width of a punctuation kern after the last shaped item, if any.
+local function getLastShape (nodelist)
+   local lastShape
+   local hasGlue
+   local punctSpaceWidth
+   if nodelist then
+      -- The node list may contain nnodes, penalties, kern and glue
+      -- We skip the latter, and retrieve the last shaped item.
+      for i = #nodelist, 1, -1 do
+         local n = nodelist[i]
+         if n.is_nnode then
+            local items = n.nodes[#n.nodes].value.items
+            lastShape = items[#items]
+            break
+         end
+         if n.is_kern and n.subtype == "punctspace" then
+            -- Some languages such as French insert a special space around
+            -- punctuations.
+            -- In those case, we have different strategies for handling
+            -- italic correction.
+            punctSpaceWidth = n.width:tonumber()
+         end
+         if n.is_glue then
+            hasGlue = true
+         end
+      end
+   end
+   return lastShape, hasGlue, punctSpaceWidth
+end
+
+--- Extract the first shaped item from a node list.
+-- @tparam table nodelist A list of nodes.
+-- @treturn table The first shaped item.
+-- @treturn boolean Whether the list contains a glue before the first shaped item.
+-- @treturn number|nil The width of a punctuation kern before the first shaped item, if any.
+local function getFirstShape (nodelist)
+   local firstShape
+   local hasGlue
+   local punctSpaceWidth
+   if nodelist then
+      -- The node list may contain nnodes, penalties, kern and glue
+      -- We skip the latter, and retrieve the first shaped item.
+      for i = 1, #nodelist do
+         local n = nodelist[i]
+         if n.is_nnode then
+            local items = n.nodes[1].value.items
+            firstShape = items[1]
+            break
+         end
+         if n.is_kern and n.subtype == "punctspace" then
+            -- Some languages such as French insert a special space around
+            -- punctuations.
+            -- In those case, we have different strategies for handling
+            -- italic correction.
+            punctSpaceWidth = n.width:tonumber()
+         end
+         if n.is_glue then
+            hasGlue = true
+         end
+      end
+   end
+   return firstShape, hasGlue, punctSpaceWidth
+end
+
+--- Compute the italic correction when switching from italic to non-italic.
+-- Computing italic correction is at best heuristics.
+-- The strong assumption is that italic is slanted to the right.
+-- Thus, the part of the character that goes beyond its width is usually maximal at the top of the glyph.
+-- E.g. consider a "f", that would be the top hook extent.
+-- Pathological cases exist, such as fonts with a Q with a long tail, but these will rarely occur in usual languages.
+-- For instance, Klingon's "QaQ" might be an issue, but there's not much we can do...
+-- Another assumption is that we can distribute that extent in proportion with the next character's height.
+-- This might not work that well with non-Latin scripts.
+--
+-- @tparam table precShape The last shaped item (italic).
+-- @tparam table curShape The first shaped item (non-italic).
+-- @tparam number|nil punctSpaceWidth The width of a punctuation kern between the two items, if any.
+local function fromItalicCorrection (precShape, curShape, punctSpaceWidth)
+   local xOffset
+   if not curShape or not precShape then
+      xOffset = 0
+   elseif precShape.height <= 0 then
+      xOffset = 0
+   else
+      local d = precShape.glyphWidth + precShape.x_bearing
+      local delta = d > precShape.width and d - precShape.width or 0
+      xOffset = precShape.height <= curShape.height and delta or delta * curShape.height / precShape.height
+      if punctSpaceWidth and SILE.settings:get("typesetter.italicCorrection.punctuation") then
+         xOffset = xOffset - punctSpaceWidth > 0 and (xOffset - punctSpaceWidth) or 0
+      end
+   end
+   return xOffset
+end
+
+--- Compute the italic correction when switching from non-italic to italic.
+-- Same assumptions as fromItalicCorrection(), but on the starting side of the glyph.
+--
+-- @tparam table precShape The last shaped item (non-italic).
+-- @tparam table curShape The first shaped item (italic).
+-- @tparam number|nil punctSpaceWidth The width of a punctuation kern between the two items, if any.
+local function toItalicCorrection (precShape, curShape, punctSpaceWidth)
+   local xOffset
+   if not curShape or not precShape then
+      xOffset = 0
+   elseif precShape.depth <= 0 then
+      xOffset = 0
+   else
+      local d = curShape.x_bearing
+      local delta = d < 0 and -d or 0
+      xOffset = precShape.depth >= curShape.depth and delta or delta * precShape.depth / curShape.depth
+      if punctSpaceWidth and SILE.settings:get("typesetter.italicCorrection.punctuation") then
+         xOffset = punctSpaceWidth - xOffset > 0 and xOffset or 0
+      end
+   end
+   return xOffset
+end
+
+local function isItalicLike (nnode)
+   -- We could do...
+   --  return nnode and string.lower(nnode.options.style) == "italic"
+   -- But it's probably more robust to use the italic angle, so that
+   -- thin italic, oblique or slanted fonts etc. may work too.
+   local ot = require("core.opentype-parser")
+   local face = SILE.font.cache(nnode.options, SILE.shaper.getFace)
+   local font = ot.parseFont(face)
+   return font.post.italicAngle ~= 0
+end
+
+function typesetter.shapeAllNodes (_, nodelist, inplace)
+   inplace = SU.boolean(inplace, true) -- Compatibility with earlier versions
+   local newNodelist = {}
+   local prec
+   local precShapedNodes
+   local isItalicCorrectionEnabled = SILE.settings:get("typesetter.italicCorrection")
+   for _, current in ipairs(nodelist) do
+      if current.is_unshaped then
+         local shapedNodes = current:shape()
+
+         if isItalicCorrectionEnabled and prec then
+            local itCorrOffset
+            local isGlue
+            if isItalicLike(prec) and not isItalicLike(current) then
+               local precShape, precHasGlue = getLastShape(precShapedNodes)
+               local curShape, curHasGlue, curPunctSpaceWidth = getFirstShape(shapedNodes)
+               isGlue = precHasGlue or curHasGlue
+               itCorrOffset = fromItalicCorrection(precShape, curShape, curPunctSpaceWidth)
+            elseif not isItalicLike(prec) and isItalicLike(current) then
+               local precShape, precHasGlue, precPunctSpaceWidth = getLastShape(precShapedNodes)
+               local curShape, curHasGlue = getFirstShape(shapedNodes)
+               isGlue = precHasGlue or curHasGlue
+               itCorrOffset = toItalicCorrection(precShape, curShape, precPunctSpaceWidth)
+            end
+            if itCorrOffset and itCorrOffset ~= 0 then
+               -- If one of the node contains a glue (e.g. "a \em{proof} is..."),
+               -- line breaking may occur between them, so our correction shall be
+               -- a glue too.
+               -- Otherwise, the font change is considered to occur at a non-breaking
+               -- point (e.g. "\em{proof}!") and the correction shall be a kern.
+               local makeItCorrNode = isGlue and SILE.types.node.glue or SILE.types.node.kern
+               newNodelist[#newNodelist + 1] = makeItCorrNode({
+                  width = SILE.types.length(itCorrOffset),
+                  subtype = "itcorr",
+               })
+            end
+         end
+
+         pl.tablex.insertvalues(newNodelist, shapedNodes)
+
+         prec = current
+         precShapedNodes = shapedNodes
+      else
+         prec = nil
+         newNodelist[#newNodelist + 1] = current
+      end
+   end
+
+   if not inplace then
+      return newNodelist
+   end
+
+   for i = 1, #newNodelist do
+      nodelist[i] = newNodelist[i]
+   end
+   if #nodelist > #newNodelist then
+      for i = #newNodelist + 1, #nodelist do
+         nodelist[i] = nil
+      end
+   end
+end
+
+-- Empties self.state.nodes, breaks into lines, puts lines into vbox, adds vbox to
+-- Turns a node list into a list of vboxes
+function typesetter:boxUpNodes ()
+   local nodelist = self.state.nodes
+   if #nodelist == 0 then
+      return {}
+   end
+   for j = #nodelist, 1, -1 do
+      if not nodelist[j].is_migrating then
+         if nodelist[j].discardable then
+            table.remove(nodelist, j)
+         else
+            break
+         end
+      end
+   end
+   while #nodelist > 0 and nodelist[1].is_penalty do
+      table.remove(nodelist, 1)
+   end
+   if #nodelist == 0 then
+      return {}
+   end
+   self:shapeAllNodes(nodelist)
+   local parfillskip = SILE.settings:get("typesetter.parfillskip")
+   parfillskip.discardable = false
+   self:pushGlue(parfillskip)
+   self:pushPenalty(-inf_bad)
+   SU.debug("typesetter", function ()
+      return "Boxed up " .. (#nodelist > 500 and #nodelist .. " nodes" or SU.ast.contentToString(nodelist))
+   end)
+   local breakWidth = SILE.settings:get("typesetter.breakwidth") or self.frame:getLineWidth()
+   local lines = self:breakIntoLines(nodelist, breakWidth)
+   local vboxes = {}
+   for index = 1, #lines do
+      local line = lines[index]
+      local migrating = {}
+      -- Move any migrating material
+      local nodes = {}
+      for i = 1, #line.nodes do
+         local node = line.nodes[i]
+         if node.is_migrating then
+            for j = 1, #node.material do
+               migrating[#migrating + 1] = node.material[j]
+            end
+         else
+            nodes[#nodes + 1] = node
+         end
+      end
+      local vbox = SILE.types.node.vbox({ nodes = nodes, ratio = line.ratio })
+      local pageBreakPenalty = 0
+      if #lines > 1 and index == 1 then
+         pageBreakPenalty = SILE.settings:get("typesetter.widowpenalty")
+      elseif #lines > 1 and index == (#lines - 1) then
+         pageBreakPenalty = SILE.settings:get("typesetter.orphanpenalty")
+      elseif line.is_broken then
+         pageBreakPenalty = SILE.settings:get("typesetter.brokenpenalty")
+      end
+      vboxes[#vboxes + 1] = self:leadingFor(vbox, self.state.previousVbox)
+      vboxes[#vboxes + 1] = vbox
+      for i = 1, #migrating do
+         vboxes[#vboxes + 1] = migrating[i]
+      end
+      self.state.previousVbox = vbox
+      -- BEGIN SILEX HANGED LINES
+      if line.hanged then
+         -- Do not break the frame in hanged lines for dropped capitals etc.
+         vboxes[#vboxes+1] = SILE.types.node.penalty(10000)
+      elseif pageBreakPenalty > 0 then
+         SU.debug("typesetter", "adding penalty of", pageBreakPenalty, "after", vbox)
+         vboxes[#vboxes + 1] = SILE.types.node.penalty(pageBreakPenalty)
+      end
+      -- END SILEX HANGED LINES
+   end
+   return vboxes
+end
+
+function typesetter.pageTarget (_)
+   SU.deprecated("SILE.typesetter:pageTarget", "SILE.typesetter:getTargetLength", "0.13.0", "0.14.0")
+end
+
+function typesetter:getTargetLength ()
+   return self.frame:getTargetLength()
+end
+
+function typesetter:registerHook (category, func)
+   if not self.hooks[category] then
+      self.hooks[category] = {}
+   end
+   table.insert(self.hooks[category], func)
+end
+
+function typesetter:runHooks (category, data)
+   if not self.hooks[category] then
+      return data
+   end
+   for _, func in ipairs(self.hooks[category]) do
+      data = func(self, data)
+   end
+   return data
+end
+
+function typesetter:registerFrameBreakHook (func)
+   self:registerHook("framebreak", func)
+end
+
+function typesetter:registerNewFrameHook (func)
+   self:registerHook("newframe", func)
+end
+
+function typesetter:registerPageEndHook (func)
+   self:registerHook("pageend", func)
+end
+
+function typesetter:buildPage ()
+   local pageNodeList
+   local res
+   if self:isQueueEmpty() then
+      return false
+   end
+   if SILE.scratch.insertions then
+      SILE.scratch.insertions.thisPage = {}
+   end
+   pageNodeList, res = SILE.pagebuilder:findBestBreak({
+      vboxlist = self.state.outputQueue,
+      target = self:getTargetLength(),
+      restart = self.frame.state.pageRestart,
+   })
+   if not pageNodeList then -- No break yet
+      -- self.frame.state.pageRestart = res
+      self:runHooks("noframebreak")
+      return false
+   end
+   SU.debug("pagebuilder", "Buildding page for", self.frame.id)
+   self.state.lastPenalty = res
+   self.frame.state.pageRestart = nil
+   pageNodeList = self:runHooks("framebreak", pageNodeList)
+   self:setVerticalGlue(pageNodeList, self:getTargetLength())
+   self:outputLinesToPage(pageNodeList)
+   return true
+end
+
+function typesetter:setVerticalGlue (pageNodeList, target)
+   local glues = {}
+   local gTotal = SILE.types.length()
+   local totalHeight = SILE.types.length()
+
+   local pastTop = false
+   for _, node in ipairs(pageNodeList) do
+      if not pastTop and not node.discardable and not node.explicit then
+         -- "Ignore discardable and explicit glues at the top of a frame."
+         -- See typesetter:outputLinesToPage()
+         -- Note the test here doesn't check is_vglue, so will skip other
+         -- discardable nodes (e.g. penalties), but it shouldn't matter
+         -- for the type of computing performed here.
+         pastTop = true
+      end
+      if pastTop then
+         if not node.is_insertion then
+            totalHeight:___add(node.height)
+            totalHeight:___add(node.depth)
+         end
+         if node.is_vglue then
+            table.insert(glues, node)
+            gTotal:___add(node.height)
+         end
+      end
+   end
+
+   if totalHeight:tonumber() == 0 then
+      return SU.debug("pagebuilder", "No glue adjustment needed on empty page")
+   end
+
+   local adjustment = target - totalHeight
+   if adjustment:tonumber() > 0 then
+      if adjustment > gTotal.stretch then
+         if
+            (adjustment - gTotal.stretch):tonumber() > SILE.settings:get("typesetter.underfulltolerance"):tonumber()
+         then
+            SU.warn(
+               "Underfull frame "
+                  .. self.frame.id
+                  .. ": "
+                  .. adjustment
+                  .. " stretchiness required to fill but only "
+                  .. gTotal.stretch
+                  .. " available"
+            )
+         end
+         adjustment = gTotal.stretch
+      end
+      if gTotal.stretch:tonumber() > 0 then
+         for i = 1, #glues do
+            local g = glues[i]
+            g:adjustGlue(adjustment:tonumber() * g.height.stretch:absolute() / gTotal.stretch)
+         end
+      end
+   elseif adjustment:tonumber() < 0 then
+      adjustment = 0 - adjustment
+      if adjustment > gTotal.shrink then
+         if (adjustment - gTotal.shrink):tonumber() > SILE.settings:get("typesetter.overfulltolerance"):tonumber() then
+            SU.warn(
+               "Overfull frame "
+                  .. self.frame.id
+                  .. ": "
+                  .. adjustment
+                  .. " shrinkability required to fit but only "
+                  .. gTotal.shrink
+                  .. " available"
+            )
+         end
+         adjustment = gTotal.shrink
+      end
+      if gTotal.shrink:tonumber() > 0 then
+         for i = 1, #glues do
+            local g = glues[i]
+            g:adjustGlue(-adjustment:tonumber() * g.height.shrink:absolute() / gTotal.shrink)
+         end
+      end
+   end
+   SU.debug("pagebuilder", "Glues for this page adjusted by", adjustment, "drawn from", gTotal)
+end
+
+function typesetter:initNextFrame ()
+   local oldframe = self.frame
+   self.frame:leave(self)
+   if #self.state.outputQueue == 0 then
+      self.state.previousVbox = nil
+   end
+   if self.frame.next and self.state.lastPenalty > supereject_penalty then
+      self:initFrame(SILE.getFrame(self.frame.next))
+   elseif not self.frame:isMainContentFrame() then
+      if #self.state.outputQueue > 0 then
+         SU.warn("Overfull content for frame " .. self.frame.id)
+         self:chuck()
+      end
+   else
+      self:runHooks("pageend")
+      SILE.documentState.documentClass:endPage()
+      self:initFrame(SILE.documentState.documentClass:newPage())
+   end
+
+   if not SU.feq(oldframe:getLineWidth(), self.frame:getLineWidth()) then
+      self:pushBack()
+      -- Some what of a hack below.
+      -- Before calling this method, we were in vertical mode...
+      -- pushback occurred, and it seems it messes up a bit...
+      -- Regardless what it does, at the end, we ought to be in vertical mode
+      -- again:
+      self:leaveHmode()
+   else
+      -- If I have some things on the vertical list already, they need
+      -- proper top-of-frame leading applied.
+      if #self.state.outputQueue > 0 then
+         local lead = self:leadingFor(self.state.outputQueue[1], nil)
+         if lead then
+            table.insert(self.state.outputQueue, 1, lead)
+         end
+      end
+   end
+   self:runHooks("newframe")
+end
+
+function typesetter:pushBack ()
+   SU.debug("typesetter", "Pushing back", #self.state.outputQueue, "nodes")
+   local oldqueue = self.state.outputQueue
+   self.state.outputQueue = {}
+   self.state.previousVbox = nil
+   local lastMargins = self:getMargins()
+   for _, vbox in ipairs(oldqueue) do
+      SU.debug("pushback", "process box", vbox)
+      if vbox.margins and vbox.margins ~= lastMargins then
+         SU.debug("pushback", "new margins", lastMargins, vbox.margins)
+         if not self.state.grid then
+            self:endline()
+         end
+         self:setMargins(vbox.margins)
+      end
+      if vbox.explicit then
+         SU.debug("pushback", "explicit", vbox)
+         self:endline()
+         self:pushExplicitVglue(vbox)
+      elseif vbox.is_insertion then
+         SU.debug("pushback", "pushBack", "insertion", vbox)
+         SILE.typesetter:pushMigratingMaterial({ material = { vbox } })
+      elseif not vbox.is_vglue and not vbox.is_penalty then
+         SU.debug("pushback", "not vglue or penalty", vbox.type)
+         local discardedFistInitLine = false
+         if #self.state.nodes == 0 then
+            -- Setup queue but avoid calling newPar
+            self.state.nodes[#self.state.nodes + 1] = SILE.types.node.zerohbox()
+         end
+         for i, node in ipairs(vbox.nodes) do
+            if node.is_glue and not node.discardable then
+               self:pushHorizontal(node)
+            elseif node.is_glue and node.value == "margin" then
+               SU.debug("pushback", "discard", node.value, node)
+            elseif node.is_discretionary then
+               SU.debug("pushback", "re-mark discretionary as unused", node)
+               node.used = false
+               if i == 1 then
+                  SU.debug("pushback", "keep first discretionary", node)
+                  self:pushHorizontal(node)
+               else
+                  SU.debug("pushback", "discard all other discretionaries", node)
+               end
+            elseif node.is_zero then
+               if discardedFistInitLine then
+                  self:pushHorizontal(node)
+               end
+               discardedFistInitLine = true
+            elseif node.is_penalty then
+               if not discardedFistInitLine then
+                  self:pushHorizontal(node)
+               end
+            else
+               node.bidiDone = true
+               self:pushHorizontal(node)
+            end
+         end
+      else
+         SU.debug("pushback", "discard", vbox.type)
+      end
+      lastMargins = vbox.margins
+      -- self:debugState()
+   end
+   while
+      self.state.nodes[#self.state.nodes]
+      and (self.state.nodes[#self.state.nodes].is_penalty or self.state.nodes[#self.state.nodes].is_zero)
+   do
+      self.state.nodes[#self.state.nodes] = nil
+   end
+end
+
+function typesetter:outputLinesToPage (lines)
+   SU.debug("pagebuilder", "OUTPUTTING frame", self.frame.id)
+   -- It would have been nice to avoid storing this "pastTop" into a frame
+   -- state, to keep things less entangled. There are situations, though,
+   -- we will have left horizontal mode (triggering output), but will later
+   -- call typesetter:chuck() do deal with any remaining content, and we need
+   -- to know whether some content has been output already.
+   local pastTop = self.frame.state.totals.pastTop
+   for _, line in ipairs(lines) do
+      -- Ignore discardable and explicit glues at the top of a frame:
+      -- Annoyingly, explicit glue *should* disappear at the top of a page.
+      -- if you don't want that, add an empty vbox or something.
+      if not pastTop and not line.discardable and not line.explicit then
+         -- Note the test here doesn't check is_vglue, so will skip other
+         -- discardable nodes (e.g. penalties), but it shouldn't matter
+         -- for outputting.
+         pastTop = true
+      end
+      if pastTop then
+         line:outputYourself(self, line)
+      end
+   end
+   self.frame.state.totals.pastTop = pastTop
+end
+
+function typesetter:leaveHmode (independent)
+   if self.state.hmodeOnly then
+      SU.error("Paragraphs are forbidden in restricted horizontal mode")
+   end
+   SU.debug("typesetter", "Leaving hmode")
+   local margins = self:getMargins()
+   local vboxlist = self:boxUpNodes()
+   self.state.nodes = {}
+   -- Push output lines into boxes and ship them to the page builder
+   for _, vbox in ipairs(vboxlist) do
+      vbox.margins = margins
+      self:pushVertical(vbox)
+   end
+   if independent then
+      return
+   end
+   if self:buildPage() then
+      self:initNextFrame()
+   end
+end
+
+function typesetter:inhibitLeading ()
+   self.state.previousVbox = nil
+end
+
+function typesetter.leadingFor (_, vbox, previous)
+   -- Insert leading
+   SU.debug("typesetter", "   Considering leading between two lines:")
+   SU.debug("typesetter", "   1)", previous)
+   SU.debug("typesetter", "   2)", vbox)
+   if not previous then
+      return SILE.types.node.vglue()
+   end
+   local prevDepth = previous.depth
+   SU.debug("typesetter", "   Depth of previous line was", prevDepth)
+   local bls = SILE.settings:get("document.baselineskip")
+   local depth = bls.height:absolute() - vbox.height:absolute() - prevDepth:absolute()
+   SU.debug("typesetter", "   Leading height =", bls.height, "-", vbox.height, "-", prevDepth, "=", depth)
+
+   -- the lineskip setting is a vglue, but we need a version absolutized at this point, see #526
+   local lead = SILE.settings:get("document.lineskip").height:absolute()
+   if depth > lead then
+      return SILE.types.node.vglue(SILE.types.length(depth.length, bls.height.stretch, bls.height.shrink))
+   else
+      return SILE.types.node.vglue(lead)
+   end
+end
+
+-- Beginning of liner logic (constructs spanning over several lines)
+
+-- These two special nodes are used to track the current liner entry and exit.
+-- As Sith Lords, they are always two: they are local here, so no one can
+-- use one alone and break the balance of the Force.
+local linerEnterNode = pl.class(SILE.types.node.hbox)
+function linerEnterNode:_init (name, outputMethod)
+   SILE.types.node.hbox._init(self)
+   self.outputMethod = outputMethod
+   self.name = name
+   self.is_enter = true
+end
+function linerEnterNode:clone ()
+   return linerEnterNode(self.name, self.outputMethod)
+end
+function linerEnterNode:outputYourself ()
+   SU.error("A liner enter node " .. tostring(self) .. "'' made it to output", true)
+end
+function linerEnterNode:__tostring ()
+   return "+L[" .. self.name .. "]"
+end
+local linerLeaveNode = pl.class(SILE.types.node.hbox)
+function linerLeaveNode:_init (name)
+   SILE.types.node.hbox._init(self)
+   self.name = name
+   self.is_leave = true
+end
+function linerLeaveNode:clone ()
+   return linerLeaveNode(self.name)
+end
+function linerLeaveNode:outputYourself ()
+   SU.error("A liner leave node " .. tostring(self) .. "'' made it to output", true)
+end
+function linerLeaveNode:__tostring ()
+   return "-L[" .. self.name .. "]"
+end
+
+local linerBox = pl.class(SILE.types.node.hbox)
+function linerBox:_init (name, outputMethod)
+   SILE.types.node.hbox._init(self)
+   self.width = SILE.types.length()
+   self.height = SILE.types.length()
+   self.depth = SILE.types.length()
+   self.name = name
+   self.inner = {}
+   self.outputYourself = outputMethod
+end
+function linerBox:append (node)
+   self.inner[#self.inner + 1] = node
+   if node.is_discretionary then
+      -- Discretionary nodes don't have a width of their own.
+      if node.used then
+         if node.is_prebreak then
+            self.width:___add(node:prebreakWidth())
+         else
+            self.width:___add(node:postbreakWidth())
+         end
+      else
+         self.width:___add(node:replacementWidth())
+      end
+   else
+      self.width:___add(node.width:absolute())
+   end
+   self.height = SU.max(self.height, node.height)
+   self.depth = SU.max(self.depth, node.depth)
+end
+function linerBox:count ()
+   return #self.inner
+end
+function linerBox:outputContent (tsetter, line)
+   for _, node in ipairs(self.inner) do
+      node.outputYourself(node, tsetter, line)
+   end
+end
+function linerBox:__tostring ()
+   return "*L["
+      .. self.name
+      .. "]H<"
+      .. tostring(self.width)
+      .. ">^"
+      .. tostring(self.height)
+      .. "-"
+      .. tostring(self.depth)
+      .. "v"
+end
+
+--- Any unclosed liner is reopened on the current line, so we clone and repeat it.
+-- An assumption is that the inserts are done after the current slice content,
+-- supposed to be just before meaningful (visible) content.
+-- @tparam table slice Flat nodes from current line
+-- @treturn boolean Whether a liner was reopened
+function typesetter:_repeatEnterLiners (slice)
+   local m = self.state.liners
+   if #m > 0 then
+      for i = 1, #m do
+         local n = m[i]:clone()
+         slice[#slice + 1] = n
+         SU.debug("typesetter.liner", "Reopening liner", n)
+      end
+      return true
+   end
+   return false
+end
+
+--- All pairs of liners are rebuilt as hboxes wrapping their content.
+-- Migrating content, however, must be kept outside the hboxes at top slice level.
+-- @tparam table slice Flat nodes from current line
+-- @treturn table New reboxed slice
+function typesetter._reboxLiners (_, slice)
+   local outSlice = {}
+   local migratingList = {}
+   local lboxStack = {}
+   for i = 1, #slice do
+      local node = slice[i]
+      if node.is_enter then
+         SU.debug("typesetter.liner", "Start reboxing", node)
+         local n = linerBox(node.name, node.outputMethod)
+         lboxStack[#lboxStack + 1] = n
+      elseif node.is_leave then
+         if #lboxStack == 0 then
+            SU.error("Multiliner box stacking mismatch" .. node)
+         elseif #lboxStack == 1 then
+            SU.debug("typesetter.liner", "End reboxing", node, "(toplevel) =", lboxStack[1]:count(), "nodes")
+            if lboxStack[1]:count() > 0 then
+               outSlice[#outSlice + 1] = lboxStack[1]
+            end
+         else
+            SU.debug("typesetter.liner", "End reboxing", node, "(sublevel) =", lboxStack[#lboxStack]:count(), "nodes")
+            if lboxStack[#lboxStack]:count() > 0 then
+               local hbox = lboxStack[#lboxStack - 1]
+               hbox:append(lboxStack[#lboxStack])
+            end
+         end
+         lboxStack[#lboxStack] = nil
+         pl.tablex.insertvalues(outSlice, migratingList)
+         migratingList = {}
+      else
+         if #lboxStack > 0 then
+            if not node.is_migrating then
+               local lbox = lboxStack[#lboxStack]
+               lbox:append(node)
+            else
+               migratingList[#migratingList + 1] = node
+            end
+         else
+            outSlice[#outSlice + 1] = node
+         end
+      end
+   end
+   return outSlice -- new reboxed slice
+end
+
+--- Check if a node is a liner, and process it if so, in a stack.
+-- @tparam table node Current node (any type)
+-- @treturn boolean Whether a liner was opened
+function typesetter:_processIfLiner (node)
+   local entered = false
+   if node.is_enter then
+      SU.debug("typesetter.liner", "Enter liner", node)
+      self.state.liners[#self.state.liners + 1] = node
+      entered = true
+   elseif node.is_leave then
+      SU.debug("typesetter.liner", "Leave liner", node)
+      if #self.state.liners == 0 then
+         SU.error("Multiliner stack mismatch" .. node)
+      elseif self.state.liners[#self.state.liners].name == node.name then
+         self.state.liners[#self.state.liners].link = node -- for consistency check
+         self.state.liners[#self.state.liners] = nil
+      else
+         SU.error("Multiliner stack inconsistency" .. self.state.liners[#self.state.liners] .. "vs. " .. node)
+      end
+   end
+   return entered
+end
+
+function typesetter:_repeatLeaveLiners (slice, insertIndex)
+   for _, v in ipairs(self.state.liners) do
+      if not v.link then
+         local n = linerLeaveNode(v.name)
+         SU.debug("typesetter.liner", "Closing liner", n)
+         table.insert(slice, insertIndex, n)
+      else
+         SU.error("Multiliner stack inconsistency" .. v)
+      end
+   end
+end
+-- End of liner logic
+
+function typesetter:addrlskip (slice, margins, hangLeft, hangRight)
+   local LTR = self.frame:writingDirection() == "LTR"
+   local rskip = margins[LTR and "rskip" or "lskip"]
+   if not rskip then
+      rskip = SILE.types.node.glue(0)
+   end
+   if hangRight and hangRight > 0 then
+      rskip = SILE.types.node.glue({ width = rskip.width:tonumber() + hangRight })
+   end
+   rskip.value = "margin"
+   -- while slice[#slice].discardable do table.remove(slice, #slice) end
+   table.insert(slice, rskip)
+   table.insert(slice, SILE.types.node.zerohbox())
+   local lskip = margins[LTR and "lskip" or "rskip"]
+   if not lskip then
+      lskip = SILE.types.node.glue(0)
+   end
+   if hangLeft and hangLeft > 0 then
+      lskip = SILE.types.node.glue({ width = lskip.width:tonumber() + hangLeft })
+   end
+   lskip.value = "margin"
+   while slice[1].discardable do
+      table.remove(slice, 1)
+   end
+   table.insert(slice, 1, lskip)
+   table.insert(slice, 1, SILE.types.node.zerohbox())
+end
+
+function typesetter:breakpointsToLines (breakpoints)
+   local linestart = 1
+   local lines = {}
+   local nodes = self.state.nodes
+
+   for i = 1, #breakpoints do
+      local point = breakpoints[i]
+      if point.position ~= 0 then
+         local slice = {}
+         local seenNonDiscardable = false
+         local seenLiner = false
+         local lastContentNodeIndex
+
+         for j = linestart, point.position do
+            local currentNode = nodes[j]
+            if
+               not currentNode.discardable
+               and not (currentNode.is_glue and not currentNode.explicit)
+               and not currentNode.is_zero
+            then
+               -- actual visible content starts here
+               lastContentNodeIndex = #slice + 1
+            end
+            if not seenLiner and lastContentNodeIndex then
+               -- Any stacked liner (unclosed from a previous line) is reopened on
+               -- the current line.
+               seenLiner = self:_repeatEnterLiners(slice)
+               lastContentNodeIndex = #slice + 1
+            end
+            if currentNode.is_discretionary and currentNode.used then
+               -- This is the used (prebreak) discretionary from a previous line,
+               -- repeated. Replace it with a clone, changed to a postbreak.
+               currentNode = currentNode:cloneAsPostbreak()
+            end
+            slice[#slice + 1] = currentNode
+            if currentNode then
+               if not currentNode.discardable then
+                  seenNonDiscardable = true
+               end
+               seenLiner = self:_processIfLiner(currentNode) or seenLiner
+            end
+         end
+         if not seenNonDiscardable then
+            -- Slip lines containing only discardable nodes (e.g. glues).
+            SU.debug("typesetter", "Skipping a line containing only discardable nodes")
+            linestart = point.position + 1
+         else
+            local is_broken = false
+            if slice[#slice].is_discretionary then
+               -- The line ends, with a discretionary:
+               -- repeat it on the next line, so as to account for a potential postbreak.
+               linestart = point.position
+               -- And mark it as used as prebreak for now.
+               slice[#slice]:markAsPrebreak()
+               -- We'll want a "brokenpenalty" eventually (if not an orphan or widow)
+               -- to discourage page breaking after this line.
+               is_broken = true
+            else
+               linestart = point.position + 1
+            end
+
+            -- Any unclosed liner is closed on the next line in reverse order.
+            if lastContentNodeIndex then
+               self:_repeatLeaveLiners(slice, lastContentNodeIndex + 1)
+            end
+
+            -- BEGIN SILEX HANGED LINES
+            -- Track hanged lines
+            if self.state.hangAfter then
+               if self.state.hangAfter < 0
+                  and (point.left > 0 or point.right > 0) then
+                  -- count a hanged line
+                  self.state.hangAfter = self.state.hangAfter + 1
+               elseif self.state.hangAfter > 0
+                  and point.left == 0 and point.right == 0 then
+                  -- count a full line
+                  self.state.hangAfter = self.state.hangAfter - 1
+               end
+            end
+            -- END SILEX HANGED LINES
+
+            -- Then only we can add some extra margin glue...
+            local mrg = self:getMargins()
+            self:addrlskip(slice, mrg, point.left, point.right)
+
+            -- And compute the line...
+            local ratio = self:computeLineRatio(point.width, slice)
+
+            -- Re-shuffle liners, if any, into their own boxes.
+            if seenLiner then
+               slice = self:_reboxLiners(slice)
+            end
+
+            local thisLine = { ratio = ratio, nodes = slice, is_broken = is_broken }
+            lines[#lines + 1] = thisLine
+
+            -- BEGIN SILEX HANGED LINES
+            if self.state.hangAfter and self.state.hangAfter < 0 then
+               -- Mark the line as hanged so we can later add a penalty:
+               -- Surely we don't want a frame break in the middle of dropped
+               -- capitals &c.
+               thisLine.hanged = true
+            end
+            -- END SILEX HANGED LINES
+         end
+      end
+   end
+   if linestart < #nodes then
+      -- Abnormal, but warn so that one has a chance to check which bits
+      -- are missing at output.
+      SU.warn("Internal typesetter error " .. (#nodes - linestart) .. " skipped nodes")
+   end
+   return lines
+end
+
+function typesetter.computeLineRatio (_, breakwidth, slice)
+   local naturalTotals = SILE.types.length()
+
+   -- From the line end, account for the margin but skip any trailing
+   -- glues (spaces to ignore) and zero boxes until we reach actual content.
+   local npos = #slice
+   while npos > 1 do
+      if slice[npos].is_glue or slice[npos].is_zero then
+         if slice[npos].value == "margin" then
+            naturalTotals:___add(slice[npos].width)
+         end
+      else
+         break
+      end
+      npos = npos - 1
+   end
+
+   -- Due to discretionaries, keep track of seen parent nodes
+   local seenNodes = {}
+   -- CODE SMELL: Not sure which node types were supposed to be skipped
+   -- at initial positions in the line!
+   local skipping = true
+
+   -- Until end of actual content
+   for i = 1, npos do
+      local node = slice[i]
+      if node.is_box then
+         skipping = false
+         if node.parent and not node.parent.hyphenated then
+            if not seenNodes[node.parent] then
+               naturalTotals:___add(node.parent:lineContribution())
+            end
+            seenNodes[node.parent] = true
+         else
+            naturalTotals:___add(node:lineContribution())
+         end
+      elseif node.is_penalty and node.penalty == -inf_bad then
+         skipping = false
+      elseif node.is_discretionary then
+         skipping = false
+         local seen = node.parent and seenNodes[node.parent]
+         if not seen then
+            if node.used then
+               if node.is_prebreak then
+                  naturalTotals:___add(node:prebreakWidth())
+                  node.height = node:prebreakHeight()
+               else
+                  naturalTotals:___add(node:postbreakWidth())
+                  node.height = node:postbreakHeight()
+               end
+            else
+               naturalTotals:___add(node:replacementWidth():absolute())
+               node.height = node:replacementHeight():absolute()
+            end
+         end
+      elseif not skipping then
+         naturalTotals:___add(node.width)
+      end
+   end
+
+   local _left = breakwidth:tonumber() - naturalTotals:tonumber()
+   local ratio = _left / naturalTotals[_left < 0 and "shrink" or "stretch"]:tonumber()
+   ratio = math.max(ratio, -1)
+   return ratio, naturalTotals
+end
+
+function typesetter:chuck () -- emergency shipout everything
+   self:leaveHmode(true)
+   if #self.state.outputQueue > 0 then
+      SU.debug("typesetter", "Emergency shipout", #self.state.outputQueue, "lines in frame", self.frame.id)
+      self:outputLinesToPage(self.state.outputQueue)
+      self.state.outputQueue = {}
+   end
+end
+
+-- Logic for building an hbox from content.
+-- It returns the hbox and an horizontal list of (migrating) elements
+-- extracted outside of it.
+-- None of these are pushed to the typesetter node queue. The caller
+-- is responsible of doing it, if the hbox is built for anything
+-- else than e.g. measuring it. Likewise, the call has to decide
+-- what to do with the migrating content.
+local _rtl_pre_post = function (box, atypesetter, line)
+   local advance = function ()
+      atypesetter.frame:advanceWritingDirection(box:scaledWidth(line))
+   end
+   if atypesetter.frame:writingDirection() == "RTL" then
+      advance()
+      return function () end
+   else
+      return advance
+   end
+end
+function typesetter:makeHbox (content)
+   local recentContribution = {}
+   local migratingNodes = {}
+
+   self:pushState()
+   self.state.hmodeOnly = true
+   SILE.process(content)
+
+   -- We must do a first pass for shaping the nnodes:
+   -- This is also where italic correction may occur.
+   local nodes = self:shapeAllNodes(self.state.nodes, false)
+
+   -- Then we can process and measure the nodes.
+   local l = SILE.types.length()
+   local h, d = SILE.types.length(), SILE.types.length()
+   for i = 1, #nodes do
+      local node = nodes[i]
+      if node.is_migrating then
+         migratingNodes[#migratingNodes + 1] = node
+      elseif node.is_discretionary then
+         -- HACK https://github.com/sile-typesetter/sile/issues/583
+         -- Discretionary nodes have a null line contribution...
+         -- But if discretionary nodes occur inside an hbox, since the latter
+         -- is not line-broken, they will never be marked as 'used' and will
+         -- evaluate to the replacement content (if any)...
+         recentContribution[#recentContribution + 1] = node
+         l = l + node:replacementWidth():absolute()
+         -- The replacement content may have ascenders and descenders...
+         local hdisc = node:replacementHeight():absolute()
+         local ddisc = node:replacementDepth():absolute()
+         h = hdisc > h and hdisc or h
+         d = ddisc > d and ddisc or d
+      -- By the way it's unclear how this is expected to work in TTB
+      -- writing direction. For other type of nodes, the line contribution
+      -- evaluates to the height rather than the width in TTB, but the
+      -- whole logic might then be dubious there too...
+      else
+         recentContribution[#recentContribution + 1] = node
+         l = l + node:lineContribution():absolute()
+         h = node.height > h and node.height or h
+         d = node.depth > d and node.depth or d
+      end
+   end
+   self:popState()
+
+   local hbox = SILE.types.node.hbox({
+      height = h,
+      width = l,
+      depth = d,
+      value = recentContribution,
+      outputYourself = function (box, atypesetter, line)
+         local _post = _rtl_pre_post(box, atypesetter, line)
+         local ox = atypesetter.frame.state.cursorX
+         local oy = atypesetter.frame.state.cursorY
+         SILE.outputter:setCursor(atypesetter.frame.state.cursorX, atypesetter.frame.state.cursorY)
+         SU.debug("hboxes", function ()
+            -- setCursor is also invoked by the internal (wrapped) hboxes etc.
+            -- so we must show our debug box before outputting its content.
+            SILE.outputter:debugHbox(box, box:scaledWidth(line))
+            return "Drew debug outline around hbox"
+         end)
+         for _, node in ipairs(box.value) do
+            node:outputYourself(atypesetter, line)
+         end
+         atypesetter.frame.state.cursorX = ox
+         atypesetter.frame.state.cursorY = oy
+         _post()
+      end,
+   })
+   return hbox, migratingNodes
+end
+
+function typesetter:pushHlist (hlist)
+   for _, h in ipairs(hlist) do
+      self:pushHorizontal(h)
+   end
+end
+
+--- A liner is a construct that may span multiple lines.
+-- This is the user-facing method for creating such liners in packages.
+-- The content may be line-broken, and each bit on each line will be wrapped
+-- into a box.
+-- These boxes will be formatted according to some output logic.
+-- The output method has the same signature as the outputYourself method
+-- of a box, and is responsible for outputting the liner inner content with the
+-- outputContent(typesetter, line) method, possibly surrounded by some additional
+-- effects.
+-- If we are already in horizontal-restricted mode, the liner is processed
+-- immediately, since line breaking won't occur then.
+-- @tparam string name Name of the liner (useful for debugging)
+-- @tparam table content SILE AST to process
+-- @tparam function outputYourself Output method for wrapped boxes
+function typesetter:liner (name, content, outputYourself)
+   if self.state.hmodeOnly then
+      SU.debug("typesetter.liner", "Applying liner in horizontal-restricted mode")
+      local hbox, hlist = self:makeHbox(content)
+      local lbox = linerBox(name, outputYourself)
+      lbox:append(hbox)
+      self:pushHorizontal(lbox)
+      self:pushHlist(hlist)
+   else
+      self.state.linerCount = (self.state.linerCount or 0) + 1
+      local uname = name .. "_" .. self.state.linerCount
+      SU.debug("typesetter.liner", "Applying liner in standard mode")
+      local enter = linerEnterNode(uname, outputYourself)
+      local leave = linerLeaveNode(uname)
+      self:pushHorizontal(enter)
+      SILE.process(content)
+      self:pushHorizontal(leave)
+   end
+end
+
+--- Flatten a node list into just its string representation.
+-- @tparam table nodes Typeset nodes
+-- @treturn string Text reconstruction of the nodes
+local function _nodesToText (nodes)
+   -- A real interword space width depends on several settings (depending on variable
+   -- spaces being enabled or not, etc.), and the computation below takes that into
+   -- account.
+   local iwspc = SILE.shaper:measureSpace(SILE.font.loadDefaults({}))
+   local iwspcmin = (iwspc.length - iwspc.shrink):tonumber()
+
+   local string = ""
+   for i = 1, #nodes do
+      local node = nodes[i]
+      if node.is_nnode or node.is_unshaped then
+         string = string .. node:toText()
+      elseif node.is_glue or node.is_kern then
+         -- What we want to avoid is "small" glues or kerns to be expanded as full
+         -- spaces.
+         -- Comparing them to half of the smallest width of a possibly shrinkable
+         -- interword space is fairly fragile and empirical: the content could contain
+         -- font changes, so the comparison is wrong in the general case.
+         -- It's a simplistic approach. We cannot really be sure what a "space" meant
+         -- at the point where the kern or glue got absolutized.
+         if node.width:tonumber() > iwspcmin * 0.5 then
+            string = string .. " "
+         end
+      elseif not (node.is_zerohbox or node.is_migrating) then
+         -- Here, typically, the main case is an hbox.
+         -- Even if extracting its content could be possible in some regular cases
+         -- we cannot take a general decision, as it is a versatile object  and its
+         -- outputYourself() method could moreover have been redefined to do fancy
+         -- things. Better warn and skip.
+         SU.warn("Some content could not be converted to text: " .. node)
+      end
+   end
+   -- Trim leading and trailing spaces, and simplify internal spaces.
+   return pl.stringx.strip(string):gsub("%s%s+", " ")
+end
+
+--- Convert a SILE AST to a textual representation.
+-- This is similar to SU.ast.contentToString(), but it performs a full
+-- typesetting of the content, and then reconstructs the text from the
+-- typeset nodes.
+-- @tparam table content SILE AST to process
+-- @treturn string Textual representation of the content
+function typesetter:contentToText (content)
+   self:pushState()
+   self.state.hmodeOnly = true
+   SILE.process(content)
+   local text = _nodesToText(self.state.nodes)
+   self:popState()
+   return text
+end
+
+return typesetter


### PR DESCRIPTION
 - Switch to GNU GPL v3 license
 - Refactoring as sketched in https://github.com/Omikhleia/silex.sile/issues/23:
    - Removal of the dependency on **silex.ast**
    - Removal of the dependency on SILE's plain class (for easier inheritance tree before more refactors)
    - Move the **fancytoc** module into resilient (as "resilient.fancytoc"), with silex removed and code modernized
    - Move the **printoptions** module into resilient (kept as "printoptions"), with silex removed and code modernized
    - Removal of the dependency on **silex** for class/typesetter overrides
       - We no longer monkey-patch the whole base class but use inheritance to just bring a few of the former hacks
       - The typesetter (now "typesetters.silent") is still a full-copied monkey-patched version but at least it's here and we can start dropping the rest of silex.
       - Still some weird/fragile stuff in place (e.g. multiple instantiation cancellation still has to be effective). Walking on eggs...

Closes #128 