### PR TITLE
feat(classes,packages): Add page style to page-breaking sectioning commands

### DIFF
--- a/classes/resilient/book.lua
+++ b/classes/resilient/book.lua
@@ -336,9 +336,11 @@ function class:registerStyles ()
                   align = "center",
                   after = { skip = "bigskip" } },
     sectioning = {  counter = { id ="parts", level = 1 },
+                    pagestyle = {
+                      open = "odd"
+                    },
                     settings = {
                       toclevel = 0,
-                      open = "odd"
                     },
                     numberstyle= {
                       main = "sectioning-part-main-number",
@@ -352,9 +354,11 @@ function class:registerStyles ()
     paragraph = {  align = "left",
                    after = { skip = "bigskip" } },
     sectioning = { counter = { id = "sections", level = 1 },
+                    pagestyle = {
+                      open = "odd",
+                    },
                     settings = {
                       toclevel = 1,
-                      open = "odd"
                     },
                     numberstyle= {
                       main = "sectioning-chapter-main-number",

--- a/examples/en-book/book-styles.yml
+++ b/examples/en-book/book-styles.yml
@@ -28,9 +28,11 @@ blockquote:
     paragraph:
       after:
         skip: "smallskip"
-      align: "quotation"
       before:
         skip: "smallskip"
+      margin:
+        left: "1.75em"
+        right: "0.875em"
 
 bookmatter-author:
   inherit: "bookmatter-titlepage"
@@ -48,7 +50,7 @@ bookmatter-backcover:
 bookmatter-copyright:
   style:
     paragraph:
-      align: "noparindent"
+      indent: false
 
 bookmatter-cover-author:
   inherit: "bookmatter-coverpage"
@@ -1283,7 +1285,9 @@ verbatim:
   inherit: "code"
   style:
     paragraph:
-      align: "obeylines"
+      align: "left"
       before:
         skip: "smallskip"
+      indent: false
+      lines: "preserve"
 

--- a/examples/en-book/book-styles.yml
+++ b/examples/en-book/book-styles.yml
@@ -1,5 +1,5 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/Omikhleia/resilient.sile/v2.8.0/schemas/stylefile.json
-# $schema: https://raw.githubusercontent.com/Omikhleia/resilient.sile/v2.8.0/schemas/stylefile.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Omikhleia/resilient.sile/v4.2.0/schemas/stylefile.json
+# $schema: https://raw.githubusercontent.com/Omikhleia/resilient.sile/v4.2.0/schemas/stylefile.json
 
 Author:
   style:
@@ -250,6 +250,14 @@ figure-caption:
 figure-caption-base-number:
   style:
 
+figure-caption-legend:
+  inherit: "figure-caption"
+  style:
+    paragraph:
+      after:
+        skip: "0"
+        vbreak: false
+
 figure-caption-main-number:
   inherit: "figure-caption-base-number"
   style:
@@ -268,6 +276,18 @@ figure-caption-ref-number:
     numbering:
       before:
         text: "fig. "
+
+figure-legend:
+  style:
+    font:
+      size: "0.95em"
+    paragraph:
+      after:
+        skip: "medskip"
+      align: "center"
+      before:
+        indent: false
+        vbreak: false
 
 folio-backmatter:
   style:
@@ -572,6 +592,14 @@ listing-caption:
 listing-caption-base-number:
   style:
 
+listing-caption-legend:
+  inherit: "listing-caption"
+  style:
+    paragraph:
+      after:
+        skip: "0"
+        vbreak: false
+
 listing-caption-main-number:
   inherit: "listing-caption-base-number"
   style:
@@ -590,6 +618,18 @@ listing-caption-ref-number:
     numbering:
       before:
         text: "listing "
+
+listing-legend:
+  style:
+    font:
+      size: "0.95em"
+    paragraph:
+      after:
+        skip: "medskip"
+      align: "center"
+      before:
+        indent: false
+        vbreak: false
 
 lists-enumerate-alternate1:
   inherit: "lists-enumerate-base"
@@ -808,8 +848,9 @@ sectioning-chapter:
         header: "sectioning-chapter-head-number"
         main: "sectioning-chapter-main-number"
         reference: "sectioning-chapter-ref-number"
-      settings:
+      pagestyle:
         open: "odd"
+      settings:
         toclevel: 1
 
 sectioning-chapter-base-number:
@@ -870,8 +911,9 @@ sectioning-part:
         header: "sectioning-part-head-number"
         main: "sectioning-part-main-number"
         reference: "sectioning-part-ref-number"
-      settings:
+      pagestyle:
         open: "odd"
+      settings:
         toclevel: 0
 
 sectioning-part-base-number:
@@ -1007,6 +1049,14 @@ table-caption:
 table-caption-base-number:
   style:
 
+table-caption-legend:
+  inherit: "table-caption"
+  style:
+    paragraph:
+      after:
+        skip: "0"
+        vbreak: false
+
 table-caption-main-number:
   inherit: "table-caption-base-number"
   style:
@@ -1025,6 +1075,18 @@ table-caption-ref-number:
     numbering:
       before:
         text: "table "
+
+table-legend:
+  style:
+    font:
+      size: "0.95em"
+    paragraph:
+      after:
+        skip: "medskip"
+      align: "center"
+      before:
+        indent: false
+        vbreak: false
 
 toc:
   style:

--- a/examples/fr-book/book-styles.yml
+++ b/examples/fr-book/book-styles.yml
@@ -28,9 +28,11 @@ blockquote:
     paragraph:
       after:
         skip: "smallskip"
-      align: "quotation"
       before:
         skip: "smallskip"
+      margin:
+        left: "1.75em"
+        right: "0.875em"
 
 bookmatter-author:
   inherit: "bookmatter-titlepage"
@@ -48,7 +50,7 @@ bookmatter-backcover:
 bookmatter-copyright:
   style:
     paragraph:
-      align: "noparindent"
+      indent: false
 
 bookmatter-cover-author:
   inherit: "bookmatter-coverpage"
@@ -1286,7 +1288,9 @@ verbatim:
   inherit: "code"
   style:
     paragraph:
-      align: "obeylines"
+      align: "left"
       before:
         skip: "smallskip"
+      indent: false
+      lines: "preserve"
 

--- a/examples/fr-book/book-styles.yml
+++ b/examples/fr-book/book-styles.yml
@@ -1,5 +1,5 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/Omikhleia/resilient.sile/v2.8.0/schemas/stylefile.json
-# $schema: https://raw.githubusercontent.com/Omikhleia/resilient.sile/v2.8.0/schemas/stylefile.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Omikhleia/resilient.sile/v4.2.0/schemas/stylefile.json
+# $schema: https://raw.githubusercontent.com/Omikhleia/resilient.sile/v4.2.0/schemas/stylefile.json
 
 Author:
   style:
@@ -250,6 +250,14 @@ figure-caption:
 figure-caption-base-number:
   style:
 
+figure-caption-legend:
+  inherit: "figure-caption"
+  style:
+    paragraph:
+      after:
+        skip: "0"
+        vbreak: false
+
 figure-caption-main-number:
   inherit: "figure-caption-base-number"
   style:
@@ -268,6 +276,18 @@ figure-caption-ref-number:
     numbering:
       before:
         text: "fig. "
+
+figure-legend:
+  style:
+    font:
+      size: "0.95em"
+    paragraph:
+      after:
+        skip: "medskip"
+      align: "center"
+      before:
+        indent: false
+        vbreak: false
 
 folio-backmatter:
   style:
@@ -575,6 +595,14 @@ listing-caption:
 listing-caption-base-number:
   style:
 
+listing-caption-legend:
+  inherit: "listing-caption"
+  style:
+    paragraph:
+      after:
+        skip: "0"
+        vbreak: false
+
 listing-caption-main-number:
   inherit: "listing-caption-base-number"
   style:
@@ -593,6 +621,18 @@ listing-caption-ref-number:
     numbering:
       before:
         text: "listing "
+
+listing-legend:
+  style:
+    font:
+      size: "0.95em"
+    paragraph:
+      after:
+        skip: "medskip"
+      align: "center"
+      before:
+        indent: false
+        vbreak: false
 
 lists-enumerate-alternate1:
   inherit: "lists-enumerate-base"
@@ -811,8 +851,9 @@ sectioning-chapter:
         header: "sectioning-chapter-head-number"
         main: "sectioning-chapter-main-number"
         reference: "sectioning-chapter-ref-number"
-      settings:
+      pagestyle:
         open: "odd"
+      settings:
         toclevel: 1
 
 sectioning-chapter-base-number:
@@ -873,8 +914,9 @@ sectioning-part:
         header: "sectioning-part-head-number"
         main: "sectioning-part-main-number"
         reference: "sectioning-part-ref-number"
-      settings:
+      pagestyle:
         open: "odd"
+      settings:
         toclevel: 0
 
 sectioning-part-base-number:
@@ -1010,6 +1052,14 @@ table-caption:
 table-caption-base-number:
   style:
 
+table-caption-legend:
+  inherit: "table-caption"
+  style:
+    paragraph:
+      after:
+        skip: "0"
+        vbreak: false
+
 table-caption-main-number:
   inherit: "table-caption-base-number"
   style:
@@ -1028,6 +1078,18 @@ table-caption-ref-number:
     numbering:
       before:
         text: "table "
+
+table-legend:
+  style:
+    font:
+      size: "0.95em"
+    paragraph:
+      after:
+        skip: "medskip"
+      align: "center"
+      before:
+        indent: false
+        vbreak: false
 
 toc:
   style:

--- a/examples/sil/lefevre-tuor-idril-styles.yml
+++ b/examples/sil/lefevre-tuor-idril-styles.yml
@@ -17,9 +17,11 @@ blockquote:
     paragraph:
       after:
         skip: "smallskip"
-      align: "quotation"
       before:
         skip: "smallskip"
+      margin:
+        left: "1.75em"
+        right: "0.875em"
 
 code:
   style:
@@ -1174,7 +1176,9 @@ verbatim:
   inherit: "code"
   style:
     paragraph:
-      align: "obeylines"
+      align: "left"
       before:
         skip: "smallskip"
+      indent: false
+      lines: "preserve"
 

--- a/examples/sil/lefevre-tuor-idril-styles.yml
+++ b/examples/sil/lefevre-tuor-idril-styles.yml
@@ -1,5 +1,5 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/Omikhleia/resilient.sile/v2.8.0/schemas/stylefile.json
-# $schema: https://raw.githubusercontent.com/Omikhleia/resilient.sile/v2.8.0/schemas/stylefile.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Omikhleia/resilient.sile/v4.2.0/schemas/stylefile.json
+# $schema: https://raw.githubusercontent.com/Omikhleia/resilient.sile/v4.2.0/schemas/stylefile.json
 
 Author:
   style:
@@ -138,6 +138,14 @@ figure-caption:
 figure-caption-base-number:
   style:
 
+figure-caption-legend:
+  inherit: "figure-caption"
+  style:
+    paragraph:
+      after:
+        skip: "0"
+        vbreak: false
+
 figure-caption-main-number:
   inherit: "figure-caption-base-number"
   style:
@@ -156,6 +164,18 @@ figure-caption-ref-number:
     numbering:
       before:
         text: "fig. "
+
+figure-legend:
+  style:
+    font:
+      size: "0.95em"
+    paragraph:
+      after:
+        skip: "medskip"
+      align: "center"
+      before:
+        indent: false
+        vbreak: false
 
 folio-backmatter:
   style:
@@ -419,6 +439,14 @@ highlight-variable.builtin:
   style:
     color: "#C82829"
 
+index-entry-main:
+  style:
+
+index-pages-main:
+  style:
+    font:
+      features: "+onum"
+
 listing:
   style:
     paragraph:
@@ -455,6 +483,14 @@ listing-caption:
 listing-caption-base-number:
   style:
 
+listing-caption-legend:
+  inherit: "listing-caption"
+  style:
+    paragraph:
+      after:
+        skip: "0"
+        vbreak: false
+
 listing-caption-main-number:
   inherit: "listing-caption-base-number"
   style:
@@ -473,6 +509,18 @@ listing-caption-ref-number:
     numbering:
       before:
         text: "listing "
+
+listing-legend:
+  style:
+    font:
+      size: "0.95em"
+    paragraph:
+      after:
+        skip: "medskip"
+      align: "center"
+      before:
+        indent: false
+        vbreak: false
 
 lists-enumerate-alternate1:
   inherit: "lists-enumerate-base"
@@ -691,8 +739,9 @@ sectioning-chapter:
         header: "sectioning-chapter-head-number"
         main: "sectioning-chapter-main-number"
         reference: "sectioning-chapter-ref-number"
-      settings:
+      pagestyle:
         open: "odd"
+      settings:
         toclevel: 1
 
 sectioning-chapter-base-number:
@@ -753,8 +802,9 @@ sectioning-part:
         header: "sectioning-part-head-number"
         main: "sectioning-part-main-number"
         reference: "sectioning-part-ref-number"
-      settings:
+      pagestyle:
         open: "odd"
+      settings:
         toclevel: 0
 
 sectioning-part-base-number:
@@ -890,6 +940,14 @@ table-caption:
 table-caption-base-number:
   style:
 
+table-caption-legend:
+  inherit: "table-caption"
+  style:
+    paragraph:
+      after:
+        skip: "0"
+        vbreak: false
+
 table-caption-main-number:
   inherit: "table-caption-base-number"
   style:
@@ -908,6 +966,18 @@ table-caption-ref-number:
     numbering:
       before:
         text: "table "
+
+table-legend:
+  style:
+    font:
+      size: "0.95em"
+    paragraph:
+      after:
+        skip: "medskip"
+      align: "center"
+      before:
+        indent: false
+        vbreak: false
 
 toc:
   style:

--- a/guides/djot-markdown/sile-and-markdown-manual-styles.yml
+++ b/guides/djot-markdown/sile-and-markdown-manual-styles.yml
@@ -1,5 +1,5 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/Omikhleia/resilient.sile/v2.8.0/schemas/stylefile.json
-# $schema: https://raw.githubusercontent.com/Omikhleia/resilient.sile/v2.8.0/schemas/stylefile.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Omikhleia/resilient.sile/v4.2.0/schemas/stylefile.json
+# $schema: https://raw.githubusercontent.com/Omikhleia/resilient.sile/v4.2.0/schemas/stylefile.json
 
 CodeBlock:
   style:
@@ -947,8 +947,9 @@ sectioning-chapter:
       numberstyle:
         main: "sectioning-chapter-main-number"
         reference: "sectioning-chapter-ref-number"
-      settings:
+      pagestyle:
         open: "odd"
+      settings:
         toclevel: 1
 
 sectioning-chapter-base-number:
@@ -1009,8 +1010,9 @@ sectioning-part:
         header: "sectioning-part-head-number"
         main: "sectioning-part-main-number"
         reference: "sectioning-part-ref-number"
-      settings:
+      pagestyle:
         open: "odd"
+      settings:
         toclevel: 0
 
 sectioning-part-base-number:

--- a/guides/resilient/manual-styling/basics/sectioning.dj
+++ b/guides/resilient/manual-styling/basics/sectioning.dj
@@ -23,6 +23,7 @@ With these first assumptions in mind, let’s summarize the requirements:
  - Sections going into a table of contents may as well possibly go in the PDF bookmarks
    (outline).
  - Sections may trigger a page break and may even need to open on an odd page.
+   When they do, a background color or image can be set for the page they start on.
  - Sections, especially those who do not cause a (forced) page break, may recommmend
    allowing a page break before them (so usual that it should default to true).
  - Sections can be interdependent, in the sense that some of them may reset the counters
@@ -53,8 +54,12 @@ Here is, therefore, the style specification.
       settings:
         toclevel: ⟨integer⟩
         bookmark: true|false
-        open: "unset|any|odd"
         goodbreak: true|false
+      pagestyle:
+        open: "unset|any|odd"
+        background:
+          color: "⟨color specification⟩"
+          image: "⟨string⟩" | ⟨image specification⟩
       numberstyle:
         main: "⟨number style name⟩"
         header: "⟨number style name⟩"
@@ -65,7 +70,30 @@ Here is, therefore, the style specification.
 That’s a lot of fields. However, many have default values and the simple
 inheritance mechanism provided by the styles also allows one to reuse existing
 base specifications. In this author’s opinion, it is quite flexible and clear.
-The two last options, however, may require a clarification.
+The three last options, however, may require a clarification.
+
+The `pagestyle` specification defines the page break behavior of the section, and the background to be applied to the page it starts on, if any.
+If the `open` property is set to "any" or "odd", the section will cause a page break.
+In that case, the `background` specification will be applied to the new page it starts on.
+It can consist in a color, an image, or both.
+The color will be applied as a background color to the page, while the image will be placed on top of it, with the specified scaling and anchoring.
+
+The image, when set, can be specified as a simple string, in which case it will be used as is, scaled and anchored to the center of the page.
+Alternatively, it can be specified with more options, as follows:
+
+```yaml
+image:
+  src: "⟨string⟩"
+  scale: true|false
+  preserve-aspect: false|true
+  anchor: "center|n|e|e|se|s|sw|w|nw"
+  page: ⟨integer⟩
+```
+
+It can also be anchored to a specific position on the page.
+If the image is a multi-page document, the `page` property can be used to specify which page to use (default is 1).
+New pages are typically used with parts and chapters.
+The background specification is then a nice way to set some visual distinction for these sections.
 
 The `numberstyle` specification defines which number style should be used for the section number, depending on the context where it appears (main text flow, running headers and cross-references).[^toc-numbering-incertain]
 Note that if a given context is absent, the section number will not be displayed.

--- a/guides/resilient/sile-resilient-manual-styles.yml
+++ b/guides/resilient/sile-resilient-manual-styles.yml
@@ -250,7 +250,7 @@ figure-caption:
       align: "center"
       before:
         indent: false
-        skip: "medskip"
+        skip: "smallskip"
         vbreak: false
     sectioning:
       counter:
@@ -1336,7 +1336,9 @@ verbatim:
     paragraph:
       after:
         skip: "smallskip"
-      align: "obeylines"
+      align: "left"
       before:
         skip: "smallskip"
+      indent: false
+      lines: "preserve"
 

--- a/guides/resilient/sile-resilient-manual-styles.yml
+++ b/guides/resilient/sile-resilient-manual-styles.yml
@@ -1,5 +1,5 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/Omikhleia/resilient.sile/v2.8.0/schemas/stylefile.json
-# $schema: https://raw.githubusercontent.com/Omikhleia/resilient.sile/v2.8.0/schemas/stylefile.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Omikhleia/resilient.sile/v4.2.0/schemas/stylefile.json
+# $schema: https://raw.githubusercontent.com/Omikhleia/resilient.sile/v4.2.0/schemas/stylefile.json
 
 blockquote:
   style:
@@ -904,8 +904,9 @@ sectioning-chapter:
       numberstyle:
         main: "sectioning-chapter-main-number"
         reference: "sectioning-chapter-ref-number"
-      settings:
+      pagestyle:
         open: "odd"
+      settings:
         toclevel: 1
 
 sectioning-chapter-base-number:
@@ -965,8 +966,9 @@ sectioning-part:
         header: "sectioning-part-head-number"
         main: "sectioning-part-main-number"
         reference: "sectioning-part-ref-number"
-      settings:
+      pagestyle:
         open: "odd"
+      settings:
         toclevel: 0
 
 sectioning-part-base-number:

--- a/packages/resilient/sectioning/init.lua
+++ b/packages/resilient/sectioning/init.lua
@@ -21,6 +21,7 @@ package._name = "resilient.sectioning"
 function package:_init (options)
   base._init(self, options)
   self:loadPackage("counters")
+  self:loadPackage("background")
 end
 
 local function hasContentInCurrentPage()
@@ -56,6 +57,26 @@ local function nameIfNotNull (name)
   SU.error("Invalid style name, expected a string or YAML null")
 end
 
+local function pageBackgroundOptions (options)
+  local pageOpts = {
+    allpages = false,
+    color = options.color,
+  }
+  local imageOpts = options.image
+  if imageOpts then
+    if type(imageOpts) == "table" then
+      pageOpts.src = imageOpts.src and tostring(imageOpts.src) or nil
+      pageOpts.scale = SU.boolean(imageOpts.scale, true)
+      pageOpts.preserveaspect = SU.boolean(imageOpts["preserve-aspect"], false)
+      pageOpts.page = imageOpts.page and SU.cast("integer", imageOpts.page) or nil
+      pageOpts.anchor = imageOpts.anchor
+    else
+      pageOpts.src = tostring(imageOpts)
+    end
+  end
+  return pageOpts
+end
+
 --- (Override) Register all commands provided by this package.
 function package:registerCommands ()
 
@@ -68,9 +89,11 @@ function package:registerCommands ()
         or SU.error("Sectioning style '"..name.."' must have a counter")
       styledef.sectioning.counter.level = styledef.sectioning.counter.level or 1
 
+      -- Apply pagestyle defaults
+      styledef.sectioning.pagestyle = styledef.sectioning.pagestyle or {}
+
       -- Apply settings defaults
       styledef.sectioning.settings = styledef.sectioning.settings or {}
-      -- styledef.sectioning.settings.open: if nil = do not open a page
       styledef.sectioning.settings.toclevel = styledef.sectioning.settings.toclevel
         and SU.cast("integer", styledef.sectioning.settings.toclevel)
       styledef.sectioning.settings.goodbreak = SU.boolean(styledef.sectioning.settings.goodbreak, true)
@@ -99,9 +122,9 @@ function package:registerCommands ()
 
     -- Handle the page-break: opening page: "unset", "odd" or "any"
     -- (Would "even" be useful? I do not think is has any actual use)
-    if secStyle.settings.open and secStyle.settings.open ~= "unset" then
+    if secStyle.pagestyle.open and secStyle.pagestyle.open ~= "unset" then
       -- Sectioning style that causes a page-break.
-      if secStyle.settings.open == "odd" then
+      if secStyle.pagestyle.open == "odd" then
         SILE.call("open-on-odd-page")
       else -- Case: any
         SILE.call("open-on-any-page")
@@ -111,6 +134,14 @@ function package:registerCommands ()
         -- the page. Introduces a line, though. I haven't found how to avoid
         -- it :(
         SILE.typesetter:initline()
+      end
+      if secStyle.pagestyle and secStyle.pagestyle.background then
+        local opts = pageBackgroundOptions(secStyle.pagestyle.background)
+        if not(opts.color or opts.src) then
+          SU.warn("Sectioning style '" .. name .. "' has a pagestyle background without color or image source")
+        else
+          SILE.call("background", opts)
+        end
       end
     end
     -- N.B. for sectioning style that doesn't cause a forced page-break,

--- a/packages/resilient/styles/init.lua
+++ b/packages/resilient/styles/init.lua
@@ -585,7 +585,7 @@ function package:registerCommands ()
     local withIndent = styleForIndent(style, withAlign)
     local withFont = characterStyleFont(style, withIndent)
 
-    -- We never know for suree if some of the above introduced a "par"
+    -- We never know for sure if some of the above introduced a "par"
     -- possibly a parskip.
     local block = wrapContentInNovbreak(style, withFont)
     return block
@@ -760,13 +760,22 @@ function package:registerCommands ()
 
     content = hackSubContent(content, name) -- HACK: see above
 
+    -- FIXME
+    -- This whole logic is still a mix of AST manipulation and direct typesetter calls, and is quite messy.
+    --  - Leaveing hmode vs. calling "par" is a mess
+    --  - However many dubious attempts at inserting "novbreak" to avoid unwanted page breaks,
+    --    there are still some cases where unwanted breaks can occur ?!
+    --    E.g. between a figure and its caption
     local bb = SU.boolean(parSty.before.vbreak, true)
-    if #SILE.typesetter.state.nodes then
-      if not bb then
-        SILE.call("novbreak")
-      else
-        SILE.typesetter:leaveHmode()
-      end
+
+    -- Close previous paragraph if any.
+    -- FIXME: We should use a "par" to insert a parskip if needed.
+    -- But we currently have an issue with multiple consecutive "parskips"...
+    --SILE.call("par") -- Close previous paragraph
+    SILE.typesetter:leaveHmode()
+
+    if not bb then
+      SILE.call("novbreak")
     end
 
     styleForBeforeSkip(name, parSty, styledef)
@@ -785,11 +794,14 @@ function package:registerCommands ()
     if not ba then
       SILE.call("novbreak")
     end
-    -- FIXME NOTE: SILE.call("par") would cause a parskip to be inserted.
-    -- Not really sure whether we expect this here or not ???
-    -- SILE.call("par")
+    -- Close this paragraph block
+    -- FIXME: We should use a "par" to insert a parskip if needed.
+    -- But we currently have an issue with multiple consecutive "parskips"...
+    --SILE.call("par") -- Close previous paragraph
+    SILE.typesetter:leaveHmode()
 
     styleForAfterSkip(name, parSty)
+
     if parSty.after.indent then
       SILE.call("indent")
     else

--- a/packages/resilient/styles/init.lua
+++ b/packages/resilient/styles/init.lua
@@ -123,9 +123,10 @@ local function compatibilityHackV42 (style)
   -- Transitional compatibility adapter for alignments (block, quotation, poetry)
   -- Removed in v4.2, but keeping compatibility.
   -- Note the bad separation of concerns:
-  --  - block, quotation are declared in the resilient.book class and based on a book.blockquote.margin setting
-  --  - poetry is declared in the resilient.poetry package and based on a poetry.margin setting
-  --  - noparindent is declared in the resilient.bookmatters package.
+  --  - block, quotation were declared in the resilient.book class and based on a book.blockquote.margin setting
+  --  - poetry was declared in the resilient.poetry package and based on a poetry.margin setting
+  --  - noparindent was declared in the resilient.bookmatters package.
+  --  - obeylines was declared in the resilient.verbatim package.
   -- We are not querying those settings here, but just applying their defaults.
   if style.paragraph and style.paragraph.align then
     if style.paragraph.align == "block" then
@@ -155,6 +156,14 @@ local function compatibilityHackV42 (style)
       style.paragraph.indent = false
       SILE.scratch.styles.needCompatibility = true
     end
+  end
+  -- Transitional compatibility adapter for sectioning "open" pagestyle
+  -- Also a bad separation of concerns, the support is from the resilient.sectioning package.
+  if style.sectioning and style.sectioning.settings and style.sectioning.settings.open then
+    style.sectioning.pagestyle = style.sectioning.pagestyle or {}
+    style.sectioning.pagestyle.open = style.sectioning.settings.open
+    style.sectioning.settings.open = nil
+    SILE.scratch.styles.needCompatibility = true
   end
 end
 
@@ -226,8 +235,8 @@ function package.writeStyles () -- NOTE: Not called as a package method (invoked
   local styfile, err = io.open(fname, "w")
   if not styfile then return SU.error(err) end
   styfile:write([[
-# yaml-language-server: $schema=https://raw.githubusercontent.com/Omikhleia/resilient.sile/v2.8.0/schemas/stylefile.json
-# $schema: https://raw.githubusercontent.com/Omikhleia/resilient.sile/v2.8.0/schemas/stylefile.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Omikhleia/resilient.sile/v4.2.0/schemas/stylefile.json
+# $schema: https://raw.githubusercontent.com/Omikhleia/resilient.sile/v4.2.0/schemas/stylefile.json
 ]])
   styfile:write(stydata)
   styfile:close()

--- a/schemas/stylefile.json
+++ b/schemas/stylefile.json
@@ -150,6 +150,10 @@
                     }
                   }
                 },
+                "pagestyle": {
+                  "description": "Page style properties for the sectioning style",
+                  "$ref": "#/$defs/PageStyleProperties"
+                },
                 "settings": {
                   "description": "Settings for the sectioning style",
                   "type": "object",
@@ -162,15 +166,6 @@
                     "bookmark": {
                       "description": "Whether to create a bookmark",
                       "type": "boolean"
-                    },
-                    "open": {
-                      "description": "Whether to start on an odd page, on any page, or unset",
-                      "type": "string",
-                      "enum": [
-                        "unset",
-                        "any",
-                        "odd"
-                      ]
                     },
                     "goodbreak": {
                       "description": "Whether a good break is considered good",
@@ -412,6 +407,81 @@
         "lines": {
           "description": "Number of drop cap lines",
           "type": "integer"
+        }
+      }
+    },
+    "PageBackgroundProperties": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "color": {
+          "description": "Background color of the page",
+          "$ref": "#/$defs/ColorSpecification"
+        },
+        "image": {
+          "oneOf": [
+            {
+              "description": "Background image of the page (file name)",
+              "type": "string"
+            },
+            {
+              "description": "Background image of the page (with options)",
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "src": {
+                  "description": "Source of the background image",
+                  "type": "string"
+                },
+                "scale": {
+                  "description": "Whether to scale the background image to fit the page",
+                  "type": "boolean"
+                },
+                "preserve-aspect": {
+                  "description": "Whether to preserve the aspect ratio of the background image when scaling",
+                  "type": "boolean"
+                },
+                "anchor": {
+                  "description": "Anchor point for the background image (default: center)",
+                  "type": "string",
+                  "enum": [
+                    "center",
+                    "n",
+                    "ne",
+                    "e",
+                    "se",
+                    "s",
+                    "sw",
+                    "w",
+                    "nw"
+                  ]
+                },
+                "page": {
+                  "description": "page to use as background (default: 1) if the background image is a multi-page image (e.g. a PDF)",
+                  "type": "integer"
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    "PageStyleProperties": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "open": {
+          "description": "Whether to start on an odd page, on any page, or unset",
+          "type": "string",
+          "enum": [
+            "unset",
+            "any",
+            "odd"
+          ]
+        },
+        "background": {
+          "description": "Page background properties (when open is not 'unset')",
+          "$ref": "#/$defs/PageBackgroundProperties"
         }
       }
     },


### PR DESCRIPTION
In recent books for Le Dragon de Brume, we fancied having background images on chapters' opening page.

In slides (experimental support ~~not pushed yet~~)[^1], I want a color or an image background in part-like sections.

~~N.B. Full support requires https://github.com/sile-typesetter/sile/pull/2346 (proposed in Nov. 2025) for SILE's background package.~~ No longer needed, see #200 for details.

[^1]: See #202 for (at this day) some work in progress on that matter.