### PR TITLE
fix(packages): Avoid ToC link destinations to mess with the indexer links

### DIFF
--- a/packages/resilient/tableofcontents/init.lua
+++ b/packages/resilient/tableofcontents/init.lua
@@ -191,7 +191,7 @@ function package:registerCommands ()
   self:registerCommand("tocentry", function (options, content)
     local dest
     if SILE.Commands["pdf:destination"] then
-      dest = "dest" .. dc
+      dest = "resilient.toc:" .. dc
       SILE.call("pdf:destination", { name = dest })
       if SU.boolean(options.bookmark, true) then
         local title = SILE.typesetter:contentToText(content)


### PR DESCRIPTION
Going for the "quick win" solution, using our own prefix as sort of a namespace.

Closes #146 