### PR TITLE
feat(packages): Add resilient.gradients package

### DIFF
--- a/examples/en-book/book.silm
+++ b/examples/en-book/book.silm
@@ -27,7 +27,7 @@ language: en
 book:
   enabled: true
   cover:
-    background: "#9ebd76"
+    background: anthracites
     front:
       template: cover
     back:

--- a/examples/fr-book/book.silm
+++ b/examples/fr-book/book.silm
@@ -27,7 +27,7 @@ language: fr
 book:
   enabled: true
   cover:
-    background: "#9ebd76"
+    background: anthracites
     front:
       template: cover
     back:

--- a/guides/resilient/manual-masterdoc/bookmatters.dj
+++ b/guides/resilient/manual-masterdoc/bookmatters.dj
@@ -144,7 +144,7 @@ book:
   cover:
     back:
       image: mycover-back.jpg
-      background: ⟨named color⟩|"#⟨RGB color⟩"
+      background: "⟨color specification|gradient name⟩"
       content: mybackcover.dj
 ```
 
@@ -158,9 +158,9 @@ You also have the option to specify a separate background color specifically for
 book:
   cover:
     back:
-      background: ⟨named color⟩|"#⟨RGB color⟩"
+      background: "⟨color specification|gradient name⟩"
       content: mybackcover.dj
-      content-background: ⟨named color⟩|"#⟨RGB color⟩"
+      content-background: "⟨color specification|gradient name⟩"
 ```
 
 ## Configuring the front cover

--- a/guides/resilient/manual-packages/packages.dj
+++ b/guides/resilient/manual-packages/packages.dj
@@ -268,3 +268,8 @@ class writers.
 ``` =sile
 \package-documentation{resilient.forms}
 ```
+
+## Support for gradients
+
+``` =sile
+\package-documentation{resilient.gradients}

--- a/guides/resilient/manual-styling/basics/character.dj
+++ b/guides/resilient/manual-styling/basics/character.dj
@@ -49,7 +49,7 @@ The ⟨decoration specification⟩ is an object which can contain any of the fol
 ```yaml
 decoration:
   line: "underline|strikethrough|redacted|mark"
-  color: "⟨color specification⟩"
+  color: "⟨color specification|gradient name⟩"
   thickness: "⟨dimen⟩"
   rough: true|false
   fillstyle: "hachure|solid|zigzag|cross-hatch|dashed|zigzag-line"

--- a/guides/resilient/manual-styling/basics/sectioning.dj
+++ b/guides/resilient/manual-styling/basics/sectioning.dj
@@ -58,7 +58,7 @@ Here is, therefore, the style specification.
       pagestyle:
         open: "unset|any|odd"
         background:
-          color: "⟨color specification⟩"
+          color: "⟨color specification|gradient name⟩"
           image: "⟨string⟩" | ⟨image specification⟩
       numberstyle:
         main: "⟨number style name⟩"

--- a/inputters/silm.lua
+++ b/inputters/silm.lua
@@ -427,7 +427,7 @@ function inputter:parse (doc)
     content[#content+1] = SU.ast.createCommand("bookmatters:back-cover", {
       image = cover and cover.image or book.cover.image,
       background = background,
-      bgcontent = cover and cover["content-background"] or background,
+      bgcontent = cover and cover["content-background"],
       metadata = metadataOptions
     }, doBackCoverContent(coverContent, metadataOptions))
   end

--- a/packages/resilient/background/init.lua
+++ b/packages/resilient/background/init.lua
@@ -1,4 +1,3 @@
-
 --- Re-implementation of the background package for re·sil·ient.
 --
 -- Version based on my PR https://github.com/sile-typesetter/sile/pull/2346
@@ -12,6 +11,9 @@
 -- Extends `packages.base`.
 --
 -- @type packages.resilient.background
+
+local PathRenderer = require("grail.renderer")
+local Color = require("grail.color")
 
 local base = require("packages.base")
 local package = pl.class(base)
@@ -31,14 +33,21 @@ local outputBackground = function ()
    -- The image may not fully cover the area (depending on scaling
    -- and aspect ratio preservation), and may anyway have transparent areas.
    if background.bg then
-      SILE.outputter:pushColor(background.bg)
-      SILE.outputter:drawRule(
-         pagea:left() - offset,
-         pagea:top() - offset,
-         pagea:width() + 2 * offset,
-         pagea:height() + 2 * offset
-      )
-      SILE.outputter:popColor()
+      local painter = PathRenderer()
+      local path, grad
+      local x0 = (pagea:left() - offset):tonumber()
+      local y0 = (pagea:top() - offset):tonumber()
+      local w = (pagea:width() + 2 * offset):tonumber()
+      local h = (pagea:height() + 2 * offset):tonumber()
+
+      path, grad = painter:rectangle(0, 0, w, -h, {
+        fill = background.bg, stroke = "none"
+      })
+
+      SILE.outputter:drawSVG(path, x0, y0, w, -h, 1)
+      if grad and #grad > 0 then
+         SILE.documentState.documentClass.packages["resilient.gradients"]:outputGradient(grad[1], x0, y0, w, -h)
+      end
    end
 
    if background.src then
@@ -117,6 +126,7 @@ end
 -- @tparam table options Package options (none currently).
 function package:_init ()
    base._init(self)
+   self:loadPackage("resilient.gradients")
    self.class:registerHook("newpage", outputBackground)
 end
 
@@ -134,7 +144,7 @@ function package:registerCommands ()
       end
       local allpages = SU.boolean(options.allpages, true)
       local pageno = SU.cast("integer", options.page or 1)
-      local color = options.color and SILE.types.color(options.color)
+      local color = options.color and Color(options.color)
       local src = options.src
 
       background.pageno = pageno
@@ -154,7 +164,7 @@ function package:registerCommands ()
       else
          SU.error("background requires at least a color or an image option")
       end
-      -- Changing the background immediately on the cuurrent page is what one may
+      -- Changing the background immediately on the current page is what one may
       -- expect. But note that it may result in the previous background having been
       -- already output on that page (via the newpage hook), esp. when allpages=true
       -- (but also when the command is invoked multiple times on the same page).

--- a/packages/resilient/background/init.lua
+++ b/packages/resilient/background/init.lua
@@ -2,6 +2,10 @@
 --
 -- Version based on my PR https://github.com/sile-typesetter/sile/pull/2346
 --
+-- Additional features include:
+--  - support for gradient names as color values (via the resilient.gradients package)
+--  - support for arbitrary frames, not just the page frame
+--
 -- @license MIT
 -- @copyright (c) The SILE Typesetter (original version); 2026 Omikhkeia / Didier Willis
 -- @module packages.resilient.background
@@ -19,7 +23,7 @@ local base = require("packages.base")
 local package = pl.class(base)
 package._name = "resilient.background"
 
