### PR TITLE
refactor(schemas): Improve schema validation on our YAML/table formats

### DIFF
--- a/inputters/invoice.lua
+++ b/inputters/invoice.lua
@@ -57,9 +57,9 @@ end
 local function Unit (qty, unit)
   local n = tonumber(qty)
   local i18nUnit
-  -- Unit ignored if unit is "EA" or absent,
+  -- Unit ignored if "EA" (default)
   -- otherwise we try to localize it.
-  if unit and unit ~= "EA" then
+  if unit ~= "EA" then
     local choice = I18n(unit)
     if type(choice) == "table" then
       -- Singular/plural form
@@ -284,7 +284,7 @@ local knownISO4217CurrencySymbol = { -- Not exhaustive, TOTO move to a common mo
 -- @tparam number n Numerical value
 -- @treturn string Formatted decimal number
 local function Decimal (n)
-  local lang = context.language or "en" -- luacheck: ignore
+  local lang = context.language -- luacheck: ignore
   n = SU.cast("number", n)
   local formatted = icu.format_number(n, lang, 1) -- 1 = UNUM_DECIMAL
   return formatted
@@ -300,7 +300,7 @@ end
 -- @tparam string currency ISO 4217 currency code
 -- @treturn string Formatted currency
 local function Currency (n, currency)
-  local lang = context.language or "en" -- luacheck: ignore
+  local lang = context.language -- luacheck: ignore
   n = SU.cast("number", n)
   currency = knownISO4217CurrencySymbol[currency:upper()] or currency
   local formatted = icu.format_number(n, lang, 10) -- 10 = UNUM_CURRENCY
@@ -315,7 +315,7 @@ end
 -- @tparam number n Number between 0 and 1.
 -- @treturn string Formatted perrcentage
 local function Percent (n)
-  local lang = context.language or "en" -- luacheck: ignore
+  local lang = context.language -- luacheck: ignore
   -- ICU is not reliable/sufficient here, it rounds percentages to integers
   -- but we can have taxes such as 5.5%...
   -- HACK: We'll do a ISO currency format and replace the symbol.
@@ -531,7 +531,7 @@ local function lineItemBox (it, invoice, isLast)
       Style("invoice-line-description", (it.description:gsub("\n+", "\n\n"):gsub("\n+$",""):gsub("^\n+","")))
     ),
     Cell({ border = border, valign="middle", halign = "right"  },
-      Decimal(it.quantity), it.unit and it.unit ~= "EA" and Style("invoice-unit", Unit(it.quantity, it.unit))
+      Decimal(it.quantity), it.unit ~= "EA" and Style("invoice-unit", Unit(it.quantity, it.unit))
     ),
     Cell({ border = border, valign="middle", halign = "right"  },
       Currency(it["unit-price"], invoice.currency)
@@ -834,7 +834,7 @@ function inputter:parse (doc)
   local invoice = t.invoice
 
   -- Extend function environments for i18n and number formatting
-  local context = { context = { language = invoice.language or "en" } }
+  local context = { context = { language = invoice.language } }
   I18n     = extendFunctionEnvironment(I18n, context)
   Currency = extendFunctionEnvironment(Currency, context)
   Percent  = extendFunctionEnvironment(Percent, context)
@@ -869,7 +869,7 @@ function inputter:parse (doc)
       )
     end
 
