### PR TITLE
Additional page layouts

### DIFF
--- a/guides/resilient/manual-layouts/layouts-predefined.dj
+++ b/guides/resilient/manual-layouts/layouts-predefined.dj
@@ -193,6 +193,25 @@ The `geometry` layout allows explicitly setting the page margins, as either a pa
 :::
 ^ Be my guests — arbitrary margins.
 
+{.notoc}
+### Bringhurst’s layout for 1:√3 pages
+
+In his book _The Elements of Typographic Style_, Robert Bringhurst used a page size in the 1:√3 ratio.
+He designed an elegant layout for this uncommon page size, based on several geometric proportions.
+Below is an approximation of the layout, applied to a 6in × 10.4in page.[^bringhurst-approximate]
+
+[^bringhurst-approximate]: The layout also specifies where the folio footer should be placed, and includes other guidelines for paragraphs.
+Our implementation does not take these into account.
+
+:::
+``` =sile
+\showlayout[layout=bringhurst, papersize=6in x 10.4in]
+```
+:::
+^ Bringhurst’s elegant layout for unconventional 1:√3 pages.
+
+By definition, this layout was specifically designed for 1:√3 pages, and is not suitable for other page sizes.
+
 ## Summary table
 
 | Layout option                   | Description                                          |
@@ -218,4 +237,5 @@ The `geometry` layout allows explicitly setting the page margins, as either a pa
 | `none`                          | Centered with margins at 1/6^th^                     |
 | `geometry V H`                  | Vertical margin, horizontal margin                   |
 | `geometry H I F O`              | Head margin, inner margin, foot margin, outer margin |
+| `bringhurst`                    | Bringhurst’s layout for 1:√3 pages                   |
 ^ Off-the-shelf layouts at a glance.

--- a/guides/resilient/manual-layouts/layouts-predefined.dj
+++ b/guides/resilient/manual-layouts/layouts-predefined.dj
@@ -119,6 +119,35 @@ It is provided here as `canonical`.
 :::
 ^ Jan Tschichold's canonical layout.
 
+## Bringhurst’s improved layouts for ISO formats
+
+Compared to the usual formats of printed books, ISO formats (A4, A5, etc.) are perceived as large, with their 1:√2 ratio.
+Jan Tschichold did not think much of them, for their lack of dynamism.
+Robert Bringhurst proposed a method to create a more dynamic text block, with proportions close to the golden ratio (1.618), and margins in the 1:2 ratio.
+The inner and top margin are set to 1/9^th^ of the page width, and the outer and bottom margins to 2/9^th^ of the page width.
+This layout is provided as `isophi 9`.
+
+:::
+``` =sile
+\showlayout[layout=isophi 9, papersize=a5]
+```
+:::
+^ ISO-$`\phi` layout (1/9^th^ and 2/9^th^ margin ratios).
+
+Bringhurst also proposed a variant with wider inner and top margins, set to 1/8^th^ of the page width, and the outer and bottom margins to 15/72^th^ of the page width.
+It retains similar proportions for the text block.
+In addition, the ratio between the inner and outer margins, and the top and bottom margins, is 1.67, which is also closer to the golden ratio.
+This improved layout is provided as `isophi 8` or simply `isophi`.
+
+:::
+``` =sile
+\showlayout[layout=isophi, papersize=a5]
+```
+:::
+^ ISO-$`\phi` improved layout (1/8^th^ and 15/72^th^ margin ratios).
+
+By definition, these layouts were specifically designed for ISO formats, and are not suitable for other page sizes.
+
 ## Non-standard layouts
 
 {.notoc}
@@ -182,6 +211,8 @@ The `geometry` layout allows explicitly setting the page margins, as either a pa
 | `division N`                    | Division by _N_, _H/W_ ratio                         |
 | `division N v`                  | Division by _N_, _v_ ratio                           |
 | `canonical`                     | Tschichold’s golden canon                            |
