### PR TITLE
fix(typesetter,packages): Prevent fragile commands from leaking

### DIFF
--- a/classes/resilient/book.lua
+++ b/classes/resilient/book.lua
@@ -181,6 +181,13 @@ function class:_init (options)
       SILE.call("style:apply:number", { name = stylename, text = text })
     end
   end)
+  -- TRANSITIONAL FIXME: These packages should do it themselves eventually,
+  -- with a proper interface to declare commands as contextual.
+  -- Here, there's also a strong reason that packages are not "reloaded" (and their commands reset)
+  -- (which we cancel in our override superclass)
+  SILE.resilient.enforceContextualCommand("footnote")
+  SILE.resilient.enforceContextualCommand("label")
+  SILE.resilient.enforceContextChangingCommand("ref", "ref")
 end
 
 function class:declareOptions ()

--- a/classes/resilient/override.lua
+++ b/classes/resilient/override.lua
@@ -6,16 +6,15 @@
 -- Copyright (C) 2023-2025 Omikhleia / Didier Willis
 --
 
--- INPUTTERS
+-- BOOTSTRAP GLOBAL OVERRIDES
 -- This ensure our inputters are loaded, so one can \include files of the relevant format
 -- afterwards, without having to load the inputter first.
+-- This also tweaks some SILE core behavior.
 -- In our setup notes, we recommended users to define an alias to run sile with the
 -- resilient bootstrap file loaded, e.g.:
 --   alias resilient='sile -e "require('"'"'resilient.bootstrap'"'"')"'
 -- So this should be already done, but we ensure it here anyway in case
 -- the user did not do so.
-
-SU.debug("resilient.override", "Ensuring extra inputters are loaded")
 require("resilient.bootstrap")
 
 -- BASE CLASS OVERLOAD

--- a/packages/resilient/fancytoc/init.lua
+++ b/packages/resilient/fancytoc/init.lua
@@ -32,19 +32,6 @@ local function getMinLevel (toc)
   return smallest.level
 end
 
-local function cancelFragile (func)
-    -- Temporarilly kill footnotes and labels (fragile)
-    local oldFt = SILE.Commands["footnote"]
-    SILE.Commands["footnote"] = function () end
-    local oldLbl = SILE.Commands["label"]
-    SILE.Commands["label"] = function () end
-
-    func()
-
-    SILE.Commands["footnote"] = oldFt
-    SILE.Commands["label"] = oldLbl
-end
-
 function package:findToc (packages)
   if self._toc then return self._toc end -- memoized
 
@@ -88,7 +75,7 @@ function package:registerCommands ()
       SILE.settings:set("current.parindent", SILE.types.node.glue())
       SILE.settings:set("document.parindent", SILE.types.node.glue())
 
