### PR TITLE
Clarify some licensing concerns on template, style files and ouput

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,9 +18,15 @@ The _re·sil·ient_ project owes a lot to the SILE Typesetter project, and on a 
 
 ### License grants for submitted documentation
 
-By submitting documentation, you agree to license your contribution under the same license as the project (CC-BY-SA 2.0 or any other license that is compatible with the CC-BY-SA 2.0 license). This means that your documentation will be available for others to use, modify, and distribute under the same terms as the project itself.
+By submitting documentation, you agree to license your contribution under the same license as the project (CC-BY-SA 2.0 or any other license that is compatible with the CC-BY-SA 2.0 license). This means that your documentation will be available for others to use, modify, and distribute under the same terms as the project documentation itself.
 
 By documentation, we mean any text, images, or other content that you submit to the project, including but not limited to README files, user guides, and other in-code documentation content.
+
+### License grants for submitted templates
+
+By submitting templates (notably used for "book matters" such as cover pages, title and half-title pages, endpapers, etc.), you agree to license your contribution under CC0 Universal / Public Domain. This means that your templates will be available for others to use, modify, and distribute unumcumbered of constraints.
+
+The rationale for this is that such templates should be considered as data files, which will likely be copied and used with or without modification by authors and editors in their books, and that users should not be constrained by any license or copyright regarding the output of processing their original content with _re·sil·ient_ when using such templates.
 
 ## Issues first, Pull Requests later
 

--- a/README.md
+++ b/README.md
@@ -85,13 +85,12 @@ Please check their respective license or ask, in case of doubts, for details and
 
 The [templates for some book parts](./templates/README.md) are licensed under CC0 Universal / Public Domain, as well as some convenience [schemas](./schemas/README.md) for interoperability and ease of use.
 
-It should go without saying, but the above licenses apply to the source code of the program, and not to typeset documents produced with it.
-Documents typeset using this collection remain under the license and copyright of their respective authors, i.e. the authors of the input files.
+It should go without saying, but the above licenses apply to the source code and documentation of the program, and not to typeset documents produced with it.
+Documents composed using this solution remain subject to the terms and conditions set forth by respective copyright holders, i.e. the copyright holders of the original material (documents and assets)
+
 The outputs of the typesetting process encompass several generated files, besides the final PDF document (or other output format that SILE can produce).
 They include converted images, temporary files indexes and table of contents, etc.
 In particular, style definition files are also generated, with a content varying depending on the packages and classes used.
 Such generated files are also outside the scope of the source code license, and are not covered by it.
 
 Would you want to credit this collection in your works, you are free to do so, but it is not required in any way.
-
-In brief, documents typeset using this collection remain under the license and copyright of their respective authors, i.e. the authors of the input files.

--- a/README.md
+++ b/README.md
@@ -82,3 +82,16 @@ The documentation is under CC-BY-SA 2.0.
 
 The examples (i.e. anythings in the “example” folder) have varying licenses and some are used by courtesy of the authors.
 Please check their respective license or ask, in case of doubts, for details and exact licensing terms.
+
+The [templates for some book parts](./templates/README.md) are licensed under CC0 Universal / Public Domain, as well as some convenience [schemas](./schemas/README.md) for interoperability and ease of use.
+
+It should go without saying, but the above licenses apply to the source code of the program, and not to typeset documents produced with it.
+Documents typeset using this collection remain under the license and copyright of their respective authors, i.e. the authors of the input files.
+The outputs of the typesetting process encompass several generated files, besides the final PDF document (or other output format that SILE can produce).
+They include converted images, temporary files indexes and table of contents, etc.
+In particular, style definition files are also generated, with a content varying depending on the packages and classes used.
+Such generated files are also outside the scope of the source code license, and are not covered by it.
+
+Would you want to credit this collection in your works, you are free to do so, but it is not required in any way.
+
+In brief, documents typeset using this collection remain under the license and copyright of their respective authors, i.e. the authors of the input files.

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -1,0 +1,36 @@
+# YAML Schemas
+
+This folder contains YAML schemas for master documents and style definition files.
+
+## Intended use
+
+When (re)generated, style files start with a comment block:
+
+```yaml
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Omikhleia/resilient.sile/v2.8.0/schemas/stylefile.json
+# $schema: https://raw.githubusercontent.com/Omikhleia/resilient.sile/v2.8.0/schemas/stylefile.json
+```
+
+It's a comment, so it has no effect, right? Well, it is actually a hint for external tools that can read and understand JSON schemas.
+
+If your preferred text editor supports an appropriate YAML language server, it will be able to provide you with auto-completion and validation based on the schema. This is a small but useful feature that can help you write your style files more efficiently.
+
+Likewise, you can also (manually) add a similar comment block to your master documents:
+
+```yaml
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Omikhleia/resilient.sile/v2.8.0/schemas/masterfile.json
+# $schema: https://raw.githubusercontent.com/Omikhleia/resilient.sile/v2.8.0/schemas/masterfile.json
+```
+
+With editors that support it, you can then benefit from auto-completion and validation for your master documents as well.
+
+This is known to work with **Visual Studio Code**, with the [YAML Language Support by Red Hat](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml) extension. Other editors and plugins may also support this feature.
+
+This is a non-essential feature, but it can be a nice addition to your workflow if you are using such tools.
+It might still be somewhat experimental, and the actual code is actually more permissive than the schema, but it should be a good starting point.
+
+## License
+
+These schemas are not considered as source code, but rather as documentation / interface definition files, for interoperability and ease of use.
+
+As such, they are licensed under **CC0 Universal / Public Domain**.

--- a/templates/README.md
+++ b/templates/README.md
@@ -1,0 +1,13 @@
+# Templates
+
+This folder contains default templates notably used for "book matters" (cover pages, title and half-title pages, endpapers, etc.).
+
+All these templates are licensed under **CC0 Universal / Public Domain**.
+
+As explained in the User Guide, authors are totally free to use their own templates, and can override the default ones by providing their own templates and use them in their works (e.g. usually in their master documents).
+
+This being said, the default templates can be used as they are.
+
+Obviously, it should go without saying, but using the default templates does not require any special mention in your documents, and does not affect the license of your documents in any way.
+
+Note that the default "endpaper" verso template includes a small mention "This book is typeset with the SILE typesetting system and the _re·sil·ient_ collection of classes & packages." This is **not** a requirement for any work produced using this collection, and you are entirely free not to have such a mention in your own templates and generated documents. While credit is always appreciated, as far as we are concerned, we do not require it, neither for SILE nor for the _re·sil·ient_ collection.


### PR DESCRIPTION
Part of #131 

 - Exclude template files by making them CC0 + the default mention (crediting SILE and resilient) is not mandatory by any mean.
 - Exclude YAML schemas by making them CC0 = they are just convenience files currently, but in the future we may use a dynamic parser/validator to replace the current Lua hand-made code, so let's plan ahead.
 - Exclude typeset documents (obviously...) and related generated files (typically, generated style definition files are data files, not code, but let's word things correctly here too.