-local background = {}
+local backgrounds = pl.OrderedMap()
 
 local knownAnchorSet = pl.Set({
    "center", "n", "ne", "e", "se", "s", "sw", "w", "nw"
@@ -27,98 +31,120 @@ local knownAnchorSet = pl.Set({
 
 local outputBackground = function ()
    local pagea = SILE.getFrame("page")
+   local xp = pagea:left():tonumber()
+   local yp = pagea:top():tonumber()
+   local wp = pagea:width():tonumber()
+   local hp = pagea:height():tonumber()
    local offset = SILE.documentState.bleed / 2
 
-   -- Background color first:
-   -- The image may not fully cover the area (depending on scaling
-   -- and aspect ratio preservation), and may anyway have transparent areas.
-   if background.bg then
-      local painter = PathRenderer()
-      local path, grad
-      local x0 = (pagea:left() - offset):tonumber()
-      local y0 = (pagea:top() - offset):tonumber()
-      local w = (pagea:width() + 2 * offset):tonumber()
-      local h = (pagea:height() + 2 * offset):tonumber()
-
-      path, grad = painter:rectangle(0, 0, w, -h, {
-        fill = background.bg, stroke = "none"
-      })
-
-      SILE.outputter:drawSVG(path, x0, y0, w, -h, 1)
-      if grad and #grad > 0 then
-         SILE.documentState.documentClass.packages["resilient.gradients"]:outputGradient(grad[1], x0, y0, w, -h)
-      end
-   end
-
-   if background.src then
-      local scale = background.scale
-      local preserveaspect = background.preserveaspect
-      local anchor = background.anchor
-
-      -- Determine target image width and height fitting the area.
-      local imgw, imgh = SILE.outputter:getImageSize(background.src, background.pageno)
-      local w
-      local h
-      if scale then
-         w = pagea:width() + 2 * offset
-         h = pagea:height() + 2 * offset
-         local xratio = w / imgw
-         local yratio = h / imgh
-         if preserveaspect then
-            local scaleFactor = SU.min(xratio, yratio)
-            w = imgw * scaleFactor
-            h = imgh * scaleFactor
-         else
-            w = imgw * xratio
-            h = imgh * yratio
-         end
+   for frame, background in backgrounds:iter() do
+      local x, y, w, h
+      if frame == "page" then
+         -- Extend the whole background to the bleed area.
+         x = xp - offset
+         y = yp - offset
+         w = wp + 2 * offset
+         h = hp + 2 * offset
       else
-         w = imgw
-         h = imgh
-      end
-      -- Determine image position.
-      -- When not scaling or preserving aspect ratio, we default to top-left
-      -- since it does not matter (and we can ignore the anchor).
-      local x = pagea:left() - offset
-      local y = pagea:top() - offset
-      local pw = pagea:width() + 2 * offset
-      local ph = pagea:height() + 2 * offset
-      -- Otherwise, we adjust the position based on the anchor.
-      if not scale or preserveaspect then
-         if anchor == "center" then
-            x = x + (pw - w) / 2
-            y = y + (ph - h) / 2
-         elseif anchor == "n" then
-            x = x + (pw - w) / 2
-         elseif anchor == "ne" then
-            x = x + (pw - w)
-         elseif anchor == "e" then
-            x = x + (pw - w)
-            y = y + (ph - h) / 2
-         elseif anchor == "se" then
-            x = x + (pw - w)
-            y = y + (ph - h)
-         elseif anchor == "s" then
-            x = x + (pw - w) / 2
-            y = y + (ph - h)
-         elseif anchor == "sw" then
-            y = y + (ph - h)
-         elseif anchor == "w" then
-            y = y + (ph - h) / 2
+         local framea = SILE.getFrame(frame)
+         x = framea:left():tonumber()
+         y = framea:top():tonumber()
+         w = framea:width():tonumber()
+         h = framea:height():tonumber()
+         -- If the frame overlaps the page area edges, extend these edges to the bleed area.
+         if x <= xp then
+            x = x - offset
+            w = w + offset
+         end
+         if y <= yp then
+            y = y - offset
+            h = h + offset
+         end
+         if x + w >= xp + wp then
+            w = w + offset
+         end
+         if y + h >= yp + hp then
+            h = h + offset
          end
       end
-      SILE.outputter:drawImage(
-         background.src,
-         x,
-         y,
-         w,
-         h,
-         background.pageno
-      )
-   end
-   if not background.allpages then
-      background.bg = nil
-      background.src = nil
+
+      -- Background color first:
+      -- The image may not fully cover the area (depending on scaling
+      -- and aspect ratio preservation), and may anyway have transparent areas.
+      if background.bg then
+         local painter = PathRenderer()
+         local path, grad = painter:rectangle(0, 0, w, -h, {
+            fill = background.bg, stroke = "none"
+         })
+         SILE.outputter:drawSVG(path, x, y, w, -h, 1)
+         if grad and #grad > 0 then
+            SILE.documentState.documentClass.packages["resilient.gradients"]:outputGradient(grad[1], x, y, x + w, y - h)
+         end
+      end
+
+      if background.src then
+         local scale = background.scale
+         local preserveaspect = background.preserveaspect
+         local anchor = background.anchor
+
+         -- Determine target image width and height fitting the area.
+         local imgw, imgh = SILE.outputter:getImageSize(background.src, background.pageno)
+         local iw, ih
+         if scale then
+            local xratio = w / imgw
+            local yratio = h / imgh
+            if preserveaspect then
+               local scaleFactor = SU.min(xratio, yratio)
+               iw = imgw * scaleFactor
+               ih = imgh * scaleFactor
+            else
+               iw = imgw * xratio
+               ih = imgh * yratio
+            end
+         else
+            iw = imgw
+            ih = imgh
+         end
+         -- Determine image position.
+         -- When not scaling or preserving aspect ratio, we default to top-left (x, y)
+         -- since it does not matter (and we can ignore the anchor).
+         -- Otherwise, we adjust the position based on the anchor.
+         if not scale or preserveaspect then
+            if anchor == "center" then
+               x = x + (w - iw) / 2
+               y = y + (h - ih) / 2
+            elseif anchor == "n" then
+               x = x + (w - iw) / 2
+            elseif anchor == "ne" then
+               x = x + (w - iw)
+            elseif anchor == "e" then
+               x = x + (w - iw)
+               y = y + (h - ih) / 2
+            elseif anchor == "se" then
+               x = x + (w - iw)
+               y = y + (h - ih)
+            elseif anchor == "s" then
+               x = x + (w - iw) / 2
+               y = y + (h - ih)
+            elseif anchor == "sw" then
+               y = y + (h - ih)
+            elseif anchor == "w" then
+               y = y + (h - ih) / 2
+            end
+         end
+         SILE.outputter:drawImage(
+            background.src,
+            x,
+            y,
+            iw,
+            ih,
+            background.pageno
+         )
+      end
+      if not background.allpages then
+         background.bg = nil
+         background.src = nil
+      end
    end
 end
 
@@ -127,6 +153,11 @@ end
 function package:_init ()
    base._init(self)
    self:loadPackage("resilient.gradients")
+   -- Backgrounds are applied in the order they are declared.
+   -- We'll ensure that the page background is always first, so that it is drawn before any other frame background.
+   -- But overlapping frame may be declared in any order, and the stacking might not be obvious.
+   -- Whether this is a feature or a bug is open to debate.
+   backgrounds:set("page", {})
    self.class:registerHook("newpage", outputBackground)
 end
 
@@ -136,12 +167,20 @@ end
 --
 function package:registerCommands ()
    self:registerCommand("background", function (options, _)
+      local frame = options.frame or "page"
+      local background = backgrounds:get(frame)
+      if not backgrounds:get(frame) then
+         background = {}
+         backgrounds:set(frame, background)
+      end
+
       if SU.boolean(options.disable, false) then
          -- This option is certainly better than enforcing a white color.
          background.bg = nil
          background.src = nil
          return
       end
+
       local allpages = SU.boolean(options.allpages, true)
       local pageno = SU.cast("integer", options.page or 1)
       local color = options.color and Color(options.color)
@@ -179,8 +218,9 @@ package.documentation = [[
 \begin{document}
 The \autodoc:package{resilient.background} package is a re-implementation of the default \autodoc:package{background} package from SILE.
 This alternate implementation accepts both color specifications and gradient names as color values.
+It also works on arbitrary frames, not just the page frame.
 
-As its name implies, the package allows you to set the color of the page canvas background or to use a background image extending to the full page width and height.
+As its name implies, the package allows you to set the color of the frame background or to use a background image extending to the full frame width and height.
 
 The package provides a \autodoc:command{\background} command which usually requires at least one of the following parameters:
 \begin{itemize}
@@ -188,8 +228,14 @@ The package provides a \autodoc:command{\background} command which usually requi
 \item{\autodoc:parameter{src=<file>} sets the background of the current and all following pages to the specified image. The latter will be scaled to the target dimension.}
 \end{itemize}
 
-The background color extends to the page trim area (“page bleed”) if the latter is defined.
+
+For the page, the background color extends to the page trim area (“page bleed”) if the latter is defined.
 This is to ensure that it indeed “bleeds” off the sides of the page, so as to avoid thin white lignes on an otherwise full color page when the paper sheet is cut to dimension but some pages are trimmed slightly more than others.
+
+The command also accepts an optional \autodoc:parameter{frame=<name>} parameter to specify the frame to which the background should be applied (default is “page”, obviously).
+When the frames overlap the page area edges, their background is also extended to the bleed area on these edges.
+The page background is always drawn first, so that it is behind any other frame background.
+Otherwise, when multiple frame backgrounds overlap, the stacking order is determined by the order in which backgrounds are declared.
 
 When using an image as background, the following options are also available:
 \begin{itemize}

--- a/packages/resilient/background/init.lua
+++ b/packages/resilient/background/init.lua
@@ -178,12 +178,13 @@ end
 package.documentation = [[
 \begin{document}
 The \autodoc:package{resilient.background} package is a re-implementation of the default \autodoc:package{background} package from SILE.
+This alternate implementation accepts both color specifications and gradient names as color values.
 
 As its name implies, the package allows you to set the color of the page canvas background or to use a background image extending to the full page width and height.
 
 The package provides a \autodoc:command{\background} command which usually requires at least one of the following parameters:
 \begin{itemize}
-\item{\autodoc:parameter{color=<color specification>} sets the background of the current and all following pages to that color. The color specification has the same syntax as specified in the \autodoc:package{color} package.}
+\item{\autodoc:parameter{color=<color specification|gradient name>} sets the background of the current and all following pages to that color.}
 \item{\autodoc:parameter{src=<file>} sets the background of the current and all following pages to the specified image. The latter will be scaled to the target dimension.}
 \end{itemize}
 

--- a/packages/resilient/bookmatters/init.lua
+++ b/packages/resilient/bookmatters/init.lua
@@ -11,6 +11,8 @@
 local layoutParser = require("resilient.layoutparser")
 local loadkit = require("loadkit")
 local templateLoader = loadkit.make_loader("djt")
+local Color = require("grail.color")
+local getGradient = require("grail.gradient").getGradient
 
 --- Resolve a template and prepare an include command specification.
 --
@@ -30,7 +32,7 @@ end
 
 --- Compute a weighted color distance in 3D space.
 --
--- @tparam SILE.types.color color Input color (RGB only for now)
+-- @tparam Color color Input color (RGB only for now)
 local function weightedColorDistanceIn3D (color)
   -- Source: https://www.nbdtech.com/Blog/archive/2008/04/27/Calculating-the-Perceived-Brightness-of-a-Color.aspx
   return math.sqrt(
@@ -40,11 +42,47 @@ local function weightedColorDistanceIn3D (color)
   )
 end
 
+--- Compute the average color around the midpoint of a linear gradient.
+--
+-- We just pick the 2 or 3 stops around the midpoint, and average their RGB values.
+--
+-- @tparam string gradname Name of the gradient
+-- @treturn Color Average color around the midpoint of the gradient
+local function averageLinearGradientMidpointColors (gradname)
+  local grad = getGradient(gradname)
+  if not grad then
+    SU.error("Gradient '" .. gradname .. "' not found for average color computation")
+  end
+  local mid = math.ceil(#grad.stops / 2)
+  local prevstopindex = mid > 1 and (mid - 1) or mid
+  local nextstopindex = mid < #grad.stops and mid + 1 or mid
+  local r = 0
+  local g = 0
+  local b = 0
+  for k = prevstopindex, nextstopindex do
+    local stop = grad.stops[k]
+    r = r + stop.r
+    g = g + stop.g
+    b = b + stop.b
+  end
+  local n = nextstopindex - prevstopindex + 1
+  return { r = r / n, g = g / n, b = b / n } -- no need to cast as a Color object
+end
+
 --- Compute the best contrast color (black or white) for a given background color.
 --
--- @tparam SILE.types.color color Input color (RGB only for now)
+-- If the background color is a gradient, there is no perfect solution, and we can compute an average color
+-- around the midpoint of the gradient.
+-- The implicit assumption is that the gradient is reasonably smooth, and that the midpoint is representative
+-- of the overall gradient for use with text content.
+-- This is certainly not perfect, but it seems to be a reasonable heuristic for most cases.
+--
+-- @tparam Color color Input color (RGB only for now)
 -- @treturn string "black" or "white"
 local function contrastColor(color)
+  if color.G then
+    color = averageLinearGradientMidpointColors(color.G)
+  end
   if not color.r then
     -- Not going to bother with other color schemes for now...
     SU.error([[Background color for back cover must be in RGB.
@@ -124,7 +162,7 @@ function package:registerCommands ()
     local backgroundColor = options.background
     local metadata = options.metadata or {} -- Unusual: table of metadata options
     local template = options.template
-    local textColor = contrastColor(SILE.types.color(backgroundColor or "white"))
+    local textColor = contrastColor(Color(backgroundColor or "white"))
 
     SILE.call("switch-master-one-page", { id = "bookmatters-front-cover" })
     SILE.call("hbox") -- To ensure some content
@@ -155,8 +193,9 @@ function package:registerCommands ()
     local image = options.image
     local metadata = options.metadata or {} -- Unusual: table of metadata options
     local backgroundColor = options.background
-    local backgroundContentColor = options.bgcontent or backgroundColor
-    local textColor = contrastColor(SILE.types.color(backgroundContentColor or "white"))
+     -- Things get messy with gradients, but this seems to be the sanest option
+    local backgroundContentColor = options.bgcontent or image and backgroundColor
+    local textColor = contrastColor(Color(backgroundContentColor or backgroundColor or "white"))
 
     SILE.call("open-on-even-page")
     SILE.call("switch-master-one-page", { id = "bookmatters-back-cover" })

--- a/packages/resilient/forms/init.lua
+++ b/packages/resilient/forms/init.lua
@@ -103,11 +103,17 @@ function package:_init (options)
 
   if SILE.outputter._name ~= "libtexpdf" then
     SU.warn("The resilient.forms package only does something with the libtexpdf backend.")
+    print(SILE.outputter._name)
     self._hasFormSupport = false
   else
-    self._hasFormSupport = true
-    self:_hackOutputterLinkAnnotations() -- HACK
     pdf = require("justenoughlibtexpdf")
+    if not pdf.add_page_annotation then
+      SU.warn("The resilient.forms package requires a recent version of SILE.")
+      self._hasFormSupport = false
+    else
+      self._hasFormSupport = true
+      SU.debug("resilient.forms", "PDF outputter supports forms, package enabled.")
+    end
   end
   local this = self
   SILE.outputter:registerHook("prefinish", function ()
@@ -294,14 +300,8 @@ function package:_registerOnParentAndInsetInPage (annotDict, parent)
   pdf.push_array(parent.kids, pdf.reference(annotDict))
 
   -- Add the annotation to the page's /Annots array
-  local page = pdf.get_dictionary("@THISPAGE")
-  local annots = pdf.lookup_dictionary(page, "Annots")
-  if not annots then
-    SU.debug("resilient.forms", "Creating /Annots array on current page")
-    annots = pdf.parse("[]")
-    pdf.add_dict(page, pdf.parse("/Annots"), annots)
-  end
-  pdf.push_array(annots, pdf.reference(annotDict))
+  -- We use a special method so that it plays well with libtexpdf's internal states
+  pdf.add_page_annotation(pdf.reference(annotDict))
   pdf.release(annotDict) -- Release the annotation object, no longer needed
 end
 
@@ -568,6 +568,9 @@ end
 -- @tparam number x1 End X coordinate
 -- @tparam number y1 End Y coordinate
 function package:_createCheckboxWidgetAnnotation (name, options, x0, y0, x1, y1)
+  if not self._hasFormSupport then
+    return
+  end
   SU.debug("resilient.forms", "Creating checkbox widget annotation for field", name)
   local value = SU.boolean(options.checked, false) and "/Yes" or "/Off"
   -- <<
@@ -614,6 +617,9 @@ end
 -- @tparam number x1 End X coordinate
 -- @tparam number y1 End Y coordinate
 function package:_createRadioWidgetAnnotation (name, options, x0, y0, x1, y1)
+  if not self._hasFormSupport then
+    return
+  end
   SU.debug("resilient.forms", "Creating radio button widget annotation for field", name)
   local value = assertNameValidity(SU.required(options, "value", "Radio button option must have a value"))
   local selected = SU.boolean(options.selected, false)
@@ -685,6 +691,9 @@ end
 -- @tparam number y1 End Y coordinate
 -- @tparam number fontSize Font size
 function package:_createTextWidgetAnnotation (name, options, x0, y0, x1, y1, fontSize)
+  if not self._hasFormSupport then
+    return
+  end
   SU.debug("resilient.forms", "Creating text widget annotation for field", name)
   -- <<
   --   /Type /Annot          % Annotation
@@ -748,6 +757,9 @@ end
 -- @tparam number y1 End Y coordinate
 -- @tparam number fontSize Font size
 function package:_createChoiceWidgetAnnotation (name, options, x0, y0, x1, y1, fontSize)
+  if not self._hasFormSupport then
+    return
+  end
   SU.debug("resilient.forms", "Creating choice widget annotation for field", name)
   -- <<
   --   /Type /Annot          % Annotation
@@ -786,10 +798,6 @@ end
 function package:registerCommands ()
 
   self:registerCommand("checkbox", function (options, _)
-    if not self._hasFormSupport then
-      SU.warn("The resilient.forms package requires the libtexpdf outputter to create PDF forms.")
-      return
-    end
     local name = assertNameValidity(SU.required(options, "name", "checkbox"))
     SILE.typesetter:pushHbox({
       value = nil,
@@ -813,10 +821,6 @@ function package:registerCommands ()
   end)
 
   self:registerCommand("radiobutton", function (options, _)
-    if not self._hasFormSupport then
-      SU.warn("The resilient.forms package requires the libtexpdf outputter to create PDF forms.")
-      return
-    end
     local name = assertNameValidity(SU.required(options, "name", "radiobutton"))
     SILE.typesetter:pushHbox({
       value = nil,
@@ -840,10 +844,6 @@ function package:registerCommands ()
   end)
 
   self:registerCommand("textfield", function (options, _)
-    if not self._hasFormSupport then
-      SU.warn("The resilient.forms package requires the libtexpdf outputter to create PDF forms.")
-      return
-    end
     local name = assertNameValidity(SU.required(options, "name", "textfield"))
 
     -- Quite empirical, attempt to have a reasonable height/depth
@@ -877,10 +877,6 @@ function package:registerCommands ()
   end)
 
   self:registerCommand("choicemenu", function (options, _)
-    if not self._hasFormSupport then
-      SU.warn("The resilient.forms package requires the libtexpdf outputter to create PDF forms.")
-      return
-    end
     local name = assertNameValidity(SU.required(options, "name", "choicemenu"))
 
     -- Quite empirical, attempt to have a reasonable height/depth
@@ -947,83 +943,6 @@ function package:registerCommands ()
   --  - Firefox replaces all interactive form fields with its own widgets, ignoring the appearance streams.
   --  - Chromium seems shows the appearance streams properly.
   -- PDF is a complicated format and form support is spotty in many viewers.
-end
-
--- HACK
--- Copied from the internals (locals) of the libtexpdf outputter.
-
-local function borderColor (color)
-   if color then
-      if color.r then
-         return "/C [" .. color.r .. " " .. color.g .. " " .. color.b .. "]"
-      end
-      if color.c then
-         return "/C [" .. color.c .. " " .. color.m .. " " .. color.y .. " " .. color.k .. "]"
-      end
-      if color.l then
-         return "/C [" .. color.l .. "]"
-      end
-   end
-   return ""
-end
-local function borderStyle (style, width)
-   if style == "underline" then
-      return "/BS<</Type/Border/S/U/W " .. width .. ">>"
-   end
-   if style == "dashed" then
-      return "/BS<</Type/Border/S/D/D[3 2]/W " .. width .. ">>"
-   end
-   return "/Border[0 0 " .. width .. "]"
-end
-
-function package:_hackOutputterLinkAnnotations ()
-  SILE.outputter.endLink = function (_, dest, opts, x0, y0, x1, y1)
-    local bordercolor = borderColor(opts.bordercolor)
-    local borderwidth = SU.cast("integer", opts.borderwidth)
-    local borderstyle = borderStyle(opts.borderstyle, borderwidth)
-    local target = opts.external and "/Type/Action/S/URI/URI" or "/S/GoTo/D"
-    local d = "<</Type/Annot/Subtype/Link" .. borderstyle .. bordercolor .. "/A<<" .. target .. "(" .. dest .. ")>>>>"
-    -- BEGIN HACK
-    -- pdf.end_annotation(
-    --    d,
-    --    trueXCoord(x0),
-    --    trueYCoord(y0 - opts.borderoffset),
-    --    trueXCoord(x1),
-    --    trueYCoord(y1 + opts.borderoffset)
-    -- )
-    --
-    -- Add the annotation to the page's /Annots array manually, not using pdf.end_annotation().
-    --
-    -- pdf.end_annotation() called in the original outputter code does add the annotation to the page,
-    -- but the libtexpdf internal logic uses a page->annots pointer to store it.
-    -- It then creates the dictionary without checking for its existence, so we have a conflict between
-    -- the two logics.
-    --
-    -- Let's bypass the libtexpdf logic for now.
-    -- We cannot use it for our forms, as justenoughlibtexpdf expects a string, not a parsed dictionary with
-    -- references...
-    -- Another option would be to extend the justenoughlibtexpdf package to provide a proper API to handle our
-    -- different cases (links, form fields, etc.), but this would need hacking into the C code...
-    -- And the libtexpdf module is a mess full of internal state, global variables, and side effects, which
-    -- do not help. Understandably, since it wasn't supposed to be used this way originally, but still...
-    --
-    -- There's still a problem if links are used on a page before loading the resilient.forms package,
-    -- but let's assume that this won't be the case for now, i.e. that the package will be loaded early
-    -- enough in the document...
-    local annotDict = pdf.parse(d)
-    local page = pdf.get_dictionary("@THISPAGE")
-    local annots = pdf.lookup_dictionary(page, "Annots")
-    local rect = string.format("[%f %f %f %f]", trueXCoord(x0), trueYCoord(y0 - opts.borderoffset), trueXCoord(x1), trueYCoord(y1 + opts.borderoffset))
-    pdf.add_dict(annotDict, pdf.parse("/Rect"), pdf.parse(rect))
-    if not annots then
-      SU.debug("resilient.forms", "Creating /Annots array on current page for link annotation")
-      annots = pdf.parse("[]")
-      pdf.add_dict(page, pdf.parse("/Annots"), annots)
-    end
-    pdf.push_array(annots, pdf.reference(annotDict))
-    pdf.release(annotDict) -- Release the annotation object, no longer needed
-    -- END HACK
-  end
 end
 
 package.documentation = [[\begin{document}

--- a/packages/resilient/gradients/init.lua
+++ b/packages/resilient/gradients/init.lua
@@ -297,15 +297,15 @@ The experimental \autodoc:package{resilient.gradients} package allows the creati
 
 It does not proivide any user-level command, but other packages need it to actually insert gradients into the PDF document.
 
-For instance, packages \autodoc:package{framebox} and \autodoc:package{resilient.background} also accept a gradient name in all their color-accepting options.
+For instance, packages \autodoc:package{framebox} and \autodoc:package{resilient.background} accept a gradient name in all their color-accepting options.
 
 Named gradients provided out of the box include:
 \begin{itemize}
 \item{Some usual gradients
   (\code{viridis}, \code{cividis}, \code{inferno}, \code{magma}, \code{plasma}, \code{spectral},
   \code{turbo}, \code{rocket}, \code{flare}, \code{crest}, \code{mako}, \code{vlag}),}
-\item{The plural form of a CSS named color
-  (e.g. \code{goldenrods}, \code{steelblues}, \code{orangereds}, \code{forestgreens}…) as 2-stop gradients that go from a slightly lighter to a darker shade of the corresponding color,}
+\item{The plural form of a named color
+  (ex. \language[main=und]{\code{goldenrods}, \code{steelblues}, \code{orangereds}, \code{forestgreens}…}) as 2-stop gradients that go from a slightly darker to a lighter shade of the corresponding color,}
 \item{This authors’s own gradients (\code{omissible}, \code{metallic}),}
 \end{itemize}
 

--- a/packages/resilient/gradients/init.lua
+++ b/packages/resilient/gradients/init.lua
@@ -1,0 +1,321 @@
+--- Gradients package for re·sil·ient.
+--
+-- This package allows using gradients in PDF documents generated with the `libtexpdf` outputter.
+-- in PDF documents generated with the `libtexpdf` outputter.
+--
+-- @license MIT
+-- @copyright (c) 2026 Omikhkeia / Didier Willis
+-- @module packages.resilient.gradients
+
+--- The "resilient.gradients" package.
+--
+-- Extends `packages.base`.
+--
+-- @type packages.resilient.gradients
+
+local base = require("packages.base")
+local package = pl.class(base)
+package._name = "resilient.gradients"
+
+local pdf -- Loaded later only if needed
+
+--- (Constructor) Initialize the package.
+--
+-- @tparam table options Package options (none currently defined)
+function package:_init (options)
+  base._init(self, options)
+
+  self._objectsToRelease = {} -- List of PDF objects to release at end
+
+  if SILE.outputter._name ~= "libtexpdf" then
+    SU.warn("The resilient.forms package only does something with the libtexpdf backend.")
+    self._hasGradientsSupport = false
+  else
+    pdf = require("justenoughlibtexpdf")
+    if not pdf.get_page_resources then
+      SU.warn("The resilient.gradients package requires a recent version of SILE.")
+      self._hasGradientsSupport = false
+    else
+      self._hasGradientsSupport = true
+      SU.debug("resilient.gradients", "PDF outputter supports gradients, package enabled.")
+    end
+  end
+  local this = self
+  SILE.outputter:registerHook("prefinish", function ()
+    -- Use a closure to access 'this', check support and release PDF objects.
+    if this._hasGradientsSupport then
+      this:_releasePdfObjects()
+    end
+  end)
+end
+
+--- (Private) Release PDF objects that were kept until the end.
+--
+-- Some objects (appearances, parent field dictionaries) need to be
+-- released after the PDF is finished:
+-- They are only referenced indirectly in other objects as we build
+-- them one by one.
+--
+function package:_releasePdfObjects ()
+  SU.debug("resilient.gradients", "Releasing", #self._objectsToRelease, "PDF objects (gradients)")
+  for _, obj in ipairs(self._objectsToRelease) do
+    pdf.release(obj)
+  end
+  -- CODE SMELL
+  -- We don't expect the method to be called multiple times,
+  -- but with SILE's plain class (i.e. not in resilient, which cancels "multiple" package re-loads),
+  -- this is possible... So we clear our list of objects to release, just in case.
+  self._objectsToRelease = {}
+end
+
+--- (Private) Insert pattern dictionary in the current page
+--
+-- @tparam PdfDict patternDict Pattern dictionary to insert
+-- @tparam Gradient gradient Gradient definition (with a name)
+function package:_InsertInPage (patternDict, gradient)
+  local resources = pdf.get_page_resources()
+  local patterns = pdf.lookup_dictionary(resources, "Pattern")
+  if not patterns then
+    SU.debug("resilient.gradients", "Creating /Pattern dictionary in /Resources on current page for pattern insertion")
+    patterns = pdf.parse("<< >>")
+    pdf.add_dict(resources, pdf.parse("/Pattern"), patterns)
+  end
+
+  local patternName = gradient.name
+  pdf.add_dict(patterns, pdf.parse("/" .. patternName), pdf.reference(patternDict))
+  pdf.release(patternDict) -- Release the pattern dictionary, no longer needed
+  SU.debug("resilient.gradients", "Inserting pattern dictionary for gradient", gradient.name)
+end
+
+--- (Private) Build the shading function for a gradient.
+--
+-- The Gradient definition is expected to have a "stops" field, which is an array of `{r, g, b}` color stops
+-- with values between 0 and 1, and at least two stops.
+--
+-- @tparam Gradient gradient Gradient definition
+function package:_buildShadingFunction (gradient)
+  local n = #gradient.gradient.stops - 1
+  if n < 1 then
+    SU.error("Gradient definition must have at least two color stops.")
+  end
+
+  -- TODO FIXME:
+  -- The shading function should be memoized, as the same gradient may be used multiple times in the document,
+  -- and only the shading pattern dictionary needs to be created multiple times (with different coordinates and/or angles).
+
+  local functionRefs = pdf.parse("[]")
+
+  -- 1. Define interpolation functions
+  -- For each adjacent pair of color stops (c1, c2), create an interpolation function.
+  -- <<
+  --   /FunctionType 2   % Type 2 is an exponential interpolation function, linear if N=1
+  --   /Domain [0 1]     % Input range for the interpolation (0 to 1)
+  --   /N 1              % Linear interpolation
+  --   /C0 [R1 G1 B1]    % Starting color
+  --   /C1 [R2 G2 B2]    % Ending color
+  -- >>
+  for i = 1, n do
+    local c0 = gradient.gradient.stops[i]
+    local c1 = gradient.gradient.stops[i + 1]
+    local interpFunctionSpec = string.format([[<<
+        /FunctionType 2
+        /Domain [0 1]
+        /N 1
+        /C0 [%f %f %f]
+        /C1 [%f %f %f]
+      >>]],
+        c0.r or 0, c0.g or 0, c0.b or 0,
+        c1.r or 0, c1.g or 0, c1.b or 0
+    )
+    local interpFunction = pdf.parse(interpFunctionSpec)
+    local interpFunctionRef = pdf.reference(interpFunction)
+    pdf.release(interpFunction)
+    pdf.push_array(functionRefs, interpFunctionRef)
+  end
+
+  -- Split points
+  local bounds = {}
+  for i = 1, n - 1 do
+    bounds[i] = i / n
+  end
+
+  -- 2. Define the shading function.
+  -- <<
+  --   /FunctionType 3        % Type 3 = stitching function (combines multiple functions)
+  --   /Domain[0 1]           % Input range for the entire gradient (0 to 1)
+  --   /Bounds[B1 ... Bn]     % Split points not including the first (0) and last (1)
+  --   /Encode[0 1 ... 0 1]   % Encoding for each function, 0 1 for linear interpolation
+  --   /Functions [R1 ... Rn] % Array of interpolation function references
+  -- >>
+  local shadingFunctionSpec = string.format([[<<
+    /FunctionType 3
+    /Domain [0 1]
+    /Bounds [%s]
+    /Encode [%s]
+  >>]],
+    table.concat(bounds, " "),
+    string.rep("0 1 ", n)
+  )
+  local shadingFunction = pdf.parse(shadingFunctionSpec)
+  pdf.add_dict(shadingFunction, pdf.parse("/Functions"), functionRefs)
+
+  table.insert(self._objectsToRelease, shadingFunction)
+  return shadingFunction
+end
+
+-- @tparam Gradient gradient Gradient definition
+-- @tparam number x0 Start X coordinate
+-- @tparam number y0 Start Y coordinate
+-- @tparam number x1 End X coordinate
+-- @tparam number y1 End Y coordinate
+function package:outputGradient (gradient, x0, y0, x1, y1)
+  SILE.outputter:_ensureInit()
+  local shadingFunction = self:_buildShadingFunction(gradient)
+
+  -- 1. Define the shading dictionary.
+  -- <<
+  --   /ShadingType 2          % Type 2 = axial shading (linear gradient)
+  --   /Extend[true true]      % Whether to extend the shading past the start and ending points.
+  --   /ColorSpace /DeviceRGB  % Color space for the gradient
+  --   /Coords [X0 Y0 X1 Y1]   % Coordinates defining the gradient vector.
+  --   /Function REF           % Reference to the shading function
+  -- >>
+  local angle = gradient.angle or 0
+  local coords =
+    angle == 0 and {0, 0, x1 - x0, 0} or
+    angle == 90 and {0, 0, 0, y1 - y0} or
+    SU.error("Only angles of 0 and 90 degrees are currently supported for gradients.\n" .. [[
+  I am a bit lost at /Coords, /Matrix, the cm matrix that ends up where the
+  drawing is inserted, and how to do rotations...
+  If this is something you need, please study the code, the PDF specification,
+  and consider contributing a patch to support other angles and/or radial gradients.
+]])
+  local shadingDictSpec = string.format([[<<
+    /ShadingType 2
+    /Extend [true true]
+    /ColorSpace /DeviceRGB
+    /Coords [%f %f %f %f]
+  >>]],
+    coords[1], coords[2], coords[3], coords[4]
+  )
+  local shaderDict = pdf.parse(shadingDictSpec)
+  pdf.add_dict(shaderDict, pdf.parse("/Function"), pdf.reference(shadingFunction))
+
+  -- 2. Define the shading pattern.
+  -- <<
+  --   /Type /Pattern
+  --   /PatternType 2          % Type 2 = shading pattern
+  --   /Shading REF            % Reference to the shading dictionary
+  --   /Matrix [ a b c d e f ] % Transformation matrix for the pattern
+  --                           % Where:
+  --                           %   a, d = scale factors for X and Y (width and height of the rectangle)
+  --                           %   b, c = rotation/skew factors (0 for no rotation/skew)
+  --                           %   e, f = translation (x0, y0)
+  -- >>
+
+  -- Frame coordinates are relative to the page area (a.k.a paper),
+  -- but the PDF coordinates needs to be relative to the actual media (print sheet).
+  local deltaX = SILE.documentState.sheetSize and (SILE.documentState.sheetSize[1] - SILE.documentState.paperSize[1]) / 2 or 0
+  local deltaY = SILE.documentState.sheetSize and (SILE.documentState.sheetSize[2] - SILE.documentState.paperSize[2]) / 2 or 0
+
+  -- PDF coordinates are bottom-left origin, SILE's are top-left
+  local Y0 = SILE.documentState.paperSize[2] - y0
+
+  local patternDictSpec = string.format([[<<
+    /Type /Pattern
+    /PatternType 2
+    /Matrix [%f %f %f %f %f %f]
+  >>]],
+    1, 0, 0, 1, x0 + deltaX, Y0 + deltaY
+  )
+  local patternDict = pdf.parse(patternDictSpec)
+  pdf.add_dict(patternDict, pdf.parse("/Shading"), pdf.reference(shaderDict))
+  pdf.release(shaderDict)
+
+  -- 3. Insert the pattern in the page resources and release the pattern dictionary.
+  self:_InsertInPage(patternDict, gradient)
+end
+
+--- (Override) Register all commands provided by this package.
+--
+function package:registerCommands ()
+
+  self:registerCommand("gradients:demo", function ()
+    if not self._hasGradientsSupport then
+      SU.error("The resilient.gradients package requires the libtexpdf outputter to create gradients.")
+      return
+    end
+    self:loadPackage("framebox")
+    self:loadPackage("leaders")
+    self:loadPackage("struts")
+    self:loadPackage("parbox")
+    local GRADIENTS = {
+      "viridis", "cividis",
+      "plasma", "inferno", "magma", "rocket",
+      "turbo", "spectral", "vlag",
+      "crest",
+      "flare", "mako",
+      "goldenrods", "steelblues", "forestgreens",
+      "omissible", "metallic",
+    }
+    SILE.call("smallskip")
+    SILE.call("noindent")
+    SILE.call("raggedleft", {}, function ()
+      for _, name in ipairs(GRADIENTS) do
+        SILE.typesetter:typeset(" ")
+        SILE.call("framebox", { fillcolor = name, padding = "0.8em" }, function ()
+          SILE.call("parbox", { width = "25%lw" }, function ()
+            SILE.call("center", {}, function ()
+              SILE.call("font", { size = "0.8em", family = "Libertinus Sans" }, { name })
+              SILE.call("strut")
+            end)
+          end)
+        end)
+      end
+      SILE.call("smallskip")
+      SILE.call("noindent")
+      for _, name in ipairs({ "omissible", "metallic" }) do
+        SILE.typesetter:typeset(" ")
+        SILE.call("framebox", { fillcolor = name .. " 90", padding = "0.8em" }, function ()
+          SILE.call("parbox", { width = "25%lw" }, function ()
+            SILE.call("center", {}, function ()
+              SILE.call("font", { size = "0.8em", family = "Libertinus Sans" }, { name })
+              SILE.call("strut")
+            end)
+          end)
+        end)
+      end
+    end)
+    SILE.call("smallskip")
+  end)
+
+end
+
+
+package.documentation = [[\begin{document}
+The experimental \autodoc:package{resilient.gradients} package allows the creation of gradients in PDF documents.
+
+It does not proivide any user-level command, but other packages need it to actually insert gradients into the PDF document.
+
+For instance, packages \autodoc:package{framebox} and \autodoc:package{resilient.background} also accept a gradient name in all their color-accepting options.
+
+Named gradients provided out of the box include:
+\begin{itemize}
+\item{Some usual gradients
+  (\code{viridis}, \code{cividis}, \code{inferno}, \code{magma}, \code{plasma}, \code{spectral},
+  \code{turbo}, \code{rocket}, \code{flare}, \code{crest}, \code{mako}, \code{vlag}),}
+\item{The plural form of a CSS named color
+  (e.g. \code{goldenrods}, \code{steelblues}, \code{orangereds}, \code{forestgreens}…) as 2-stop gradients that go from a slightly lighter to a darker shade of the corresponding color,}
+\item{This authors’s own gradients (\code{omissible}, \code{metallic}),}
+\end{itemize}
+
+The gradient name may be suffixed with an angle (e.g. \code{omissible 90}). Currently only angles of 0 and 90 degrees are supported.
+
+\gradients:demo
+
+\medskip
+Note that gradients are only supported with SILE’s \code{libtexpdf} outputter, and are ignored otherwise.
+
+\end{document}]]
+
+return package

--- a/packages/resilient/gradients/init.lua
+++ b/packages/resilient/gradients/init.lua
@@ -185,21 +185,39 @@ function package:outputGradient (gradient, x0, y0, x1, y1)
   -- 1. Define the shading dictionary.
   -- <<
   --   /ShadingType 2          % Type 2 = axial shading (linear gradient)
-  --   /Extend[true true]      % Whether to extend the shading past the start and ending points.
+  --   /Extend[true true]      % Whether to extend the shading past the start and ending points
   --   /ColorSpace /DeviceRGB  % Color space for the gradient
-  --   /Coords [X0 Y0 X1 Y1]   % Coordinates defining the gradient vector.
+  --   /Coords [X0 Y0 X1 Y1]   % Coordinates defining the gradient vector
   --   /Function REF           % Reference to the shading function
   -- >>
-  local angle = gradient.angle or 0
-  local coords =
-    angle == 0 and {0, 0, x1 - x0, 0} or
-    angle == 90 and {0, 0, 0, y1 - y0} or
-    SU.error("Only angles of 0 and 90 degrees are currently supported for gradients.\n" .. [[
-  I am a bit lost at /Coords, /Matrix, the cm matrix that ends up where the
-  drawing is inserted, and how to do rotations...
-  If this is something you need, please study the code, the PDF specification,
-  and consider contributing a patch to support other angles and/or radial gradients.
-]])
+
+  -- Handle the gradient vector:
+  -- The rectangle defined by (x0, y0) and (x1, y1) in global (print sheet) coordinates,
+  -- but /Coords is in local coordinates (assumiing, as does the outputter, that the shapes are
+  -- positionned xith a cm transformation matrix.
+  -- CAVEAT: This author has a hard time with rotation matrices and coordinate spaces.
+  -- This does seem correct, but it would be good to have a second pair of eyes on this.
+  local angle = (gradient.angle or 0) % 360
+  local width  = x1 - x0
+  local height = y1 - y0
+  -- Center in local coordinates
+  local cx, cy = width * 0.5, height * 0.5
+  -- Half-dimensions of the rectangle
+  local hx, hy = math.abs(width) * 0.5, math.abs(height) * 0.5
+  -- Unit vector in the direction of the gradient
+  local dx = math.cos(math.rad(angle))
+  local dy = math.sin(math.rad(angle))
+  -- Avoid division by zero on straight gradients angles
+  local tx = (dx ~= 0) and (hx / math.abs(dx)) or nil
+  local ty = (dy ~= 0) and (hy / math.abs(dy)) or nil
+  -- Distance from the center to the intersection with the rectangle edge along the gradient direction
+  local t = (tx and ty) and math.min(tx, ty) or (tx or ty)
+  -- Gradient vector coordinates in local space, relative to the rectangle center
+  local coords = {
+    cx - t * dx, cy - t * dy,
+    cx + t * dx, cy + t * dy
+  }
+
   local shadingDictSpec = string.format([[<<
     /ShadingType 2
     /Extend [true true]
@@ -347,7 +365,7 @@ Named gradients provided out of the box include:
 \item{This authors’s own gradient families.}
 \end{itemize}
 
-The gradient name may be suffixed with an angle (e.g. \code{omissible 90}). Currently only angles of 0 and 90 degrees are supported.
+The gradient name may be suffixed with an angle (e.g. \code{omissible 90}).
 
 \gradients:demo
 

--- a/packages/resilient/gradients/init.lua
+++ b/packages/resilient/gradients/init.lua
@@ -259,19 +259,16 @@ function package:registerCommands ()
     self:loadPackage("leaders")
     self:loadPackage("struts")
     self:loadPackage("parbox")
-    local GRADIENTS = {
-      "viridis", "cividis",
-      "plasma", "inferno", "magma", "rocket",
-      "turbo", "spectral", "vlag",
-      "crest",
-      "flare", "mako",
-      "goldenrods", "steelblues", "forestgreens",
-      "omissible", "metallic",
-    }
     SILE.call("smallskip")
     SILE.call("noindent")
     SILE.call("raggedleft", {}, function ()
-      for _, name in ipairs(GRADIENTS) do
+      for _, name in ipairs({
+          "viridis", "cividis",
+          "plasma", "inferno", "magma", "rocket",
+          "turbo", "spectral", "vlag",
+          "crest",
+          "flare", "mako",
+        }) do
         SILE.typesetter:typeset(" ")
         SILE.call("framebox", { fillcolor = name, padding = "0.8em" }, function ()
           SILE.call("parbox", { width = "25%lw" }, function ()
@@ -284,7 +281,42 @@ function package:registerCommands ()
       end
       SILE.call("smallskip")
       SILE.call("noindent")
-      for _, name in ipairs({ "omissible", "metallic" }) do
+      for _, name in ipairs({
+          "firebricks", "forestgreens", "steelblues"
+        }) do
+        SILE.typesetter:typeset(" ")
+        SILE.call("framebox", { fillcolor = name, padding = "0.8em" }, function ()
+          SILE.call("parbox", { width = "25%lw" }, function ()
+            SILE.call("center", {}, function ()
+              SILE.call("font", { size = "0.8em", family = "Libertinus Sans" }, { name })
+              SILE.call("strut")
+            end)
+          end)
+        end)
+      end
+      SILE.call("smallskip")
+      SILE.call("noindent")
+      for _, name in ipairs({
+          "omissible", "omissiblesilver", "omissiblegold",
+          "omissiblecopper", "omissiblebrass", "omissiblebronze",
+          "omissibleruby", "omissibleemerald", "omissiblesapphire"
+        }) do
+        SILE.typesetter:typeset(" ")
+        SILE.call("framebox", { fillcolor = name .. " 90", padding = "0.8em" }, function ()
+          SILE.call("parbox", { width = "25%lw" }, function ()
+            SILE.call("center", {}, function ()
+              SILE.call("font", { size = "0.8em", family = "Libertinus Sans" }, { name })
+              SILE.call("strut")
+            end)
+          end)
+        end)
+      end
+      SILE.call("smallskip")
+      SILE.call("noindent")
+      for _, name in ipairs({
+            "metallicsteel", "metallicsilver", "metallicgold",
+            "metalliccopper", "metallicbrass", "metallicbronze"
+        }) do
         SILE.typesetter:typeset(" ")
         SILE.call("framebox", { fillcolor = name .. " 90", padding = "0.8em" }, function ()
           SILE.call("parbox", { width = "25%lw" }, function ()
@@ -303,27 +335,22 @@ end
 
 
 package.documentation = [[\begin{document}
-The experimental \autodoc:package{resilient.gradients} package allows the creation of gradients in PDF documents.
+The experimental \autodoc:package{resilient.gradients} package allows the creation of color gradients in PDF documents.
 
-It does not proivide any user-level command, but other packages need it to actually insert gradients into the PDF document.
-
+It does not provide any user-level command, but other packages can rely on it.
 For instance, packages \autodoc:package{framebox} and \autodoc:package{resilient.background} accept a gradient name in all their color-accepting options.
 
 Named gradients provided out of the box include:
 \begin{itemize}
-\item{Some usual gradients
-  (\code{viridis}, \code{cividis}, \code{inferno}, \code{magma}, \code{plasma}, \code{spectral},
-  \code{turbo}, \code{rocket}, \code{flare}, \code{crest}, \code{mako}, \code{vlag}),}
-\item{The plural form of a named color
-  (ex. \language[main=und]{\code{goldenrods}, \code{steelblues}, \code{orangereds}, \code{forestgreens}…}) as 2-stop gradients that go from a slightly darker to a lighter shade of the corresponding color,}
-\item{This authors’s own gradients (\code{omissible}, \code{metallic}),}
+\item{Some usual gradients (\code{viridis}, etc.),}
+\item{The plural form of a named color as 2-stop gradients that go from a slightly darker to a lighter shade of the corresponding color,}
+\item{This authors’s own gradient families.}
 \end{itemize}
 
 The gradient name may be suffixed with an angle (e.g. \code{omissible 90}). Currently only angles of 0 and 90 degrees are supported.
 
 \gradients:demo
 
-\medskip
 Note that gradients are only supported with SILE’s \code{libtexpdf} outputter, and are ignored otherwise.
 
 \end{document}]]

--- a/packages/resilient/gradients/init.lua
+++ b/packages/resilient/gradients/init.lua
@@ -179,6 +179,10 @@ end
 -- @tparam number x1 End X coordinate
 -- @tparam number y1 End Y coordinate
 function package:outputGradient (gradient, x0, y0, x1, y1)
+  if not self._hasGradientsSupport then
+    SU.warn("Gradient '" .. gradient.gradient.name .. "' cannot be output (gradients not supported).")
+    return
+  end
   SILE.outputter:_ensureInit()
   local shadingFunction = self:_buildShadingFunction(gradient)
 

--- a/packages/resilient/gradients/init.lua
+++ b/packages/resilient/gradients/init.lua
@@ -25,7 +25,8 @@ local pdf -- Loaded later only if needed
 function package:_init (options)
   base._init(self, options)
 
-  self._objectsToRelease = {} -- List of PDF objects to release at end
+  self._shadingFunctions = {} -- Cache of shading functions for gradients
+  self._objectsToRelease = {} -- List of lingering PDF objects to release at end
 
   if SILE.outputter._name ~= "libtexpdf" then
     SU.warn("The resilient.forms package only does something with the libtexpdf backend.")
@@ -42,7 +43,7 @@ function package:_init (options)
   end
   local this = self
   SILE.outputter:registerHook("prefinish", function ()
-    -- Use a closure to access 'this', check support and release PDF objects.
+    -- Use a closure to access 'this', check support and release lingering PDF objects.
     if this._hasGradientsSupport then
       this:_releasePdfObjects()
     end
@@ -51,13 +52,15 @@ end
 
 --- (Private) Release PDF objects that were kept until the end.
 --
--- Some objects (appearances, parent field dictionaries) need to be
--- released after the PDF is finished:
--- They are only referenced indirectly in other objects as we build
--- them one by one.
+-- Some re-usable objects need to be kept alive until the end of the document,
+-- and released after the PDF is finished.
+-- In this implementation, these are the shading functions, which we also keep
+-- cached for reuse, but for separation of concerns, we keep a list of objects
+-- to release in the order they were created.
+-- (The order doesn't really matter, but it makes debugging easier.)
 --
 function package:_releasePdfObjects ()
-  SU.debug("resilient.gradients", "Releasing", #self._objectsToRelease, "PDF objects (gradients)")
+  SU.debug("resilient.gradients", "Releasing", #self._objectsToRelease, "lingering PDF objects")
   for _, obj in ipairs(self._objectsToRelease) do
     pdf.release(obj)
   end
@@ -68,11 +71,11 @@ function package:_releasePdfObjects ()
   self._objectsToRelease = {}
 end
 
---- (Private) Insert pattern dictionary in the current page
+--- (Private) Insert a pattern dictionary in the current page.
 --
 -- @tparam PdfDict patternDict Pattern dictionary to insert
--- @tparam Gradient gradient Gradient definition (with a name)
-function package:_InsertInPage (patternDict, gradient)
+-- @tparam GradientRef gradient Grail gradient reference
+function package:_insertPatternInPage (patternDict, gradient)
   local resources = pdf.get_page_resources()
   local patterns = pdf.lookup_dictionary(resources, "Pattern")
   if not patterns then
@@ -89,19 +92,20 @@ end
 
 --- (Private) Build the shading function for a gradient.
 --
--- The Gradient definition is expected to have a "stops" field, which is an array of `{r, g, b}` color stops
--- with values between 0 and 1, and at least two stops.
+-- Shading functions are coordinate-independent, so we can build them once per gradient
+-- and reuse them for multiple insertions.
 --
--- @tparam Gradient gradient Gradient definition
+-- @tparam GradientRef gradient Grail gradient reference
 function package:_buildShadingFunction (gradient)
+  if self._shadingFunctions[gradient.gradient.name] then
+    SU.debug("resilient.gradients", "Using cached shading function for gradient", gradient.gradient.name)
+    return self._shadingFunctions[gradient.gradient.name]
+  end
+
   local n = #gradient.gradient.stops - 1
   if n < 1 then
     SU.error("Gradient definition must have at least two color stops.")
   end
-
-  -- TODO FIXME:
-  -- The shading function should be memoized, as the same gradient may be used multiple times in the document,
-  -- and only the shading pattern dictionary needs to be created multiple times (with different coordinates and/or angles).
 
   local functionRefs = pdf.parse("[]")
 
@@ -160,10 +164,16 @@ function package:_buildShadingFunction (gradient)
   pdf.add_dict(shadingFunction, pdf.parse("/Functions"), functionRefs)
 
   table.insert(self._objectsToRelease, shadingFunction)
+  SU.debug("resilient.gradients", "Created shading function for gradient", gradient.gradient.name)
+  self._shadingFunctions[gradient.gradient.name] = shadingFunction
   return shadingFunction
 end
 
--- @tparam Gradient gradient Gradient definition
+--- Output a gradient in the PDF document.
+--
+-- This is the public-facing method that other packages can call to insert a gradient.
+--
+-- @tparam GradientRef gradient Grail gradient reference
 -- @tparam number x0 Start X coordinate
 -- @tparam number y0 Start Y coordinate
 -- @tparam number x1 End X coordinate
@@ -213,7 +223,7 @@ function package:outputGradient (gradient, x0, y0, x1, y1)
   --                           %   e, f = translation (x0, y0)
   -- >>
 
-  -- Frame coordinates are relative to the page area (a.k.a paper),
+  -- SILE frame coordinates are relative to the page area (a.k.a paper),
   -- but the PDF coordinates needs to be relative to the actual media (print sheet).
   local deltaX = SILE.documentState.sheetSize and (SILE.documentState.sheetSize[1] - SILE.documentState.paperSize[1]) / 2 or 0
   local deltaY = SILE.documentState.sheetSize and (SILE.documentState.sheetSize[2] - SILE.documentState.paperSize[2]) / 2 or 0
@@ -233,7 +243,7 @@ function package:outputGradient (gradient, x0, y0, x1, y1)
   pdf.release(shaderDict)
 
   -- 3. Insert the pattern in the page resources and release the pattern dictionary.
-  self:_InsertInPage(patternDict, gradient)
+  self:_insertPatternInPage(patternDict, gradient)
 end
 
 --- (Override) Register all commands provided by this package.

--- a/rockspecs/resilient.sile-dev-1.rockspec
+++ b/rockspecs/resilient.sile-dev-1.rockspec
@@ -77,6 +77,7 @@ build = {
 
     ["sile.packages.resilient.attachments"]     = "packages/resilient/attachments/init.lua",
     ["sile.packages.resilient.forms"]           = "packages/resilient/forms/init.lua",
+    ["sile.packages.resilient.gradients"]       = "packages/resilient/gradients/init.lua",
 
     ["sile.packages.resilient.invoice"]         = "packages/resilient/invoice/init.lua",
 


### PR DESCRIPTION
Add a package for supporting gradients with SILE libtexpdf-based output module; and support using such gradients in various other components.

**Prerequisites**

We'd need https://github.com/sile-typesetter/sile/pull/2308 to add patterns to the `/Resources` dictionary. I currently use a locally hacked version of justenoughlibtexpdf

**Related tasks to track**
 - [x] Basic **resilient.gradients** package with proper gradient positioning and rotation. ~~Note: I'll only support 0° and 80° for a start. The interplay of PDF `/Matrix`, `/Coords` and `cm` eludes me a bit :)~~ DONE
 - [x] Add support in the **grail** library = https://github.com/Omikhleia/grail/pull/2
 - [x] Add support in the **framebox** package (ptable.sile module) = https://github.com/Omikhleia/ptable.sile/pull/27
 - [x] Add support in the **resilient.background** package
 - [x] Add support in book in book cover pages (via the internal bookmatter package used by re·sil·ient master documents).
 - [x] Add proper caching of shading functions in **resilient.gradients**  (esp. color stops, i.e. coordinate-independent objects, to avoid repeating them in the PDF). Note: I'm not going further, some other PDF objects could possibly be reused, but they are not that big anyway. Interpolation functions between color stops should however be factorized.