-      cancelFragile(function ()
+      SILE.resilient.cancelContextualCommands("toc", function ()
         -- Quick and dirty for now...
         -- TODO: We have the link only on pages, but would want it eventually on titles
         -- too, but this requires multi-line link support.

--- a/packages/resilient/headers/init.lua
+++ b/packages/resilient/headers/init.lua
@@ -61,18 +61,12 @@ function package:outputHeader (headerContent, frame)
           SILE.settings:set("document.lskip", SILE.types.node.glue())
           SILE.settings:set("document.rskip", SILE.types.node.glue())
 
-          -- Temporarilly kill footnotes and labels (fragile)
-          local oldFt = SILE.Commands["footnote"]
-          SILE.Commands["footnote"] = function() end
-          local oldLbl = SILE.Commands["label"]
-          SILE.Commands["label"] = function () end
-
-          SILE.process(headerContent)
+          -- Process the header content in a context where fragile commands are ignored.
+          SILE.resilient.cancelContextualCommands("header", function ()
+            SILE.process(headerContent)
+          end)
 
           SILE.typesetter:leaveHmode()
-
-          SILE.Commands["footnote"] = oldFt
-          SILE.Commands["label"] = oldLbl
           SILE.settings:popState()
         end
 

--- a/resilient/bootstrap.lua
+++ b/resilient/bootstrap.lua
@@ -1,5 +1,81 @@
--- Enforce all inputters to be loaded, so that the user can use them directly
+--
+-- Bootstrap code for the resilient classes and packages.
+--
+-- License: MIT
+-- Copyright (C) 2025 Omikhleia / Didier Willis
+--
+
+-- Enforce all inputters to be loaded, so that the user can use them directly.
+SU.debug("resilient.bootstrap", "Ensuring extra inputters are loaded")
+
 pcall(function () local _ = SILE.inputters.silm end)
 pcall(function () local _ = SILE.inputters.markdown end)
 pcall(function () local _ = SILE.inputters.djot end)
 pcall(function () local _ = SILE.inputters.pandocast end)
+
+-- FIXME TRANSITIONAL
+-- Create the global SILE.resilient namespace, with some state and helper functions.
+SILE.resilient = {
+   state = {},
+}
+
+--- Temporarilly cancels "fragile" commands (normally, such as like footnotes and labels).
+-- Such commands break when used in moving arguments (like table of contents entries, headers, etc.)
+-- The need to cancel them derives from the fact that AST content is stored and reused in different contexts.
+-- For instance, consider a title that contains a footnote.
+-- The title AST is stored in the TOC, and reused when typesetting the TOC.
+-- The footnote command would try to create a footnote at that point, which is not what one expects.
+-- @tparam function func The function to execute without fragile commands
+-- @tparam string context A context identifier corresponding to the suppression purpose
+function SILE.resilient.cancelContextualCommands (context, func)
+  local oldContext = SILE.resilient.state.contextFor -- Nesting occurs, e.g. from toc to header and back
+  SU.debug("resilient", "Cancelling contextual commands in context", context, "from", oldContext or "<none>")
+  SILE.resilient.state.contextFor = context
+  func()
+  SILE.resilient.state.contextFor = oldContext
+end
+
+---- Make a command "robust", i.e. ignore it in certain contexts.
+-- This is useful for commands that are known to be "fragile", such as footnotes and labels.
+--
+-- TRANSITIONAL: This is for enforcing existing commands to be robust, when they were not
+-- declared as such initially.
+-- @tparam string command The command name to make robust
+function SILE.resilient.enforceContextualCommand (command)
+  local oldCmd = SILE.Commands[command]
+  if not oldCmd then
+    SU.error("Cannot make unknown command '" .. command .. "' contextual")
+  end
+  SILE.Commands[command] = function (options, content)
+    local context = SILE.resilient.state.contextFor
+    if not context then
+      return oldCmd(options, content)
+    else
+      SU.debug("resilient", "Skipping contextual command", command, "in context", context)
+    end
+  end
+end
+
+---- Make a command context-switching, i.e. some of its processing needs needs
+-- to run in a context where fragile commands are ignored.
+-- This is useful for commands that are not fragile per se, but that process
+-- content that may contain fragile commands, such as label refs.
+--
+-- TRANSITIONAL: This is for enforcing existing commands to be context-switching,
+-- when they dit not invoke the cancellation of fragile commands initially when processing
+-- content.
+-- @tparam string context A context identifier corresponding to the suppression purpose
+-- @tparam string command The command name to make context-switching
+function SILE.resilient.enforceContextChangingCommand(context, command)
+  local oldCmd = SILE.Commands[command]
+  if not oldCmd then
+    SU.error("Cannot make unknown command '" .. command .. "' context-switching")
+  end
+  SILE.Commands[command] = function (options, content)
+    local ret
+    SILE.resilient.cancelContextualCommands(context, function ()
+      ret = oldCmd(options, content)
+    end)
+    return ret
+  end
+end


### PR DESCRIPTION
Fragile commands (e.g., footnotes, labels) could previously leak into PDF bookmarks, headers, or cross-references, causing duplicate entries or artifacts in the repeated text, despite attempts to cancel them.

This commit enforces a more aggressive, context-based cancellation. The current implementation is transitional until some dependencies are upgraded to use a more robust define API.

Example Djot document:

```
{#title}
## Hello[^1] World

Lorem, see "[](#title){.title}"

[^1]: Note here on [](#title){.title}

## Regarding [](#title){.title}...

Lorem.

:_TOC_:

:_FANCYTOC_:
```

Expected:

<img width="1343" height="520" alt="image" src="https://github.com/user-attachments/assets/d6403bab-cab0-4fb8-8388-5ec2035e1289" />

 - No leak of the footnote to the header/bookmarks/tableofcontents
 - Idem for the cross-reference to a section with footnote

Observed:
Cancelling (= voiding) a few "known commands" at various places was:
 - Repeating code
 - By nature "ad-hoc" in what it cancelled in an hard-coded way
 - Incomplete, an some leak still occurred (esp. via `contentToText()` and cross-references) = **bugs** (e.g., either repeated footnotes or footnote call occurring in inadequate places).

Solution:
We can at least draft a slightly better approach here.
This is somewhat transitional:
We could do better, by providing an API for other dependencies to subscribe to, but it also mean we'd have to make it clean, and update those dependencies (e.g. **labelrefs.sile** comes to mind).
For now, implement a minimal conservative approach that fixes the issue until we can tackle with it more thoroughly. It's something that _should_ eventually be part of SILE core (with e.g. a dedicated command registration, etc.), IMHO...
But for now let's move forward, play with it, and see how it fares...