+| `isophi` = `isophi 8`           | ISO-$`\phi`, 1/8^th^ and 15/72^th^ margins           |
+| `isophi 9`                      | ISO-$`\phi`, 1/9^th^ and 2/9^th^ margins             |
 | `marginal` = `marginal 8`       | Wide outer margin, other at 1/8^th^                  |
 | `marginal N`                    | Wide outer margin, other at 1/_N_ ^th^               |
 | `none`                          | Centered with margins at 1/6^th^                     |

--- a/resilient/layoutparser.lua
+++ b/resilient/layoutparser.lua
@@ -19,6 +19,7 @@ local layoutParser = P{
            + V"division" + V"honnecourt" + V"vencentinus"
            + V"ateliers"
            + V"isophi"
+           + V"bringhurst"
            + V"marginal") * P(-1),
   none = P("none") / function ()
     local layout = require("resilient.layouts.base")
@@ -28,11 +29,11 @@ local layoutParser = P{
     local layout = require("resilient.layouts.canonical")
     return layout()
   end,
-  honnecourt = P("honnecourt") / function()
+  honnecourt = P("honnecourt") / function ()
     local layout = require("resilient.layouts.division")
     return layout({ n = 9, ratio = 2 })
   end,
-  vencentinus = P("vencentinus") / function()
+  vencentinus = P("vencentinus") / function ()
     local layout = require("resilient.layouts.division")
     return layout({ n = 6, ratio = 2 })
   end,
@@ -41,7 +42,7 @@ local layoutParser = P{
       (ws * number * ws * number)
       + (ws * number)
       + (lpeg.Cc(9))
-    ) / function(n, ratio)
+    ) / function (n, ratio)
     local layout = require("resilient.layouts.division")
     return layout({ n = n, ratio = ratio })
   end,
@@ -49,16 +50,20 @@ local layoutParser = P{
     * (
         (ws * number)
         + lpeg.Cc(8)
-    ) / function(n)
+    ) / function (n)
     local layout = require("resilient.layouts.isophi")
     return layout({ n = n })
+  end,
+  bringhurst = P("bringhurst") / function ()
+    local layout = require("resilient.layouts.bringhurst")
+    return layout()
   end,
   marginal = P("marginal")
     * (
       (ws * number * ws * number)
       + (ws * number)
       + (lpeg.Cc(8))
-    ) / function(n, ratio)
+    ) / function (n, ratio)
     local layout = require("resilient.layouts.marginal")
     return layout({ n = n, ratio = ratio })
   end,
@@ -67,7 +72,7 @@ local layoutParser = P{
       (ws * C(V"quality") * ws * C(V"rule"))
       + (ws * C(V"quality"))
       + (lpeg.Cc("regular"))
-    ) / function(q, r)
+    ) / function (q, r)
     local layout = require("resilient.layouts.frenchcanon")
     return layout({ quality = q, rule = r })
   end,
@@ -77,7 +82,7 @@ local layoutParser = P{
   * (
     (ws * measurement * ws * measurement * ws * measurement * ws * measurement)
     + (ws * measurement * ws * measurement)
-  ) / function(head, inner, foot, outer)
+  ) / function (head, inner, foot, outer)
   local layout = require("resilient.layouts.geometry")
   return layout({ head = head, foot = foot or head, inner = inner, outer = outer or inner })
 end,

--- a/resilient/layoutparser.lua
+++ b/resilient/layoutparser.lua
@@ -18,6 +18,7 @@ local layoutParser = P{
            + V"canonical"
            + V"division" + V"honnecourt" + V"vencentinus"
            + V"ateliers"
+           + V"isophi"
            + V"marginal") * P(-1),
   none = P("none") / function ()
     local layout = require("resilient.layouts.base")
@@ -43,6 +44,14 @@ local layoutParser = P{
     ) / function(n, ratio)
     local layout = require("resilient.layouts.division")
     return layout({ n = n, ratio = ratio })
