### PR TITLE
feat(inputters): Allow enabling cover and book matters separately in master files

### DIFF
--- a/examples/en-book/book.silm
+++ b/examples/en-book/book.silm
@@ -1,5 +1,5 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/Omikhleia/resilient.sile/v2.8.0/schemas/masterfile.json
-# $schema: https://raw.githubusercontent.com/Omikhleia/resilient.sile/v2.8.0/schemas/masterfile.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Omikhleia/resilient.sile/v4.2.0/schemas/masterfile.json
+# $schema: https://raw.githubusercontent.com/Omikhleia/resilient.sile/v4.2.0/schemas/masterfile.json
 masterfile: 1.0
 metadata:
   title: The Lost Tale of Mercury

--- a/examples/fr-book/book.silm
+++ b/examples/fr-book/book.silm
@@ -1,5 +1,5 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/Omikhleia/resilient.sile/v2.8.0/schemas/masterfile.json
-# $schema: https://raw.githubusercontent.com/Omikhleia/resilient.sile/v2.8.0/schemas/masterfile.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Omikhleia/resilient.sile/v4.2.0/schemas/masterfile.json
+# $schema: https://raw.githubusercontent.com/Omikhleia/resilient.sile/v4.2.0/schemas/masterfile.json
 masterfile: 1.0
 metadata:
   title: Le conte perdu de Mercure

--- a/guides/djot-markdown/sile-and-markdown-manual.silm
+++ b/guides/djot-markdown/sile-and-markdown-manual.silm
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Omikhleia/resilient.sile/v4.2.0/schemas/masterfile.json
+# $schema: https://raw.githubusercontent.com/Omikhleia/resilient.sile/v4.2.0/schemas/masterfile.json
 masterfile: 1.0
 metadata:
   title: Markdown and Djot to PDF with SILE

--- a/guides/resilient/manual-masterdoc/bookmatters.dj
+++ b/guides/resilient/manual-masterdoc/bookmatters.dj
@@ -54,7 +54,6 @@ By default, the following templates are used:
 
 ```yaml
 book:
-  enabled: true|false
   halftitle:
     recto: halftitle-recto
     verso: halftitle-verso
@@ -195,4 +194,22 @@ If your paper size is 6 per 9 inches (US trade book), for instance, you can prin
 
 ```bash
 sile -u inputters.silm[cropmarks=true] -O sheetsize=a4 mybook.silm
