### PR TITLE
Refactor knuth plass line breaker

### DIFF
--- a/classes/resilient/override.lua
+++ b/classes/resilient/override.lua
@@ -38,7 +38,7 @@ class._name = "resilient.override"
 local forbiddenPackages = {
    -- Our autodoc-resilient should be used instead.
    -- We don't want partial half-loading of packages via the standard autodoc package.
-   -- It brreaks to many things, incl. our style-aware packages.
+   -- It breaks too many things, incl. our style-aware packages.
    autodoc = true,
    -- Integrated in the sile·nt typesetter natively.
    bidi = true,
@@ -47,6 +47,9 @@ local forbiddenPackages = {
    ['break-firstfit'] = true,
    grid = true,
    linespacing = true,
+   -- This package would also interfere interfere with sile·nt and/or page·ant.
+   -- Also disable as it required a modified knuth-plass line-breaking algorithm,
+   -- and re·sil·ient moved back to a more standard implementation of the latter.
    ['pagebuilder-bestfit'] = true,
    -- This package is for SILE's own backward compatibility.
    -- As re·sil·ient use its own package/class hierarchy, we do not want

--- a/classes/resilient/override.lua
+++ b/classes/resilient/override.lua
@@ -52,6 +52,11 @@ local forbiddenPackages = {
    -- As re·sil·ient use its own package/class hierarchy, we do not want
    -- this module to be loaded and mess with things that never applied to re·sil·ient.
    retrograde = true,
+   -- Experimental SILE package that never worked and required a modified knuth-plass
+   -- line-breaking algorithm.
+   -- Disabled as re·sil·ient moved back to a more standard implementation of the
+   -- latter.
+   gutenberg = true,
 }
 
 --- (Constructor) Initialize the class.

--- a/classes/resilient/override.lua
+++ b/classes/resilient/override.lua
@@ -52,6 +52,11 @@ local forbiddenPackages = {
    -- As re·sil·ient use its own package/class hierarchy, we do not want
    -- this module to be loaded and mess with things that never applied to re·sil·ient.
    retrograde = true,
+   -- Experimental SILE package that never worked and required a modified knuth-plass
+   -- line-breaking algorithm.
+   -- Disabled as re·sil·ient moved back to a more standard implementation of the
+   -- latter.
+   gutenberg = true,
 }
 
 -- Vendored variants of standard SILE packages:

--- a/typesetters/algorithms/knuthplass.lua
+++ b/typesetters/algorithms/knuthplass.lua
@@ -1,29 +1,32 @@
 --- (Modified) Knuth-Plass line breaking algorithm.
 --
--- TEX82 comments and numbers refer to https://tug.ctan.org/info/knuth-pdf/tex/tex.pdf
--- (At the time of writing, the linked document indicates March 12, 2025 15:39 as the date of generation).
+-- TEX82 comments and numbers refer to <https://tug.ctan.org/info/knuth-pdf/tex/tex.pdf>
+-- (At the time of writing, the linked document indicates March 12, 2025 15:39 as date of generation).
 --
--- PDFTeX comments and numbers refer to https://tug.ctan.org/info/knuth-pdf/pdftex/pdftex.pdf
--- (At the time of writing, the linked document indicates March 12, 2025 15:39 as the date of generation).
--- The latter has the "doLastLineFit" extension from e-TeX (not implemented here yet)
--- and several other PDFTeX-specific extensions (not implemented here by design).
+-- PDFTeX comments and numbers refer to <https://tug.ctan.org/info/knuth-pdf/pdftex/pdftex.pdf>
+-- (At the time of writing, the linked document indicates March 12, 2025 15:39 as date of generation).
+-- The latter has the "doLastLineFit" extension from ε-TeX (see comments below),
+-- and several other PDFTeX-specific extensions (not implemented here).
 --
 -- SILE comments refer to SILE's change to the original algorithm.
 --
 -- Interesting other references for readers:
 --
---   - https://tug.ctan.org/macros/luatex/latex/linebreaker/linebreaker-doc.pdf
---   - https://www.latex-project.org/publications/2012-FMi-TUB-tb106mittelbach-e-tex-revisited.pdf
---
+--   - <https://tug.ctan.org/macros/luatex/latex/linebreaker/linebreaker-doc.pdf>
+--   - <https://www.latex-project.org/publications/2012-FMi-TUB-tb106mittelbach-e-tex-revisited.pdf>
 --
 -- **Original code from SILE**
 --
 -- License: MIT
 -- Copyright (c) The SILE Organization / Simon Cozens
 --
--- **Modified see RESILIENT comments**
+-- **Modified**
 --
---  - Removed non-stantard "alternates" nodes (SILE's gutenberg non-working packages)
+--  - See RESILIENT comments for adaptations to work with the sile·nt typesetter.
+--  - Removed non-stantard "alternates" nodes (SILE's `gutenberg` non-working packages).
+--  - Refactored based on TeX82 and PDFTeX documentation, with comments (partial pass)
+--  - Notably added comments for non-implemented parts (doLastLineFit), but perhaps not all yet.
+--  - Removed some dead code or hard-to-follow debug code absent from the original algorithm
 --
 -- License: MIT
 -- Copyright (c) 2025 Omikhleia / Didier Willis
@@ -49,16 +52,28 @@ SILE.settings:declare({
 SILE.settings:declare({ parameter = "linebreak.looseness", type = "integer", default = 0 })
 SILE.settings:declare({ parameter = "linebreak.prevGraf", type = "integer", default = 0 })
 SILE.settings:declare({ parameter = "linebreak.emergencyStretch", type = "measurement", default = 0 })
-SILE.settings:declare({ parameter = "linebreak.doLastLineFit", type = "boolean", default = false }) -- unimplemented
 SILE.settings:declare({ parameter = "linebreak.linePenalty", type = "integer", default = 10 })
 SILE.settings:declare({ parameter = "linebreak.hyphenPenalty", type = "integer", default = 50 })
 SILE.settings:declare({ parameter = "linebreak.doubleHyphenDemerits", type = "integer", default = 10000 })
 SILE.settings:declare({ parameter = "linebreak.finalHyphenDemerits", type = "integer", default = 5000 })
 
+-- Not implemented yet,
+-- But erroneous definition here, the boolean is internal, and the \lastlinefit primitive
+-- from ε-TEX sets it to an integer value: For a value of 0 or less, ε-TEX behaves as TEX, values from 1
+-- to 1000 indicate a glue adjustment fraction f times 1000, values above 1000 are
+-- interpreted as f = 1
+SILE.settings:declare({ parameter = "linebreak.doLastLineFit", type = "boolean", default = false }) -- unimplemented,
+
 -- doubleHyphenDemerits
 -- hyphenPenalty
 
-local classes = { "tight", "decent", "loose", "veryLoose" }
+-- (TeX82 817; PDFTeX 993)
+local TIGHT_FIT = 3 -- fitness classification for lines shrinking 0.5 to 1.0 of their shrinkability
+local LOOSE_FIT = 1 -- fitness classification for lines stretching 0.5 to 1.0 of their stretchability
+local VERY_LOOSE_FIT = 0 -- fitness classification for lines stretching more than their stretchability
+local DECENT_FIT = 2 -- fitness classification for all other lines
+
+local classes = { TIGHT_FIT, DECENT_FIT, LOOSE_FIT, VERY_LOOSE_FIT }
 local passSerial = 0
 local awful_bad = 1073741823
 local inf_bad = 10000
@@ -94,17 +109,38 @@ local debugging = false
 local lineBreak = {}
 
 --- Initialize the line breaker.
+--
+-- CHECK (TeX82 816; PDFTeX 992).
 function lineBreak:init ()
-   self:trimGlue() -- 842
+   self:trimGlue() -- See (TeX82 816; PDFTeX 992)
    -- 849
    self.activeWidth = SILE.types.length()
    self.curActiveWidth = SILE.types.length()
    self.breakWidth = SILE.types.length()
-   -- 853
+
+   -- BEGIN (TeX82 827; PDFTeX 1003)
+   -- NOTE: More or less... TeX uses lots of registers here, no very clear.
    local rskip = (SILE.settings:get("document.rskip") or SILE.types.node.glue()).width:absolute()
    local lskip = (SILE.settings:get("document.lskip") or SILE.types.node.glue()).width:absolute()
    self.background = rskip + lskip
-   -- 860
+
+   -- FIXME NOT IMPLEMENTED YET
+   -- Check for special treatment of last line of paragraph.
+   -- The new algorithm for the last line requires that the stretchability of par_fill_skip is infinite
+   -- and the stretchability of left_skip plus right_skip is finite.
+   -- do_last_line_fit ← false;
+   -- active_node_size ← active_node_size_normal ; { just in case }
+   -- if last_line_fit > 0 then
+   --    begin q ← glue_ptr (last_line_fill);
+   --    if (stretch (q) > 0) ∧ (stretch_order (q) > normal ) then
+   --       if (background [3] = 0) ∧ (background [4] = 0) ∧ (background [5] = 0) then
+   --          begin do last_line_fit ← true ; active_node_size ← active_node_size_extended ; fill_width [0] ← 0;
+   --          fill_width [1] ← 0; fill_width [2] ← 0; fill_width [stretch_order (q) − 1] ← stretch (q);
+   --          end;
+   --    end
+   -- END (TeX82 827; PDFTeX 1003)
+
+   -- BEGIN (TeX82 834; PDFTeX 1010)
    self.bestInClass = {}
    for i = 1, #classes do
       self.bestInClass[classes[i]] = {
@@ -112,10 +148,52 @@ function lineBreak:init ()
       }
    end
    self.minimumDemerits = awful_bad
-   self:setupLineLengths()
+   -- END (TeX82 834; PDFTeX 1010)
+
+   -- BEGIN (TeX 848; PDFTeX 1024)
+   -- (Setup line length parameters)
+   self.parShaping = param("parShape") or false
+   if self.parShaping then
+      -- (SILE) Done differently as we use a parShape function.
+      self.lastSpecialLine = nil
+      self.easy_line = nil
+   else
+      self.hangAfter = param("hangAfter") or 0
+      self.hangIndent = param("hangIndent"):tonumber()
+      if self.hangIndent == 0 then
+         self.lastSpecialLine = 0
+         self.secondWidth = self.hsize or SU.error("No hsize")
+      else
+         -- BEGIN (TeX82 849; PDFTeX 1025)
+         -- Set line length parameters in preparation for hanging indentation.
+         self.lastSpecialLine = math.abs(self.hangAfter)
+         if self.hangAfter < 0 then
+            self.secondWidth = self.hsize or SU.error("No hsize")
+            self.firstWidth = self.hsize - math.abs(self.hangIndent)
+         else
+            self.firstWidth = self.hsize or SU.error("No hsize")
+            self.secondWidth = self.hsize - math.abs(self.hangIndent)
+         end
+         -- END (TeX82 849; PDFTeX 1025)
+      end
+      if param("looseness") == 0 then
+         self.easy_line = self.lastSpecialLine
+      else
+         self.easy_line = awful_bad -- (SILE) TeX uses a different high value here
+      end
+   end
+   -- END (TeX 848; PDFTeX 1024)
 end
 
-function lineBreak:trimGlue () -- 842
+--- Trim_glue procedure.
+--
+-- Partial implementation of (TeX82 816; PDFTeX 992)
+--
+-- (SILE) Removes trailing glue nodes from the paragraph node list.
+-- Done differently as we handle parfillskip outside.
+   -- FIXME This might however have to be revisited for doLastLineFit, as there's some setup
+   -- for that in PDFTeX 992 not implemented here yet.
+function lineBreak:trimGlue ()
    local nodes = self.nodes
    if nodes[#nodes].is_glue then
       nodes[#nodes] = nil
@@ -123,6 +201,8 @@ function lineBreak:trimGlue () -- 842
    nodes[#nodes + 1] = SILE.types.node.penalty(inf_bad)
 end
 
+--- Paragraph shaping method.
+--
 -- NOTE FOR DEVELOPERS: this method is called when the linebreak.parShape
 -- setting is true. The arguments passed are self (the linebreaker instance)
 -- and a counter representing the current line number.
@@ -141,6 +221,8 @@ end
 --
 -- TeX wizards shall also note that this is slightly different from
 -- Knuth's definition "nline l1 i1 l2 i2 ... lN iN".
+--
+-- @tparam number _ Current line number (not used here in the default implementation)
 function lineBreak:parShape (_)
    return 0, self.hsize, 0
 end
@@ -176,37 +258,11 @@ function lineBreak:parShapeCacheClear ()
    pl.tablex.clear(parShapeCache)
 end
 
-function lineBreak:setupLineLengths () -- 874
-   self.parShaping = param("parShape") or false
-   if self.parShaping then
-      self.lastSpecialLine = nil
-      self.easy_line = nil
-   else
-      self.hangAfter = param("hangAfter") or 0
-      self.hangIndent = param("hangIndent"):tonumber()
-      if self.hangIndent == 0 then
-         self.lastSpecialLine = 0
-         self.secondWidth = self.hsize or SU.error("No hsize")
-      else -- 875
-         self.lastSpecialLine = math.abs(self.hangAfter)
-         if self.hangAfter < 0 then
-            self.secondWidth = self.hsize or SU.error("No hsize")
-            self.firstWidth = self.hsize - math.abs(self.hangIndent)
-         else
-            self.firstWidth = self.hsize or SU.error("No hsize")
-            self.secondWidth = self.hsize - math.abs(self.hangIndent)
-         end
-      end
-      if param("looseness") == 0 then
-         self.easy_line = self.lastSpecialLine
-      else
-         self.easy_line = awful_bad
-      end
-      -- self.easy_line = awful_bad
-   end
-end
-
-function lineBreak:tryBreak () -- 855
+--- Try_break procedure.
+--
+-- Partially checked, see in-code comments.
+--
+function lineBreak:tryBreak ()
    local pi, breakType
    local node = self.nodes[self.place]
    if not node then
@@ -219,9 +275,10 @@ function lineBreak:tryBreak () -- 855
       breakType = "unhyphenated"
       pi = node.penalty or 0
    end
-   if debugging then
-      SU.debug("break", "Trying a", breakType, "break p =", pi)
-   end
+
+   -- procedure try_break(pi, break_type) in PDFTeX 1005.
+   -- FIXME NOT DONE HERE "Make sure that pi is in the proper range" for some reason?
+
    self.no_break_yet = true -- We have to store all this state crap in the object, or it's global variables all the way
    self.prev_prev_r = nil
    self.prev_r = self.activeListHead
@@ -231,40 +288,30 @@ function lineBreak:tryBreak () -- 855
    while true do
       while true do -- allows "break" to function as "continue"
          self.r = self.prev_r.next
-         if debugging then
-            SU.debug(
-               "break",
-               "We have moved the link  forward, ln is now",
-               self.r.type == "delta" and "XX" or self.r.lineNumber
-            )
-         end
-         if self.r.type == "delta" then -- 858
-            if debugging then
-               SU.debug("break", " Adding delta node width of", self.r.width)
-            end
-            self.curActiveWidth:___add(self.r.width)
+         -- BEGIN (PDFTeX 1008)
+         if self.r.type == "delta" then
+            self.curActiveWidth:___add(self.r.width) -- update width
             self.prev_prev_r = self.prev_r
             self.prev_r = self.r
-            break
+            break -- goto continue
+            -- END (PDFTeX 1008)
          end
-         -- 861
+         -- BEGIN (PDFTeX 1011)
+         -- If a line number class has ended, create new active nodes for the best feasible breaks in that class;
+         -- then return if r = last_active , otherwise compute the new line width;
          if self.r.lineNumber > self.old_l then
-            if debugging then
-               SU.debug("break", "Minimum demerits =", self.minimumDemerits)
-            end
+            -- now we are no longer in the inner loop.
             if self.minimumDemerits < awful_bad and (self.old_l ~= self.easy_line or self.r == self.activeListHead) then
                self:createNewActiveNodes(breakType)
             end
             if self.r == self.activeListHead then
-               if debugging then
-                  SU.debug("break", "<- tryBreak")
-               end
                return
             end
-            -- 876
+            -- BEGIN (TeX82 850; PDFTeX 1026)
+            -- Compute the new line width.
             if self.easy_line and self.r.lineNumber > self.easy_line then
                self.lineWidth = self.secondWidth
-               self.old_l = awful_bad - 1
+               self.old_l = awful_bad - 1 -- (SILE) TeX uses a different high value here
             else
                self.old_l = self.r.lineNumber
                if self.lastSpecialLine and self.r.lineNumber > self.lastSpecialLine then
@@ -276,19 +323,11 @@ function lineBreak:tryBreak () -- 855
                   self.lineWidth = self.firstWidth
                end
             end
-            if debugging then
-               SU.debug("break", "line width =", self.lineWidth)
-            end
+            -- END (TeX82 850; PDFTeX 1026)
          end
-         if debugging then
-            SU.debug("break", " ---> (2) cuaw is", self.curActiveWidth)
-            SU.debug("break", " ---> aw is", self.activeWidth)
-         end
-         self:considerDemerits(pi, breakType)
-         if debugging then
-            SU.debug("break", " <--- cuaw is", self.curActiveWidth)
-            SU.debug("break", " <--- aw is ", self.activeWidth)
-         end
+         -- END (PDFTeX 1011)
+
+         self:considerDemerits(pi, breakType) -- Calls (TeX82 851; PDFTeX 1027)
       end
    end
 end
@@ -308,11 +347,11 @@ local function fitclass (self, shortfall)
          badness = SU.rateBadness(inf_bad, shortfall, stretch)
       end
       if badness > 99 then
-         class = "veryLoose"
+         class = VERY_LOOSE_FIT
       elseif badness > 12 then
-         class = "loose"
+         class = LOOSE_FIT
       else
-         class = "decent"
+         class = DECENT_FIT
       end
    else
       shortfall = -shortfall
@@ -322,36 +361,76 @@ local function fitclass (self, shortfall)
          badness = SU.rateBadness(inf_bad, shortfall, shrink)
       end
       if badness > 12 then
-         class = "tight"
+         class = TIGHT_FIT
       else
-         class = "decent"
+         class = DECENT_FIT
       end
    end
    return badness, class
 end
 
-function lineBreak:considerDemerits (pi, breakType) -- 877
+--- Consider the demerits for a line from `r` to `cur_p`.
+--
+-- (TeX82 851; PDFTeX 1027).
+--
+-- Calculation of demerits for a break from `r` to `cur_p`.
+-- The first thing to do is calculate the badness, b. This value will always be between zero and `inf_bad` + 1;
+-- the latter value occurs only in the case of lines from `r` to `cur_p` that cannot shrink enough to fit the necessary
+-- width. In such cases, node `r` will be deactivated. We also deactivate node `r` when a break at `cur_p` is forced,
+-- since future breaks must go through a forced break
+--
+-- PARTIALLY CHECKED TODO FIXME
+--
+-- @tparam number pi Penalty
+-- @tparam string breakType ("hyphenated" or "unhyphenated")
+function lineBreak:considerDemerits (pi, breakType)
    self.artificialDemerits = false
    local nodeStaysActive = false
    local shortfall = self.lineWidth - self.curActiveWidth
+
+   -- FIXME TO CHECK for fitclass, should implement:
+   -- (TeX82 852; PDFTeX 1028): Set the value of b to the badness for stretching the line, and compute the corresponding fit class.
+   -- (TeX82 853; PDFTeX 1029): Set the value of b to the badness for shrinking the line, and compute the corresponding fit class.
    self.badness, self.fitClass = fitclass(self, shortfall)
-   if debugging then
-      SU.debug("break", self.badness, self.fitClass)
-   end
+
+   -- FIXME NOT IMPLEMENTED YET
+   -- if doLastLineFit then
+      -- BEGIN (PDFTeX 1849)
+      -- Adjust the additional data for last line.
+      -- begin
+      --    if cur p = null then shortfall ← 0;
+      --    if shortfall > 0 then g ← cur active width [2]
+      --    else if shortfall < 0 then g ← cur active width [6]
+      --    else g ← 0;
+      -- end
+
+      -- END (PDFTeX 1849)
+   -- end
+
+   -- (TeX82 851; PDFTeX 1027) = from the "found" label
    if self.badness > inf_bad or pi == ejectPenalty then
+      -- BEGIN (TeX82 854; PDFTeX 1030)
+      -- Prepare to deactivate node `r`, and goto deactivate unless there is a reason to consider lines of text from `r` to `cur_p`.
+      -- During the final pass, we dare not lose all active nodes, lest we lose touch with the line breaks already
+      -- found. The code shown here makes sure that such a catastrophe does not happen, by permitting overfull
+      -- boxes as a last resort. This particular part of TeX was a source of several subtle bugs before the correct
+      -- program logic was finally discovered; readers who seek to “improve” TeX should therefore think thrice before
+      -- daring to make any changes here.
       if
          self.finalpass
          and self.minimumDemerits == awful_bad
          and self.r.next == self.activeListHead
          and self.prev_r == self.activeListHead
       then
-         self.artificialDemerits = true
+         self.artificialDemerits = true -- Set demerits zero, this break is forced
       else
          if self.badness > self.threshold then
-            self:deactivateR()
+            self:deactivateR() -- goto deactivate = Calls (TeX82 860; PDFTeX 1036) and returns
             return
          end
+         -- TeX has nodeStaysActive = false here, but we already have it false as initialized.
       end
+      -- END (TeX82 854; PDFTeX 1030)
    else
       self.prev_r = self.r
       if self.badness > self.threshold then
@@ -360,71 +439,67 @@ function lineBreak:considerDemerits (pi, breakType) -- 877
       nodeStaysActive = true
    end
 
-   local _shortfall = shortfall:tonumber()
-   local function shortfallratio (metric)
-      local prop = self.curActiveWidth[metric]:tonumber()
-      local factor = prop ~= 0 and prop or awful_bad
-      return _shortfall / factor
+   self:recordFeasible(pi, breakType) -- Calls (TeX82 855: PDFTeX 1031) Record a new feasible break.
+   if nodeStaysActive then
+      return -- prev_r has been set to r
    end
-   self.lastRatio = shortfallratio(_shortfall > 0 and "stretch" or "shrink")
-   self:recordFeasible(pi, breakType)
-   if not nodeStaysActive then
-      self:deactivateR()
-   end
+   self:deactivateR() -- decativate: Calls (TeX82 860; PDFTeX 1036) Deactivate node r
 end
 
-function lineBreak:deactivateR () -- 886
-   if debugging then
-      SU.debug("break", " Deactivating r (" .. self.r.type .. ")")
-   end
+--- Deactivate node `r`.
+--
+-- (TeX82 860; PDFTeX 1036).
+--
+-- When an active node disappears, we must delete an adjacent delta node if the active node was at the
+-- beginning or the end of the active list, or if it was surrounded by delta nodes.
+-- We also must preserve the property that `cur_active_width` represents the length of material from
+-- `link(prev_r)` to `cur_p`.
+--
+function lineBreak:deactivateR ()
    self.prev_r.next = self.r.next
    if self.prev_r == self.activeListHead then
-      -- 887
+      -- BEGIN (TeX82 861, PDFTeX 1037)
+      -- Update the active widths, since the first active node has been deleted.
       self.r = self.activeListHead.next
       if self.r.type == "delta" then
-         self.activeWidth:___add(self.r.width)
-         self.curActiveWidth = SILE.types.length(self.activeWidth)
+         self.activeWidth:___add(self.r.width) -- Update active
+         self.curActiveWidth = SILE.types.length(self.activeWidth) -- Copy to current active
          self.activeListHead.next = self.r.next
       end
-      if debugging then
-         SU.debug("break", "  Deactivate, branch 1")
-      end
+      -- END (TeX82 861, PDFTeX 1037)
    else
       if self.prev_r.type == "delta" then
          self.r = self.prev_r.next
          if self.r == self.activeListHead then
-            self.curActiveWidth:___sub(self.prev_r.width)
-            -- FIXME It was crashing here, so changed from:
-            -- self.curActiveWidth:___sub(self.r.width)
-            -- But I'm not so sure reading Knuth here...
+            self.curActiveWidth:___sub(self.prev_r.width) -- Downdate width
             self.prev_prev_r.next = self.activeListHead
             self.prev_r = self.prev_prev_r
          elseif self.r.type == "delta" then
-            self.curActiveWidth:___add(self.r.width)
-            self.prev_r.width:___add(self.r.width)
+            self.curActiveWidth:___add(self.r.width) -- Update width
+            self.prev_r.width:___add(self.r.width) -- Combine two deltas
             self.prev_r.next = self.r.next
          end
-      end
-      if debugging then
-         SU.debug("break", "  Deactivate, branch 2")
       end
    end
 end
 
+--- Compute the demerits, `d`, from `r` to `cur_p`.
+--
+-- (TeX82 859; PDFTeX 1035).
+--
+-- @tparam number pi Penalty
+-- @tparam string breakType ("hyphenated" or "unhyphenated")
 function lineBreak:computeDemerits (pi, breakType)
-   if self.artificialDemerits then
-      return 0
-   end
    local demerit = param("linePenalty") + self.badness
    if math.abs(demerit) >= 10000 then
       demerit = 100000000
    else
       demerit = demerit * demerit
    end
+
+   -- No demerit change when pi == 0 as per (TeX82 859, PDFTeX 1035)
    if pi > 0 then
       demerit = demerit + pi * pi
-   -- elseif pi == 0 then
-   --   -- do nothing
    elseif pi > ejectPenalty then
       demerit = demerit - pi * pi
    end
@@ -435,13 +510,35 @@ function lineBreak:computeDemerits (pi, breakType)
          demerit = demerit + param("finalHyphenDemerits")
       end
    end
-   -- XXX adjDemerits not added here
+
+   -- FIXME MISSING / NOT DONE HERE FOR SOME REASON ?
+   --   if abs (fit_class − fitness (r)) > 1 then d ← d + adj_demerits ;
+   -- MAYBE:
+   -- if self.r.fitness and math.abs(self.fitClass - self.r.fitness) > 1 then
+   --    demerit = demerit + param("adjdemerits")
+   -- end
    return demerit
 end
 
-function lineBreak:recordFeasible (pi, breakType) -- 881
-   local demerit = lineBreak:computeDemerits(pi, breakType)
+--- Record a new feasible break.
+--
+-- (Tex82 855; PDFTeX 1031).
+--
+-- When we get to this part of the code, the line from `r` to `cur_p` is feasible, its badness is b, and
+-- its fitness classification is fit_class.
+-- We don’t want to make an active node for this break yet, but we will compute the total demerits
+-- and record them in the minimal demerits array, if such a break is the current champion among all
+-- ways to get to `cur_p` in a given line-number class and fitness class.
+--
+-- @tparam number pi Penalty
+-- @tparam string breakType ("hyphenated" or "unhyphenated")
+function lineBreak:recordFeasible (pi, breakType)
+   local demerit = self.artificialDemerits
+      and 0
+      or self:computeDemerits(pi, breakType) -- Calls (TeX82 859; PDFTeX 1035).
    if debugging then
+      -- Print a symbolic description of this feasible break = TeX82 856
+      -- FIXME Should be a separate function
       if self.nodes[self.place] then
          SU.debug(
             "break",
@@ -453,34 +550,57 @@ function lineBreak:recordFeasible (pi, breakType) -- 881
             self.badness,
             "demerit =",
             demerit
-         ) -- 882
+         )
       else
          SU.debug("break", "@ \\par via @@")
       end
       SU.debug("break", " fit class =", self.fitClass)
    end
-   demerit = demerit + self.r.totalDemerits
+   demerit = demerit + self.r.totalDemerits --  This is the minimum total demerits from the beginning to `cur_p` via r
    if demerit <= self.bestInClass[self.fitClass].minimalDemerits then
       self.bestInClass[self.fitClass] = {
          minimalDemerits = demerit,
-         node = self.r.serial and self.r,
+         node = self.r.serial and self.r, -- (SILE) Serial check no in TeX. We probably want to avoid the sentinel here? Dubious?
          line = self.r.lineNumber,
       }
-      -- XXX do last line fit
+
+      -- FIXME NOT IMPLEMENTED YET
+      -- if doLastLineFit then
+      --   -- BEGIN (PDFTeX 1850)
+      --   -- Store additional data for this feasible break
+      --   -- For each feasible break we record the shortfall and glue stretch or shrink (or adjustment).
+      --   best_pl_short[fit_class] ← shortfall;
+      --   best_pl_glue[fit_class ] ← g;
+      --   -- END (PDFTeX 1850)
+      -- end
+
       if demerit < self.minimumDemerits then
          self.minimumDemerits = demerit
       end
    end
 end
 
-function lineBreak:createNewActiveNodes (breakType) -- 862
+--- Create new active nodes for the best feasible breaks just found.
+--
+-- (TeX82 836; PDFTeX 1012).
+--
+-- It is not necessary to create new active nodes having minimal demerits greater than
+-- `minimum_demerits` + abs(`adj_demerits`), since such active nodes will never be chosen in the final
+-- paragraph breaks.
+-- This observation allows us to omit a substantial number of feasible breakpoints from further
+-- consideration.
+--
+-- @tparam string breakType ("hyphenated" or "unhyphenated")
+function lineBreak:createNewActiveNodes (breakType)
    if self.no_break_yet then
-      -- 863
+      -- BEGIN (TeX82 837; PDFTeX 1013)
+      -- Compute the values of break width
+      -- TODO FIXME CHECK THIS 837/1013 section:  (SILE) does it differently...
       self.no_break_yet = false
-      self.breakWidth = SILE.types.length(self.background)
+      self.breakWidth = SILE.types.length(self.background) -- Set break width to background
       local place = self.place
       local node = self.nodes[place]
-      if node and node.is_discretionary then -- 866
+      if node and node.is_discretionary then
          self.breakWidth:___add(node:prebreakWidth())
          self.breakWidth:___add(node:postbreakWidth())
          self.breakWidth:___sub(node:replacementWidth())
@@ -494,25 +614,27 @@ function lineBreak:createNewActiveNodes (breakType) -- 862
          end
          place = place + 1
       end
-      if debugging then
-         SU.debug("break", "Value of breakWidth =", self.breakWidth)
-      end
+      -- END (TeX82 837; PDFTeX 1013)
    end
-   -- 869 (Add a new delta node)
-   if self.prev_r.type == "delta" then
+   -- BEGIN (TeX82 843; PDFTeX 1019)
+   -- Insert a delta node to prepare for breaks at `cur_p`.
+   if self.prev_r.type == "delta" then -- Modify an existing delta node: Convert to breakWidth
       self.prev_r.width:___sub(self.curActiveWidth)
       self.prev_r.width:___add(self.breakWidth)
-   elseif self.prev_r == self.activeListHead then
-      self.activeWidth = SILE.types.length(self.breakWidth)
+   elseif self.prev_r == self.activeListHead then -- No delta node needed at the beginning
+      self.activeWidth = SILE.types.length(self.breakWidth) -- Store break width
    else
-      local newDelta = { next = self.r, type = "delta", width = self.breakWidth - self.curActiveWidth }
-      if debugging then
-         SU.debug("break", "Added new delta node =", newDelta.width)
-      end
+      local newDelta = {
+         next = self.r,
+         type = "delta",
+         width = self.breakWidth - self.curActiveWidth -- new delta to break width
+      }
       self.prev_r.next = newDelta
       self.prev_prev_r = self.prev_r
       self.prev_r = newDelta
    end
+   -- END (TeX82 843; PDFTeX 1019)
+
    if math.abs(self.adjdemerits) >= (awful_bad - self.minimumDemerits) then
       self.minimumDemerits = awful_bad - 1
    else
@@ -523,43 +645,66 @@ function lineBreak:createNewActiveNodes (breakType) -- 862
       local class = classes[i]
       local best = self.bestInClass[class]
       local value = best.minimalDemerits
-      if debugging then
-         SU.debug("break", "Class is", class, "Best value here is", value)
-      end
-
       if value <= self.minimumDemerits then
-         -- 871: this is what creates new active notes
+         -- BEGIN (TeX82 845; PDFTeX 1021)
+         -- Insert a new active node from best_place[fit_class] to `cur_p`.
+         -- FIXME Knuth says "When we create an active node, we also create the corresponding passive node."
+         -- Are we doing exactly that? Knuth's code is hard to read here, and (SILE) is not very clear either.
          passSerial = passSerial + 1
-
          local newActive = {
             type = breakType,
             next = self.r,
             curBreak = self.place,
             prevBreak = best.node,
             serial = passSerial,
-            ratio = self.lastRatio,
             lineNumber = best.line + 1,
             fitness = class,
             totalDemerits = value,
          }
-         -- DoLastLineFit? 1636 XXX
+
+         -- FIXME NOT IMPLEMENTED YET
+         -- if doLastLineFit then
+         --   -- BEGIN (PDFTeX 1851)
+         --   -- Store additional data in the new active node 1851.
+         --   -- Here we save these data in the active node representing a potential line break.
+         --   --    active_short (q) ← best_pl_short[fit_class];
+         --   --    active_glue (q) ← best_pl_glue [fit class ];
+         --   -- END (PDFTeX 1851)
+         -- end
+
          self.prev_r.next = newActive
          self.prev_r = newActive
          self:dumpBreakNode(newActive)
+         -- END (TeX82 845; PDFTeX 1021)
       end
       self.bestInClass[class] = { minimalDemerits = awful_bad }
    end
-
    self.minimumDemerits = awful_bad
-   -- 870
+
+   -- BEGIN (TeX82 844; PDFTeX 1020)
+   -- Insert a delta node to prepare for the next active node.
+   -- When the following code is performed, we will have just inserted at least one active node before r,
+   -- so type(prev r_) != delta_node.
    if self.r ~= self.activeListHead then
-      local newDelta = { next = self.r, type = "delta", width = self.curActiveWidth - self.breakWidth }
+      local newDelta = {
+         next = self.r,
+         type = "delta",
+         width = self.curActiveWidth - self.breakWidth -- New delta from break width
+      }
       self.prev_r.next = newDelta
       self.prev_prev_r = self.prev_r
       self.prev_r = newDelta
    end
+   -- END (TeX82 844; PDFTeX 1020)
 end
 
+-- Print a symbolic description of the new break node.
+--
+-- (TeX82 856; PDFTeX 1022).
+--
+-- (SILE) does it its own way, it's a debugging function.
+--
+-- @tparam table node Break node
 function lineBreak:dumpBreakNode (node)
    if not SU.debugging("break") then
       return
@@ -568,7 +713,6 @@ function lineBreak:dumpBreakNode (node)
 end
 
 function lineBreak:describeBreakNode (node)
-   --SU.debug("break", "@@", b.serial, ": line", b.lineNumber - 1, ".", b.fitness, b.type, "t=", b.totalDemerits, "-> @@", b.prevBreak and b.prevBreak.serial or "0")
    if node.sentinel then
       return node.sentinel
    end
@@ -589,9 +733,15 @@ function lineBreak:describeBreakNode (node)
    )
 end
 
+--- Check for legal break at the current node.
+--
+-- Derived from (TeX82 866; PDFTeX 1042) TO CHECK FIXME
+--
 -- NOTE: this function is called many thousands of times even in single
 -- page documents. Speed is more important than pretty code here.
-function lineBreak:checkForLegalBreak (node) -- 892
+--
+-- @tparam table node Current node
+function lineBreak:checkForLegalBreak (node)
    if debugging then
       SU.debug("break", "considering node " .. node)
    end
@@ -608,7 +758,7 @@ function lineBreak:checkForLegalBreak (node) -- 892
    elseif node.is_box then
       self.activeWidth:___add(node:lineContribution())
    elseif node.is_glue then
-      -- 894 (We removed the auto_breaking parameter)
+      -- auto_breaking parameter not implemented
       if previous and previous.is_box then
          self:tryBreak()
       end
@@ -624,7 +774,7 @@ function lineBreak:checkForLegalBreak (node) -- 892
       end
       self.activeWidth:___add(node.width)
       -- END RESILIENT
-   elseif node.is_discretionary then -- 895
+   elseif node.is_discretionary then
       self.activeWidth:___add(node:prebreakWidth())
       self:tryBreak()
       self.activeWidth:___sub(node:prebreakWidth())
@@ -634,7 +784,12 @@ function lineBreak:checkForLegalBreak (node) -- 892
    end
 end
 
-function lineBreak:tryFinalBreak () -- 899
+--- Try the final line break at the end of the paragraph.
+--
+-- (TeX82 873; PDFTeX 1049).
+--
+-- @treturn boolean true if the desired breakpoints have been found
+function lineBreak:tryFinalBreak ()
    -- XXX TeX has self:tryBreak() here. But this doesn't seem to work
    -- for us. If we call tryBreak(), we end up demoting all break points
    -- to veryLoose (possibly because the active width gets reset - why?).
@@ -645,9 +800,16 @@ function lineBreak:tryFinalBreak () -- 899
    -- instead of every single time. If things go strange with the break
    -- algorithm in the future, this should be the first place to look!
    -- self:tryBreak()
+   -- FIXME ?
+   -- TEX82 873 has indeed: try_break(ejectPenalty, "hyphenated") ;
+   -- self:tryBreak()
+
    if self.activeListHead.next == self.activeListHead then
-      return
+      return false
    end
+
+   -- BEGIN (TeX82 874; PDFTeX 1050)
+   -- Find an active node with fewest demerits.
    self.r = self.activeListHead.next
    local fewestDemerits = awful_bad
    repeat
@@ -657,15 +819,75 @@ function lineBreak:tryFinalBreak () -- 899
       end
       self.r = self.r.next
    until self.r == self.activeListHead
-   if param("looseness") == 0 then
+   -- END (TeX82 874; PDFTeX 1050)
+
+   local looseness = param("looseness")
+   if looseness == 0 then
       return true
    end
-   -- XXX node 901 not implemented
-   if self.actualLooseness == param("looseness") or self.finalpass then
+
+   -- BEGIN (TeX82 875; PDFTeX 1021)
+   -- Find the best active node for the desired looseness.
+   -- The adjustment for a desired looseness is a slightly more complicated version of the loop just
+   -- considered. Note that if a paragraph is broken into segments by displayed equations, each segment will be
+   -- subject to the looseness calculation, independently of the other segments.
+   --
+   -- FIXME MISSING / NOT FULLY IMPLEMENTED
+   --
+   -- begin r ← link (active); actual_looseness ← 0;
+   --    repeat if type (r) != delta node then
+   --       begin line_diff ← line_number (r) − best_line;
+   --       if ((line_diff < actual_looseness ) ∧ (looseness ≤ line_diff )) ∨
+   --             ((line_diff > actual_looseness ) ∧ (looseness ≥ line_diff )) then
+   --          begin best_bet ← r; actual_looseness ← line_diff ; fewest_demerits ← total_demerits (r);
+   --       end
+   --       else if (line_diff = actual_looseness ) ∧ (total_demerits (r) < fewest_demerits ) then
+   --          begin best_bet ← r; fewest_demerits ← total_demerits (r);
+   --          end;
+   --       end;
+   --       r ← link(r);
+   --    until r = last_active ;
+   --    best line ← line_number (best_bet);
+   -- end
+   --
+   -- MAYBE CONVERT TO:
+   --
+   -- self.r = self.activeListHead.next
+   -- local actualLooseness = 0
+   -- repeat
+   --    if self.r.type ~= "delta" then
+   --       local lineDiff = self.r.lineNumber - self.bestBet.lineNumber
+   --       if (lineDiff < actualLooseness and looseness <= lineDiff)
+   --          or (lineDiff > actualLooseness and looseness >= lineDiff)
+   --       then
+   --          self.bestBet = self.r
+   --          actualLooseness = lineDiff
+   --          fewestDemerits = self.r.totalDemerits
+   --       elseif lineDiff == actualLooseness and self.r.totalDemerits < fewestDemerits then
+   --          self.bestBet = self.r
+   --          fewestDemerits = self.r.totalDemerits
+   --       end
+   --    end
+   --    self.r = self.r.next
+   -- until self.r == self.activeListHead
+   -- -- self.bestLine = self.bestBet.lineNumber -- Not needed as we can get it from bestBet
+   --
+   -- END (TeX82 875; PDFTeX 1021)
+
+   -- FIXME self.actualLooseness not set anywhere, see above
+   if self.actualLooseness == looseness or self.finalpass then
       return true
    end
+   -- END TeX82 873
 end
 
+--- Main line breaking procedure.
+--
+-- Derived from (TeX82 863; PDFTeX 1039) PARTIALLY CHECKED FIX%E
+--
+-- @tparam table nodes List of nodes representing the paragraph
+-- @tparam SILE.length hsize Line width
+-- @tparam boolean sideways Whether we are breaking sideways text
 function lineBreak:doBreak (nodes, hsize, sideways)
    passSerial = 1
    debugging = SU.debugging("break")
@@ -674,6 +896,9 @@ function lineBreak:doBreak (nodes, hsize, sideways)
    self.sideways = sideways
    self:init()
    self.adjdemerits = param("adjdemerits")
+
+   -- BEGIN (TeX82 863; PDFTeX 1039) --- FIXME PARTIALLY CHECKED
+   -- Find optimal breakpoints
    self.threshold = param("pretolerance")
    if self.threshold >= 0 then
       self.pass = "first"
@@ -683,50 +908,68 @@ function lineBreak:doBreak (nodes, hsize, sideways)
       self.pass = "second"
       self.finalpass = param("emergencyStretch") <= 0
    end
-   -- 889
+   -- The ‘loop’ in the following code is performed at most thrice per call of line break, since it is actually
+   -- a pass over the entire paragraph.
    while 1 do
-      if debugging then
-         SU.debug("break", "@", self.pass, "pass")
-      end
       if self.threshold > inf_bad then
          self.threshold = inf_bad
       end
       if self.pass == "second" then
+         -- BEGIN (PDFTeX 1068)
+         -- Initialize for hyphenating a paragraph
+         -- (SILE) Done differently than TeX
          self.nodes = SILE.hyphenate(self.nodes)
          -- BEGIN RESILIENT (remove side effect on SILE.typesetter.state.nodes)
          -- SILE.typesetter.state.nodes = self.nodes -- Horrible breaking of separation of concerns here. :-(
          -- END RESILIENT
       end
-      -- 890
+
+      -- Create an active breakpoint representing the beginning of the paragraph
+      -- (SILE) does it differently than TeX here, with two sentinels
       self.activeListHead = {
+         -- Maybe from (TeX82 820; PDFTeX 996)?
          sentinel = "START",
          type = "hyphenated",
-         lineNumber = awful_bad,
-         subtype = 0,
-      } -- 846
+         lineNumber = awful_bad, -- (SILE) TeX uses a different high value here?
+         fitness = DECENT_FIT, -- Not needed if from (TeX82 820; PDFTeX 996)?
+      }
       self.activeListHead.next = {
          sentinel = "END",
          type = "unhyphenated",
-         fitness = "decent",
+         fitness = DECENT_FIT,
          next = self.activeListHead,
          lineNumber = param("prevGraf") + 1,
          totalDemerits = 0,
       }
 
-      -- Not doing 1630
-      self.activeWidth = SILE.types.length(self.background)
+      -- FIXME NOT IMPLEMENTED YET
+      -- if doLastLineFit then
+      --    -- BEGIN (PDFTeX 1845)
+      --    -- Initialize additional fields of the first active node
+      --    active_short(q) ← 0;
+      --    active_glue(q) ← 0;
+      --    -- END (PDFTeX 1845)
+      -- end
+
+      self.activeWidth = SILE.types.length(self.background) -- store background
+      -- END (TeX82 864; PDFTeX 1040)
 
       self.place = 1
       while self.nodes[self.place] and self.activeListHead.next ~= self.activeListHead do
+         -- BEGIN PDFTeX 1042
          self:checkForLegalBreak(self.nodes[self.place])
          self.place = self.place + 1
       end
       if self.place > #self.nodes then
+         -- Try the final line break at the end of the paragraph = Calls (TeX82 873; PDFTeX 1049).
+         -- We are done if the desired breakpoints have been found.
          if self:tryFinalBreak() then
             break
          end
       end
-      -- (Not doing 891)
+
+      -- Not doing "Clean up the memory by removing the break nodes" (TeX82 865; PDFTeX 1041)
+
       if self.pass ~= "second" then
          self.pass = "second"
          self.threshold = param("tolerance")
@@ -736,13 +979,31 @@ function lineBreak:doBreak (nodes, hsize, sideways)
          self.finalpass = true
       end
    end
-   -- Not doing 1638
+
+   -- if doLastLineFit then
+   --    -- BEGIN (PDFTeX 1853)
+   --    -- FIXME NOT IMPLEMENTED YET
+   --    -- Adjust the final line of the paragraph
+   --    -- Here we either reset do_last_line_fit or adjust the par_fill_skip glue.
+   --    if active_short(best_bet) = 0 then do last_line_fit ← false
+   --    else begin q ← new_spec (glue_ptr (last_line_fill)); delete glue_ref (glue_ptr (last_line_fill ));
+   --       width (q) ← width (q) + active_short(best_bet) − active_glue(best_bet); stretch (q) ← 0;
+   --       glue_ptr (last_line_fill) ← q;
+   --    end
+   --    -- END (PDFTeX 1853)
+   -- end
+
+   -- END (TeX82 863; PDFTeX 1039)
 
    -- RESILIENT (return breaks and also nodes, these may have been hyphenated)
    return self:postLineBreak(), self.nodes
 end
 
-function lineBreak:postLineBreak () -- 903
+--- Generate the list of line breaks after the best breakpoints have been found.
+--
+-- FIXME TODO CHECK in (TeX82; PDFTeX)
+--
+function lineBreak:postLineBreak ()
    local p = self.bestBet
    local breaks = {}
    local line = 1
@@ -798,24 +1059,6 @@ function lineBreak:postLineBreak () -- 903
    until not p
    self:parShapeCacheClear()
    return breaks
-end
-
-function lineBreak:dumpActiveRing ()
-   local p = self.activeListHead
-   if not SILE.quiet then
-      io.stderr:write("\n")
-   end
-   repeat
-      if not SILE.quiet then
-         if p == self.r then
-            io.stderr:write("-> ")
-         else
-            io.stderr:write("   ")
-         end
-      end
-      SU.debug("break", lineBreak:describeBreakNode(p))
-      p = p.next
-   until p == self.activeListHead
 end
 
 return lineBreak

--- a/typesetters/algorithms/knuthplass.lua
+++ b/typesetters/algorithms/knuthplass.lua
@@ -40,16 +40,70 @@ SILE.settings:declare({
    default = false,
    help = "If set to true, the paragraph shaping method is activated.",
 })
-SILE.settings:declare({ parameter = "linebreak.tolerance", type = "integer or nil", default = 500 })
-SILE.settings:declare({ parameter = "linebreak.pretolerance", type = "integer or nil", default = 100 })
-SILE.settings:declare({ parameter = "linebreak.hangIndent", type = "measurement", default = 0 })
-SILE.settings:declare({ parameter = "linebreak.hangAfter", type = "integer or nil", default = nil })
+
+-- BEGIN SILE
+-- Since 2019, SILE core (at least until 0.15.13) sets the default value of
+-- "linebreak.tolerance" to 500.
+-- The tolerance should be greater that the pretolerance, but TeX uses 200 here.
+-- The difference could not be justified, but is probably a mistake from earlier
+-- experimentations.
+-- See https://github.com/sile-typesetter/sile/issues/2254
+--
+-- THE DEFAULT VALUE MAY CHANGE IN A FUTURE MAJOR RELEASE.
+--
+-- Note that SILE loads its line-breaking algorithm at a very early stage in
+-- its initialization, and that settings declaration cannot be overridden,
+-- so any different default value wouldn't be honored here anyway.
+-- We could invoke SILE.settings:set("linebreak.tolerance", 200, true)
+-- explicitly here to enforce it, but that would change how lines are broken
+-- in all previous documents, so for now we just keep the default, and users can
+-- set it to 200 if they want to...
 SILE.settings:declare({
-   parameter = "linebreak.adjdemerits",
+   parameter = "linebreak.tolerance",
    type = "integer",
-   default = 10000,
-   help = "Additional demerits which are accumulated in the course of paragraph building when two consecutive lines are visually incompatible. In these cases, one line is built with much space for justification, and the other one with little space.",
+   default = 500, -- WRONG DEFAULT BUT SEE ABOVE
+   help = "A parameter without unit that tells the line-breaking algorithm how much badness is allowable in a paragraph (0 to 10000).",
 })
+-- END SILE
+
+SILE.settings:declare({
+   parameter = "linebreak.pretolerance",
+   type = "integer",
+   default = 100,
+   help = "A parameter without unit that tells the line-breaking algorithm how much badness is allowable in a paragraph during the first pass without hyphenation (0 to 10000). Set it to -1 to disable the pretolerance pass.",
+})
+
+SILE.settings:declare({
+   parameter = "linebreak.hangIndent",
+   type = "measurement",
+   default = 0
+})
+SILE.settings:declare({
+   parameter = "linebreak.hangAfter",
+   type = "integer or nil",
+   default = nil
+})
+
+-- BEGIN SILE / RESILIENT
+-- TeX sets \adjdemerits to 10000 by default, and it's used in the algorithm.
+-- SILE core (at least until 0.15.13) defines "linebreak.adjdemerits" to 10000 but doesn't
+-- use it: that part of the algorithm was skipped in the original SILE implementation:
+-- See https://github.com/sile-typesetter/sile/issues/2362
+-- It's thus always behaving as if it was set to 0.
+-- In sile·nt / re·sil·ient, we remove the unused "linebreak.adjdemerits" setting, and replace
+-- it with "linebreak.adjacentDemerits" which is used in the algorithm, but set to 0 by default,
+-- so that the behavior is the same as before, but users can set it to a different value if they
+-- want to.
+--
+-- THE DEFAULT VALUE MAY CHANGE IN A FUTURE MAJOR RELEASE.
+SILE.settings:declare({
+   parameter = "linebreak.adjacentDemerits",
+   type = "integer",
+   default = 0, -- WRONG DEFAULT BUT SEE ABOVE
+   help = "Additional demerits which are accumulated in the course of paragraph building when two consecutive lines are visually incompatible.",
+})
+-- END SILE / RESILIENT
+
 SILE.settings:declare({ parameter = "linebreak.looseness", type = "integer", default = 0 })
 SILE.settings:declare({ parameter = "linebreak.prevGraf", type = "integer", default = 0 })
 SILE.settings:declare({ parameter = "linebreak.emergencyStretch", type = "measurement", default = 0 })
@@ -64,9 +118,6 @@ SILE.settings:declare({ parameter = "linebreak.finalHyphenDemerits", type = "int
 -- to 1000 indicate a glue adjustment fraction f times 1000, values above 1000 are
 -- interpreted as f = 1
 SILE.settings:declare({ parameter = "linebreak.doLastLineFit", type = "boolean", default = false }) -- unimplemented,
-
--- doubleHyphenDemerits
--- hyphenPenalty
 
 -- (TeX82 817; PDFTeX 993)
 local TIGHT_FIT = 3 -- fitness classification for lines shrinking 0.5 to 1.0 of their shrinkability
@@ -120,7 +171,7 @@ function lineBreak:init ()
    self.breakWidth = SILE.types.length()
 
    -- BEGIN (TeX82 827; PDFTeX 1003)
-   -- NOTE: More or less... TeX uses lots of registers here, no very clear.
+   -- FIXME NOTE: More or less... TeX uses lots of registers here, no very clear.
    local rskip = (SILE.settings:get("document.rskip") or SILE.types.node.glue()).width:absolute()
    local lskip = (SILE.settings:get("document.lskip") or SILE.types.node.glue()).width:absolute()
    self.background = rskip + lskip
@@ -192,9 +243,9 @@ end
 --
 -- (SILE) Removes trailing glue nodes from the paragraph node list.
 -- Done differently as we handle parfillskip outside.
-   -- FIXME This might however have to be revisited for doLastLineFit, as there's some setup
-   -- for that in PDFTeX 992 not implemented here yet.
 function lineBreak:trimGlue ()
+   -- FIXME: This might however have to be revisited for doLastLineFit, as there's some setup
+   -- for that in PDFTeX 992 not implemented here yet.
    local nodes = self.nodes
    if nodes[#nodes].is_glue then
       nodes[#nodes] = nil
@@ -380,8 +431,6 @@ end
 -- width. In such cases, node `r` will be deactivated. We also deactivate node `r` when a break at `cur_p` is forced,
 -- since future breaks must go through a forced break
 --
--- PARTIALLY CHECKED TODO FIXME
---
 -- @tparam number pi Penalty
 -- @tparam string breakType ("hyphenated" or "unhyphenated")
 function lineBreak:considerDemerits (pi, breakType)
@@ -512,12 +561,9 @@ function lineBreak:computeDemerits (pi, breakType)
       end
    end
 
-   -- FIXME MISSING / NOT DONE HERE FOR SOME REASON ?
-   --   if abs (fit_class − fitness (r)) > 1 then d ← d + adj_demerits ;
-   -- MAYBE:
-   -- if self.r.fitness and math.abs(self.fitClass - self.r.fitness) > 1 then
-   --    demerit = demerit + param("adjdemerits")
-   -- end
+   if math.abs(self.fitClass - self.r.fitness) > 1 then
+      demerit = demerit + self.adjdemerits
+   end
    return demerit
 end
 
@@ -733,7 +779,7 @@ end
 
 --- Check for legal break at the current node.
 --
--- Derived from (TeX82 866; PDFTeX 1042) TO CHECK FIXME
+-- Derived from (TeX82 866; PDFTeX 1042) PARTIALLY CHECKED FIXME
 --
 -- NOTE: this function is called many thousands of times even in single
 -- page documents. Speed is more important than pretty code here.
@@ -779,6 +825,8 @@ end
 --
 -- @treturn boolean true if the desired breakpoints have been found
 function lineBreak:tryFinalBreak ()
+   -- FIXME
+   -- The original comment:
    -- XXX TeX has self:tryBreak() here. But this doesn't seem to work
    -- for us. If we call tryBreak(), we end up demoting all break points
    -- to veryLoose (possibly because the active width gets reset - why?).
@@ -789,9 +837,8 @@ function lineBreak:tryFinalBreak ()
    -- instead of every single time. If things go strange with the break
    -- algorithm in the future, this should be the first place to look!
    -- self:tryBreak()
-   -- FIXME ?
-   -- TEX82 873 has indeed: try_break(ejectPenalty, "hyphenated") ;
-   -- self:tryBreak()
+   -- SOMETHING IS LIKELY WRONG HERE.
+   -- TEX82 873 has indeed: try_break(ejectPenalty, "hyphenated")
 
    if self.activeListHead.next == self.activeListHead then
       return false
@@ -820,69 +867,46 @@ function lineBreak:tryFinalBreak ()
    -- The adjustment for a desired looseness is a slightly more complicated version of the loop just
    -- considered. Note that if a paragraph is broken into segments by displayed equations, each segment will be
    -- subject to the looseness calculation, independently of the other segments.
-   --
-   -- FIXME MISSING / NOT FULLY IMPLEMENTED
-   --
-   -- begin r ← link (active); actual_looseness ← 0;
-   --    repeat if type (r) != delta node then
-   --       begin line_diff ← line_number (r) − best_line;
-   --       if ((line_diff < actual_looseness ) ∧ (looseness ≤ line_diff )) ∨
-   --             ((line_diff > actual_looseness ) ∧ (looseness ≥ line_diff )) then
-   --          begin best_bet ← r; actual_looseness ← line_diff ; fewest_demerits ← total_demerits (r);
-   --       end
-   --       else if (line_diff = actual_looseness ) ∧ (total_demerits (r) < fewest_demerits ) then
-   --          begin best_bet ← r; fewest_demerits ← total_demerits (r);
-   --          end;
-   --       end;
-   --       r ← link(r);
-   --    until r = last_active ;
-   --    best line ← line_number (best_bet);
-   -- end
-   --
-   -- MAYBE CONVERT TO:
-   --
-   -- self.r = self.activeListHead.next
-   -- local actualLooseness = 0
-   -- repeat
-   --    if self.r.type ~= "delta" then
-   --       local lineDiff = self.r.lineNumber - self.bestBet.lineNumber
-   --       if (lineDiff < actualLooseness and looseness <= lineDiff)
-   --          or (lineDiff > actualLooseness and looseness >= lineDiff)
-   --       then
-   --          self.bestBet = self.r
-   --          actualLooseness = lineDiff
-   --          fewestDemerits = self.r.totalDemerits
-   --       elseif lineDiff == actualLooseness and self.r.totalDemerits < fewestDemerits then
-   --          self.bestBet = self.r
-   --          fewestDemerits = self.r.totalDemerits
-   --       end
-   --    end
-   --    self.r = self.r.next
-   -- until self.r == self.activeListHead
-   -- -- self.bestLine = self.bestBet.lineNumber -- Not needed as we can get it from bestBet
-   --
+   self.r = self.activeListHead.next
+   local actualLooseness = 0
+   repeat
+      if self.r.type ~= "delta" then
+         local lineDiff = self.r.lineNumber - self.bestBet.lineNumber
+         if (lineDiff < actualLooseness and looseness <= lineDiff)
+            or (lineDiff > actualLooseness and looseness >= lineDiff)
+         then
+            self.bestBet = self.r
+            actualLooseness = lineDiff
+            fewestDemerits = self.r.totalDemerits
+         elseif lineDiff == actualLooseness and self.r.totalDemerits < fewestDemerits then
+            self.bestBet = self.r
+            fewestDemerits = self.r.totalDemerits
+         end
+      end
+      self.r = self.r.next
+   until self.r == self.activeListHead
    -- END (TeX82 875; PDFTeX 1021)
 
-   -- FIXME self.actualLooseness not set anywhere, see above
-   if self.actualLooseness == looseness or self.finalpass then
+   if actualLooseness == looseness or self.finalpass then
       return true
    end
-   -- END TeX82 873
 end
 
 --- Main line breaking procedure.
 --
--- Derived from (TeX82 863; PDFTeX 1039) PARTIALLY CHECKED FIX%E
+-- Derived from (TeX82 863; PDFTeX 1039) PARTIALLY CHECKED FIXME
 --
 -- @tparam table nodes List of nodes representing the paragraph
 -- @tparam SILE.length hsize Line width
+-- @treturn table List of breakpoints
+-- @treturn table Possibly modified list of nodes
 function lineBreak:doBreak (nodes, hsize)
    passSerial = 1
    debugging = SU.debugging("break")
    self.nodes = nodes
    self.hsize = hsize
    self:init()
-   self.adjdemerits = param("adjdemerits")
+   self.adjdemerits = param("adjacentDemerits")
 
    -- BEGIN (TeX82 863; PDFTeX 1039) --- FIXME PARTIALLY CHECKED
    -- Find optimal breakpoints
@@ -955,7 +979,8 @@ function lineBreak:doBreak (nodes, hsize)
          end
       end
 
-      -- Not doing "Clean up the memory by removing the break nodes" (TeX82 865; PDFTeX 1041)
+      -- FIXME:
+      -- SILE: Not doing "Clean up the memory by removing the break nodes" (TeX82 865; PDFTeX 1041)
 
       if self.pass ~= "second" then
          self.pass = "second"
@@ -988,7 +1013,7 @@ end
 
 --- Generate the list of line breaks after the best breakpoints have been found.
 --
--- FIXME TODO CHECK in (TeX82; PDFTeX)
+-- FIXME NOT RE-CHECKED YET AGAINST (TeX82; PDFTeX), but there are also some SILE-specific adjustments here.
 --
 function lineBreak:postLineBreak ()
    local p = self.bestBet


### PR DESCRIPTION
**Nov. 12, 2025**

Some more code and related comments that should perhaps be up-streamed to SILE when completed: this is an attempt to check the line breaker against the original sources (TeX82, PDFTeX) and bring the implementation closer to them, and properly documented... 

 - feat: Remove non-working alternates from line-breaker algorithm = See this [SILE issue](https://github.com/sile-typesetter/sile/issues/1227#issuecomment-1077539598) for rationale. The original author himself, in 2022, advocated the removal of the non-working experiment...
 - refactor: Rewrite the line-breaker algorithm with comments from TeX = As many comments I could extract from the original code source from TeX82 and PDFTeX (see links in in-code top comments), an effort still partial and incomplete, but at least we are closer...
 - feat: Remove non-standard 'sideways' logic from the line-breaker = See this [SILE discussion](https://github.com/sile-typesetter/sile/discussions/2327#discussioncomment-14393573) for some overview. There are interesting TeX resources on the topic, but the current approach is not general (e.g. on floats, columns, repeated contents such as table headers &c), so let's not bother with the "old" and broken attempt...
 - feat: Add missing bits from TeX82 line-breaker on adjdemerits and looseness = Interesting to see missing bits when comparing to TeX82's code... The latter only ticks in when looseness != 0 (i.e. not in the default scenario), but the former is more embarrassing (actually affecting some of my books). No idea why these bits were not implemented, but let's try to be even closer to TeX's Knuth-Plass code now...

**May 23, 2026** on St. Didier's day (lol)

I have sat too long on this PR.

Changing `linebreak.adjdemerits` to `linebreak.adjacentDemerits` with a value of 0 for now allows having the missing bit of code, while not changing the output in existing documents at this point. This is a decent move (with in name in line with other such names in SILE as doubleHyphenDemerits etc.) and users can set it to 10000 as in TeX if they want it.

There are also FIXME comments left in the code, as the check against TeX is not always obvious, but at least this is better in my opinion, and more future proof.