+  end,
+  isophi = P("isophi")
+    * (
+        (ws * number)
+        + lpeg.Cc(8)
+    ) / function(n)
+    local layout = require("resilient.layouts.isophi")
+    return layout({ n = n })
   end,
   marginal = P("marginal")
     * (

--- a/resilient/layouts/bringhurst.lua
+++ b/resilient/layouts/bringhurst.lua
@@ -1,0 +1,21 @@
+--
+-- Bringhurst's layout for pages in 1:√3 ratio.
+-- As used in his book "The Elements of Typographic Style".
+--
+-- License: MIT
+-- Copyright (C) 2025 Omikhleia / Didier Willis
+--
+local base = require("resilient.layouts.base")
+local isophi = pl.class(base)
+
+function isophi:_init (options)
+  base._init(self, options)
+  self.inner = "width(page) * " .. (1 / 9)
+  self.outer = "width(page) * " .. (2 / 9)
+  self.head = "height(page) * " .. (1 / 14)
+  self.foot = "height(page) * " .. (1 / 6)
+  -- With a page in 1:√3 ratio, the text area is 1:1.98 (= almost 1:2).
+  -- This layout is obviously not suitable for other page formats.
+end
+
+return isophi

--- a/resilient/layouts/isophi.lua
+++ b/resilient/layouts/isophi.lua
@@ -1,0 +1,32 @@
+--
+-- Bringhurst's proposed layout for ISO formats.
+-- Not supposed to be used with any other non ISO page sizes (1:√2 ratio).
+--
+-- License: MIT
+-- Copyright (C) 2025 Omikhleia / Didier Willis
+--
+local base = require("resilient.layouts.base")
+local isophi = pl.class(base)
+
+function isophi:_init (options)
+  base._init(self, options)
+  self.n = options.n
+  if self.n == 8 then
+    local N1 = 1 / 8
+    local N2 = 15 / 72 -- That's actually 2/9 - (1/8 - 1/9)
+    self.inner = "width(page) * " .. N1
+    self.outer = "width(page) * " .. N2
+    self.head = self.inner
+    self.foot = self.outer
+  elseif self.n == 9 then
+    local N = 1 / 9
+    self.inner = "width(page) * " .. N
+    self.outer = "width(page) * " .. 2 * N
+    self.head = self.inner
+    self.foot = self.outer
+  else
+    SU.error("Layout 'isophi' only supports a base ratio of 8 or 9")
+  end
+end
+
+return isophi

--- a/rockspecs/resilient.sile-dev-1.rockspec
+++ b/rockspecs/resilient.sile-dev-1.rockspec
@@ -72,6 +72,7 @@ build = {
     ["sile.resilient.layouts.frenchcanon"] = "resilient/layouts/frenchcanon.lua",
     ["sile.resilient.layouts.geometry"]    = "resilient/layouts/geometry.lua",
     ["sile.resilient.layouts.marginal"]    = "resilient/layouts/marginal.lua",
+    ["sile.resilient.layouts.isophi"]      = "resilient/layouts/isophi.lua",
 
     ["sile.resilient.adapters.frameset"] = "resilient/adapters/frameset.lua",
 

--- a/rockspecs/resilient.sile-dev-1.rockspec
+++ b/rockspecs/resilient.sile-dev-1.rockspec
@@ -73,6 +73,7 @@ build = {
     ["sile.resilient.layouts.geometry"]    = "resilient/layouts/geometry.lua",
     ["sile.resilient.layouts.marginal"]    = "resilient/layouts/marginal.lua",
     ["sile.resilient.layouts.isophi"]      = "resilient/layouts/isophi.lua",
+    ["sile.resilient.layouts.bringhurst"]  = "resilient/layouts/bringhurst.lua",
 
     ["sile.resilient.adapters.frameset"] = "resilient/adapters/frameset.lua",
 


### PR DESCRIPTION
Closes #137 

 - Bringhurst's proposed layouts for ISO formats (A4, A5 etc.), a.k.a. ISO-𝜙 layouts.
 - Bringhurst's layout for 1:√3 pages 

See also [this blog post](https://dcao-sarl.odoo.com/blog/blogue-a-part-2/reussir-une-mise-en-page-lempagement-3-7) (which I found a bit easier to understand than Bringhurst's own explanations, but heh, it's in my native language) - it's also where I picked the "isophi" name, which sounds fairly adequate.