-  content[#content+1] =  CreateCommand("language", { main =  invoice.language or "en" },
+  content[#content+1] =  CreateCommand("language", { main =  invoice.language },
     mainInvoiceBox(invoice)
   )
 

--- a/inputters/silm.lua
+++ b/inputters/silm.lua
@@ -430,7 +430,7 @@ function inputter:parse (doc)
   -- Document wrap-up
   local options = sile.options or {}
   local classopts = isRoot and {
-      class = options.class or "resilient.book", -- Sane default. We Are Resilient.
+      class = options.class,
       papersize = options.papersize,
       layout = options.layout,
       resolution = options.resolution,

--- a/resilient/schemas/common.lua
+++ b/resilient/schemas/common.lua
@@ -29,6 +29,19 @@ local DateSchema = {
   required = { "year", "month", "day" },
 }
 
+--- Primitive schema (string, number, boolean).
+--
+-- @field type "oneOf"
+-- @table PrimitiveTypeSchema
+local PrimitiveTypeSchema = {
+  type = { -- oneOf
+    { type = "string" },
+    { type = "number" },
+    { type = "boolean" },
+  }
+}
+
 return {
   DateSchema = DateSchema,
+  PrimitiveTypeSchema = PrimitiveTypeSchema,
 }

--- a/resilient/schemas/invoice/init.lua
+++ b/resilient/schemas/invoice/init.lua
@@ -108,7 +108,7 @@ local IncludedSupplyChainTradeLineItemSchema = {
     },
     description = { type = "string" },
     quantity = { type = "number" },
-    unit = { type = "string", default = "EA" }, -- TODO Defaults not handled in our validator yet
+    unit = { type = "string", default = "EA" },
     ["unit-price"] = { type = "number" },
     ["tax-rate"] = { type = "number" },
   },
@@ -128,8 +128,11 @@ local InvoiceContentSchema = {
         { type = "number" },
       },
     },
-    language = { type = "string" }, -- Not from Factur-X, but we use it for localization
-    note = { type = "string" },     -- Not from Factur-X, but free text note for presentation
+    language = {  -- Not from Factur-X, but we use it for localization
+      type = "string",
+      default = "en",
+    },
+    note = { type = "string" }, -- Not from Factur-X, but free text note for presentation
     ["issue-date"] = DateSchema,
     ["due-date"] = { type = {
         DateSchema,
@@ -143,6 +146,7 @@ local InvoiceContentSchema = {
         { type = "string" },
         { type = "number" },
       },
+      default = "380", -- Standard invoice
     },
     seller = TradePartySchema,
     buyer = TradePartySchema,
@@ -160,10 +164,12 @@ local InvoiceContentSchema = {
 -- @field type "object"
 -- @table InvoiceSchema
 local InvoiceSchema = {
+  ["$id"] = "urn:example:omikhleia:resilient:invoice",
   type = "object",
   properties = {
     invoice = InvoiceContentSchema
-  }
+  },
+  required = { "invoice" },
 }
 
 return {

--- a/resilient/support/invoice/facturx.lua
+++ b/resilient/support/invoice/facturx.lua
@@ -200,7 +200,7 @@ local function IncludedSupplyChainTradeLineItem (it)
         -- UltimateCustomerOrderReferencedDocument
       '</ram:SpecifiedLineTradeAgreement>',
       '<ram:SpecifiedLineTradeDelivery>',
-        xmlTagHelper("ram:BilledQuantity", { unitCode = it.unit or "EA" }, tostring(it.quantity)), -- default unit is "EA" (each)
+        xmlTagHelper("ram:BilledQuantity", { unitCode = it.unit }, tostring(it.quantity)),
         -- ChargeFreeQuantity
         -- PackageQuantity
         -- ShipToTradeParty
@@ -218,7 +218,7 @@ local function IncludedSupplyChainTradeLineItem (it)
           -- BasisAmount
           -- LineTotalBasisAmount
           -- AllowanceChargeBasisAmount
-          xmlTagHelper("ram:CategoryCode", {}, it['tax-rate'] == 0 and "Z" or "S"),
+          xmlTagHelper("ram:CategoryCode", {}, it['tax-rate'] == 0 and "Z" or "S"), -- Zero or Standard
           -- ExemptionReasonCode
           -- TaxPointDate
           -- DueDateTypeCode


### PR DESCRIPTION
Introduce resilient.schemas debug flag.
Honor default values.
Honor additional properties sub-schemas.
These features allow for better debugging, and simplify the processing code afterwards as default values and inferred types are applied earler earlier.