+```
+
+As stated earlier, the cover and book matter pages can also be enabled with individual options passed to the master document handler.
+You can set them in the `book` section of your master document file, so as to have them enabled by default.
+Either use a single option to enable them all at once...
+
+```yaml
+book:
+  enabled: false|true
+```
+
+Or, if you want to enable and disable them separately, you can use a nested structure:
+
+```yaml
+book:
+  enabled:
+    bookmatter: false|true
+    cover: false|true
 ```

--- a/guides/resilient/sile-resilient-manual.silm
+++ b/guides/resilient/sile-resilient-manual.silm
@@ -1,5 +1,5 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/Omikhleia/resilient.sile/v2.8.0/schemas/masterfile.json
-# $schema: https://raw.githubusercontent.com/Omikhleia/resilient.sile/v2.8.0/schemas/masterfile.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Omikhleia/resilient.sile/v4.2.0/schemas/masterfile.json
+# $schema: https://raw.githubusercontent.com/Omikhleia/resilient.sile/v4.2.0/schemas/masterfile.json
 masterfile: 1.0
 metadata:
   title: The re·sil·ient collection of classes & packages for SILE

--- a/inputters/silm.lua
+++ b/inputters/silm.lua
@@ -349,42 +349,52 @@ function inputter:parse (doc)
 
   local metadataOptions = handleDjotMetadata(metadata)
 
-  local bookmatter = master.book or {}
-  bookmatter = {
-    halftitle = bookmatter.halftitle or {},
-    title = bookmatter.title or {},
-    endpaper = bookmatter.endpaper or {},
-    cover = bookmatter.cover,
-    enabled = SU.boolean(bookmatter.enabled, false)
+  local book = master.book or {}
+  if type(book.enabled) == "boolean" then
+    book.enabled = {
+      cover = SU.boolean(book.enabled, false),
+      bookmatter = SU.boolean(book.enabled, false),
+    }
+  else
+    book.enabled = book.enabled or {}
+    book.enabled.cover = SU.boolean(book.enabled.cover, false)
+    book.enabled.bookmatter = SU.boolean(book.enabled.bookmatter, false)
+  end
+  book = {
+    halftitle = book.halftitle or {},
+    title = book.title or {},
+    endpaper = book.endpaper or {},
+    cover = book.cover,
+    enabled = book.enabled
   }
-  local enabledBook = isRoot and SU.boolean(self.options.bookmatter, bookmatter.enabled)
-  local enabledCover = isRoot and SU.boolean(self.options.cover, bookmatter.enabled)
+  local enabledBookMatter = isRoot and SU.boolean(self.options.bookmatter, book.enabled.bookmatter)
+  local enabledCover = isRoot and SU.boolean(self.options.cover, book.enabled.cover)
 
-  if enabledBook or enabledCover then
+  if enabledBookMatter or enabledCover then
     content[#content+1] = SU.ast.createCommand("use", {
       module = "packages.resilient.bookmatters"
     })
   end
 
-  if enabledCover and bookmatter.cover then
-    local cover = bookmatter.cover.front
+  if enabledCover and book.cover then
+    local cover = book.cover.front
     content[#content+1] = SU.ast.createCommand("bookmatters:front-cover", {
-      image = cover and cover.image or bookmatter.cover.image,
-      background = cover and cover.background or bookmatter.cover.background,
+      image = cover and cover.image or book.cover.image,
+      background = cover and cover.background or book.cover.background,
       template = cover and cover.template,
       metadata = metadataOptions
     })
   end
 
-  if enabledBook then
+  if enabledBookMatter then
     content[#content+1] = SU.ast.createCommand("bookmatters:template", {
-      recto = bookmatter.halftitle.recto or "halftitle-recto",
-      verso = bookmatter.halftitle.verso or "halftitle-verso",
+      recto = book.halftitle.recto or "halftitle-recto",
+      verso = book.halftitle.verso or "halftitle-verso",
       metadata = metadataOptions
     })
     content[#content+1] =  SU.ast.createCommand("bookmatters:template", {
-      recto = bookmatter.title.recto or "title-recto",
-      verso = bookmatter.title.verso or "title-verso",
+      recto = book.title.recto or "title-recto",
+      verso = book.title.verso or "title-verso",
       metadata = metadataOptions
     })
   end
@@ -403,19 +413,19 @@ function inputter:parse (doc)
     doDivisionContent(content, master, baseShiftHeadings, metadataOptions)
   end
 
-  if enabledBook then
+  if enabledBookMatter then
     content[#content+1] = SU.ast.createCommand("bookmatters:template", {
-      recto = bookmatter.endpaper.recto or "endpaper-recto",
-      verso = bookmatter.endpaper.verso or "endpaper-verso",
+      recto = book.endpaper.recto or "endpaper-recto",
+      verso = book.endpaper.verso or "endpaper-verso",
       metadata = metadataOptions
     })
   end
-  if enabledCover and bookmatter.cover then
-    local cover = bookmatter.cover.back
-    local background = cover and cover.background or bookmatter.cover.background
+  if enabledCover and book.cover then
+    local cover = book.cover.back
+    local background = cover and cover.background or book.cover.background
     local coverContent = cover and cover.content or nil
     content[#content+1] = SU.ast.createCommand("bookmatters:back-cover", {
-      image = cover and cover.image or bookmatter.cover.image,
+      image = cover and cover.image or book.cover.image,
       background = background,
       bgcontent = cover and cover["content-background"] or background,
       metadata = metadataOptions

--- a/resilient/schemas/silm/init.lua
+++ b/resilient/schemas/silm/init.lua
@@ -80,7 +80,17 @@ local ContentInPartSchema = {
 local BookSchema = {
   type = "object",
   properties = {
-    enabled = { type = "boolean" },
+    enabled = {
+      type = { -- oneOf
+        { type = "boolean" },
+        { type = "object",
+          properties = {
+            cover = { type = "boolean" },
+            bookmatter = { type = "boolean" },
+          }
+        }
+      }
+    },
     cover = {
       type = "object",
       properties = {

--- a/schemas/masterfile.json
+++ b/schemas/masterfile.json
@@ -214,8 +214,26 @@
       "additionalProperties": false,
       "properties": {
         "enabled": {
-          "description": "Whether the book matters and covers are enabled by default",
-          "type": "boolean"
+          "oneOf": [
+            {
+              "type": "boolean",
+              "description": "Whether the book matters and covers are enabled by default"
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "cover": {
+                  "description": "Whether the covers are enabled by default",
+                  "type": "boolean"
+                },
+                "bookmatter": {
+                  "description": "Whether the book matters are enabled by default",
+                  "type": "boolean"
+                }
+              }
+            }
+          ]
         },
         "cover": {
           "description": "The cover configuration",


### PR DESCRIPTION
Closes #190 

Besides the existing syntax (which enables/disables both the covers and the book matter pages) in master document files:

```
book:
   enabled: false|true
```

Now also support enabling them separately:

```
book:
   enabled:
      cover: false|true
      bookmatter: false|true
```