### PR TITLE
feat(classes,packages): Finer-grain control in paragraph style specification

### DIFF
--- a/classes/resilient/book.lua
+++ b/classes/resilient/book.lua
@@ -488,13 +488,13 @@ function class:registerStyles ()
   })
 
   -- quotes
-  SILE.scratch.styles.alignments["block"] = "blockindent"
-  SILE.scratch.styles.alignments["quotation"] = "quoteindent"
+  SILE.scratch.styles.alignments["block"] = "blockindent" -- FIXME DEPRECATED
+  SILE.scratch.styles.alignments["quotation"] = "quoteindent" -- FIXME DEPRECATED
 
   self:registerStyle("blockquote", {}, {
     font = { size = "0.95em" },
     paragraph = { before = { skip = "smallskip" },
-                  align = "block",
+                  margin = { left = "2em", right = "2em" },
                   after = { skip = "smallskip" } }
   })
 
@@ -693,7 +693,7 @@ function class:declareSettings ()
     parameter = "book.blockquote.margin",
     type = "measurement",
     default = SILE.types.measurement("2em"),
-    help = "Margin (indentation) for block quotes"
+    help = "Margin (indentation) for block quotes. DEPRECATED, use styles instead (paragraph margin)"
   })
 end
 
@@ -900,6 +900,9 @@ function class:registerCommands ()
 
   -- Quotes
 
+  -- FIXME: Deprecated, use styles instead (paragraph margin).
+  -- We warn in styles, so we don't need to do it here.
+  -- TO REMOVE IN A FUTURE REVISION.
   self:registerCommand("blockindent", function (_, content)
     SILE.settings:temporarily(function ()
       local indent = SILE.settings:get("book.blockquote.margin"):absolute()
@@ -910,8 +913,11 @@ function class:registerCommands ()
       SILE.process(content)
       SILE.call("par")
     end)
-  end, "Typeset its contents in a right and left indented block.")
+  end, "Typeset its contents in a right and left indented block. DEPRECATED, use styles instead (paragraph margin).")
 
+  -- FIXME: Deprecated, use styles instead (paragraph margin).
+  -- We warn in styles, so we don't need to do it here.
+  -- TO REMOVE IN A FUTURE REVISION.
   self:registerCommand("quoteindent", function (_, content)
     SILE.settings:temporarily(function ()
       local indent = SILE.settings:get("book.blockquote.margin"):absolute() * 0.875
@@ -922,7 +928,7 @@ function class:registerCommands ()
       SILE.process(content)
       SILE.call("par")
     end)
-  end, "Typeset its contents in a right and left indented block (variant).")
+  end, "Typeset its contents in a right and left indented block (variant). DEPRECATED, use styles instead (paragraph margin).")
 
   self:registerCommand("blockquote", function (options, content)
     local variant = options.variant and "blockquote-" .. options.variant or nil

--- a/classes/resilient/book.lua
+++ b/classes/resilient/book.lua
@@ -488,9 +488,6 @@ function class:registerStyles ()
   })
 
   -- quotes
-  SILE.scratch.styles.alignments["block"] = "blockindent" -- FIXME DEPRECATED
-  SILE.scratch.styles.alignments["quotation"] = "quoteindent" -- FIXME DEPRECATED
-
   self:registerStyle("blockquote", {}, {
     font = { size = "0.95em" },
     paragraph = { before = { skip = "smallskip" },
@@ -689,12 +686,6 @@ end
 function class:declareSettings ()
   base.declareSettings(self)
 
-  SILE.settings:declare({
-    parameter = "book.blockquote.margin",
-    type = "measurement",
-    default = SILE.types.measurement("2em"),
-    help = "Margin (indentation) for block quotes. DEPRECATED, use styles instead (paragraph margin)"
-  })
 end
 
 --- (Override) Register class commands.
@@ -899,36 +890,6 @@ function class:registerCommands ()
   end, "Begin a new subsubsection.")
 
   -- Quotes
-
-  -- FIXME: Deprecated, use styles instead (paragraph margin).
-  -- We warn in styles, so we don't need to do it here.
-  -- TO REMOVE IN A FUTURE REVISION.
-  self:registerCommand("blockindent", function (_, content)
-    SILE.settings:temporarily(function ()
-      local indent = SILE.settings:get("book.blockquote.margin"):absolute()
-      local lskip = SILE.settings:get("document.lskip") or SILE.types.node.glue()
-      local rskip = SILE.settings:get("document.rskip") or SILE.types.node.glue()
-      SILE.settings:set("document.lskip", SILE.types.node.glue(lskip.width:absolute() + indent))
-      SILE.settings:set("document.rskip", SILE.types.node.glue(rskip.width:absolute() + indent))
-      SILE.process(content)
-      SILE.call("par")
-    end)
-  end, "Typeset its contents in a right and left indented block. DEPRECATED, use styles instead (paragraph margin).")
-
-  -- FIXME: Deprecated, use styles instead (paragraph margin).
-  -- We warn in styles, so we don't need to do it here.
-  -- TO REMOVE IN A FUTURE REVISION.
-  self:registerCommand("quoteindent", function (_, content)
-    SILE.settings:temporarily(function ()
-      local indent = SILE.settings:get("book.blockquote.margin"):absolute() * 0.875
-      local lskip = SILE.settings:get("document.lskip") or SILE.types.node.glue()
-      local rskip = SILE.settings:get("document.rskip") or SILE.types.node.glue()
-      SILE.settings:set("document.lskip", SILE.types.node.glue(lskip.width:absolute() + indent))
-      SILE.settings:set("document.rskip", SILE.types.node.glue(rskip.width:absolute() + indent * 0.5))
-      SILE.process(content)
-      SILE.call("par")
-    end)
-  end, "Typeset its contents in a right and left indented block (variant). DEPRECATED, use styles instead (paragraph margin).")
 
   self:registerCommand("blockquote", function (options, content)
     local variant = options.variant and "blockquote-" .. options.variant or nil

--- a/guides/djot-markdown/sile-and-markdown-manual-styles.yml
+++ b/guides/djot-markdown/sile-and-markdown-manual-styles.yml
@@ -17,9 +17,9 @@ CoverCredit:
       size: "7pt"
       weight: 300
     paragraph:
-      align: "noparindent"
       before:
         skip: "bigskip"
+      indent: false
 
 CustomDroppedInitial:
   style:
@@ -56,9 +56,11 @@ blockquote:
     paragraph:
       after:
         skip: "smallskip"
-      align: "block"
       before:
         skip: "smallskip"
+      margin:
+        left: "2em"
+        right: "2em"
 
 bookmatter-author:
   inherit: "bookmatter-titlepage"
@@ -76,7 +78,7 @@ bookmatter-backcover:
 bookmatter-copyright:
   style:
     paragraph:
-      align: "noparindent"
+      indent: false
 
 bookmatter-cover-author:
   inherit: "bookmatter-coverpage"
@@ -867,9 +869,10 @@ poetry:
     paragraph:
       after:
         skip: "medskip"
-      align: "poetry"
       before:
         skip: "medskip"
+      margin:
+        left: "0.75em"
 
 poetry-prosody:
   style:
@@ -887,9 +890,10 @@ prosody:
     font:
       size: "0.95em"
     paragraph:
-      align: "poetry"
       before:
         skip: "smallskip"
+      margin:
+        left: "0.75em"
 
 sectioning-appendix:
   inherit: "sectioning-chapter"
@@ -1378,7 +1382,9 @@ verbatim:
     font:
       size: "0.7em"
     paragraph:
-      align: "obeylines"
+      align: "left"
       before:
         skip: "smallskip"
+      indent: false
+      lines: "preserve"
 

--- a/guides/resilient/manual-classes/book.dj
+++ b/guides/resilient/manual-classes/book.dj
@@ -168,7 +168,7 @@ so the `\autodoc:command{\noheaders}`{=sile}, `\autodoc:command{\noheaderthispag
 The class provides the `\autodoc:environment{blockquote}`{=sile} environment to typeset simple block-indented paragraphs.
 Indented quotes can be nested.
 
-The environment relies on the same-named style for its styling and on the `\autodoc:setting{book.blockquote.margin}`{=sile} setting for its indentation (defaults to 2em).
+The environment relies on the same-named style for its styling.
 
 The environment also accepts a `\autodoc:parameter{variant}`{=sile} option, to switch to an alternate style, assumed to be named `blockquote-⟨variant⟩`.
 

--- a/guides/resilient/manual-styling/basics/paragraph.dj
+++ b/guides/resilient/manual-styling/basics/paragraph.dj
@@ -12,7 +12,11 @@ Such a paragraph style obeys to the following specification
   style:
     ⟨character style specification⟩
     paragraph:
+      margin:
+        left: "⟨dimen⟩"
+        right: "⟨dimen⟩"
       align: "center|right|left|justify"
+      indent: true|false
       before:
         skip: "⟨glue⟩"
         indent: true|false
@@ -26,8 +30,12 @@ Such a paragraph style obeys to the following specification
 First of all, it is also a character style, so any formatting defined
 there will be applied. The specification additionnaly provides:
 
+ - The left and right margins of the paragraph block, as dimensions.
+   These are added to the current text block margins, so they can be used
+   to create indented blocks supporting nesting.
  - The alignment of the paragraph block (center, left, right or justify---the
    latter is the default but may be useful to overwrite an inherited alignment).
+ - Whether paragraph indentation is disabled (`false`) for the block and all its descendants.
  - Rules applying before the paragraph block:
 
     - The amount of vertical space before the content, as a variable length or a
@@ -56,15 +64,10 @@ however, is to always indent regular paragraphs, even after a section title.
 
 {custom-style="admon"}
 :::
-This version of the specification does not provide any way to configure
-the margins (left and right text block indents), internal skips, and other
-low-level paragraph formatting options (paragraph indent, etc.)[^styles-par-margins]
+This version of the specification does not provide any way to, internal skips, and other
+low-level paragraph formatting options.
+This might be considered in a future version of the specification.
 :::
-
-[^styles-par-margins]: This might be considered in a future revision, but note
-that it may also be addressed by defining extra alignment options.
-The *resilient.book* class, for instance, defines its own `block` alignment option
-(used in block quotes, see further); the *resilient.verbatim* packages defines and `obeylines` alignment, etc.
 
 Please note that changing an existing character style into a paragraph style
 does not imply that the content is magically turned into paragraphs.
@@ -87,9 +90,11 @@ blockquote:
     font:
       size: "0.95em"
     paragraph:
+      margin:
+        left: "2em"
+        right: "2em"
       after:
         skip: "smallskip"
-      align: "block"
       before:
         skip: "smallskip"
 ```

--- a/guides/resilient/sile-resilient-manual-styles.yml
+++ b/guides/resilient/sile-resilient-manual-styles.yml
@@ -8,9 +8,11 @@ blockquote:
     paragraph:
       after:
         skip: "smallskip"
-      align: "block"
       before:
         skip: "smallskip"
+      margin:
+        left: "2em"
+        right: "2em"
 
 bookmatter-author:
   inherit: "bookmatter-titlepage"
@@ -28,7 +30,7 @@ bookmatter-backcover:
 bookmatter-copyright:
   style:
     paragraph:
-      align: "noparindent"
+      indent: false
 
 bookmatter-cover-author:
   inherit: "bookmatter-coverpage"
@@ -137,7 +139,7 @@ defn-desc-Simple:
     font:
       weight:
     paragraph:
-      align: "noparindent"
+      indent: false
 
 defn-term:
   inherit: "defn-base"
@@ -156,7 +158,7 @@ defn-term-Simple:
     font:
       weight:
     paragraph:
-      align: "noparindent"
+      indent: false
 
 dropcap:
   style:
@@ -822,9 +824,10 @@ poetry:
     paragraph:
       after:
         skip: "medskip"
-      align: "poetry"
       before:
         skip: "medskip"
+      margin:
+        left: "0.75em"
 
 poetry-prosody:
   style:
@@ -844,9 +847,10 @@ prosody:
     font:
       size: "0.95em"
     paragraph:
-      align: "poetry"
       before:
         skip: "smallskip"
+      margin:
+        left: "0.75em"
 
 sectioning-appendix:
   inherit: "sectioning-chapter"

--- a/packages/resilient/bookmatters/init.lua
+++ b/packages/resilient/bookmatters/init.lua
@@ -239,6 +239,9 @@ function package:registerCommands ()
   -- Book matter helpful default pseudo-styles
   -- (for easier Djot custom styling)
 
+  -- FIXME: Deprecated, use styles instead.
+  -- We warn in styles, so we don't need to do it here.
+  -- TO REMOVE IN A FUTURE REVISION.
   self:registerCommand("noparindent", function (_, content)
     SILE.settings:temporarily(function ()
       SILE.settings:set("document.parindent", SILE.types.node.glue())
@@ -246,8 +249,7 @@ function package:registerCommands ()
       SILE.process(content)
       SILE.call("par")
     end)
-  end, "Typeset its contents without paragraph indentation.")
-
+  end, "Typeset its contents without paragraph indentation. Deprecated, use styles instead (paragraph.indent: false).")
   SILE.scratch.styles.alignments["noparindent"] = "noparindent"
 
   self:registerCommand("bookmatter-ean13", function (_, content)
@@ -372,7 +374,7 @@ function package:registerStyles ()
   -- Styles for (usually) title page recto
   self:registerStyle("bookmatter-copyright", {}, {
     paragraph = {
-      align = "noparindent"
+      indent = false,
     }
   })
   self:registerStyle("bookmatter-legal", {}, {

--- a/packages/resilient/bookmatters/init.lua
+++ b/packages/resilient/bookmatters/init.lua
@@ -239,19 +239,6 @@ function package:registerCommands ()
   -- Book matter helpful default pseudo-styles
   -- (for easier Djot custom styling)
 
-  -- FIXME: Deprecated, use styles instead.
-  -- We warn in styles, so we don't need to do it here.
-  -- TO REMOVE IN A FUTURE REVISION.
-  self:registerCommand("noparindent", function (_, content)
-    SILE.settings:temporarily(function ()
-      SILE.settings:set("document.parindent", SILE.types.node.glue())
-      SILE.settings:set("current.parindent", SILE.types.node.glue())
-      SILE.process(content)
-      SILE.call("par")
-    end)
-  end, "Typeset its contents without paragraph indentation. Deprecated, use styles instead (paragraph.indent: false).")
-  SILE.scratch.styles.alignments["noparindent"] = "noparindent"
-
   self:registerCommand("bookmatter-ean13", function (_, content)
     local code = content[1]
     -- Markdown/Djot parser may interpret a dash between digits as smart typography for en-dash.

--- a/packages/resilient/poetry/init.lua
+++ b/packages/resilient/poetry/init.lua
@@ -279,24 +279,6 @@ function package:registerCommands ()
     SILE.call("par")
   end, "A single verse (theoretically an internal command).")
 
-  -- FIXME: Deprecated, use styles instead (paragraph margin).
-  -- We warn in styles, so we don't need to do it here.
-  -- TO REMOVE IN A FUTURE REVISION.
-  self:registerCommand("poetryindent", function (_, content)
-    SILE.settings:temporarily(function ()
-      local indent = SILE.settings:get("poetry.margin"):absolute()
-      local lskip = SILE.settings:get("document.lskip") or SILE.types.node.glue()
-      SILE.settings:set("document.lskip", SILE.types.node.glue(lskip.width.length + indent))
-      SILE.process(content)
-      SILE.call("par")
-    end)
-  end, "Special poetry block alignment. DEPRECATED, use styles instead (paragraph margin).")
-  -- HACK.
-  -- This poetry "alignment" is lame, but the real thing is hard!
-  -- See the discussion (esp. the "extra bonus"):
-  -- https://github.com/sile-typesetter/sile/discussions/1602
-  SILE.scratch.styles.alignments["poetry"] = "poetryindent"
-
 end
 
 --- (Override) Declare all settings provided by this package.
@@ -315,12 +297,6 @@ function package:declareSettings ()
     help = "Length (height) of the prodosy annotation line."
   })
 
-  SILE.settings:declare({
-    parameter = "poetry.margin",
-    type = "measurement",
-    default = SILE.types.measurement("0.75em"),
-    help = "Left margin (indentation) for poetry. DEPRECATED, use styles instead (paragraph margin)."
-  })
 end
 
 --- (Override) Register all styles provided by this package.

--- a/packages/resilient/poetry/init.lua
+++ b/packages/resilient/poetry/init.lua
@@ -279,6 +279,9 @@ function package:registerCommands ()
     SILE.call("par")
   end, "A single verse (theoretically an internal command).")
 
+  -- FIXME: Deprecated, use styles instead (paragraph margin).
+  -- We warn in styles, so we don't need to do it here.
+  -- TO REMOVE IN A FUTURE REVISION.
   self:registerCommand("poetryindent", function (_, content)
     SILE.settings:temporarily(function ()
       local indent = SILE.settings:get("poetry.margin"):absolute()
@@ -287,7 +290,7 @@ function package:registerCommands ()
       SILE.process(content)
       SILE.call("par")
     end)
-  end, "Special poetry block alignment.")
+  end, "Special poetry block alignment. DEPRECATED, use styles instead (paragraph margin).")
   -- HACK.
   -- This poetry "alignment" is lame, but the real thing is hard!
   -- See the discussion (esp. the "extra bonus"):
@@ -316,7 +319,7 @@ function package:declareSettings ()
     parameter = "poetry.margin",
     type = "measurement",
     default = SILE.types.measurement("0.75em"),
-    help = "Left margin (indentation) for poetry"
+    help = "Left margin (indentation) for poetry. DEPRECATED, use styles instead (paragraph margin)."
   })
 end
 
@@ -336,7 +339,9 @@ function package:registerStyles ()
   self:registerStyle("prosody", {}, {
     font = { size = "0.95em" },
     paragraph = {
-      align = "poetry",
+      margin = {
+        left = "0.75em",
+      },
       before = {
         skip = "smallskip"
       },
@@ -351,7 +356,9 @@ function package:registerStyles ()
       before = {
         skip = "medskip"
       },
-      align = "poetry",
+      margin = {
+        left = "0.75em",
+      },
       after = {
         skip = "medskip"
       },

--- a/packages/resilient/styles/init.lua
+++ b/packages/resilient/styles/init.lua
@@ -127,35 +127,33 @@ local function compatibilityHackV42 (style)
   --  - poetry is declared in the resilient.poetry package and based on a poetry.margin setting
   --  - noparindent is declared in the resilient.bookmatters package.
   -- We are not querying those settings here, but just applying their defaults.
-  if SILE.resilient.forceCompatibility then
-    if style.paragraph and style.paragraph.align then
-      if style.paragraph.align == "block" then
-        style.paragraph.align = nil
-        style.paragraph.margin = style.paragraph.margin or {}
-        style.paragraph.margin.left = style.paragraph.margin.left or "2em"
-        style.paragraph.margin.right = style.paragraph.margin.right or "2em"
-        SILE.scratch.styles.needCompatibility = true
-      elseif style.paragraph.align == "quotation" then
-        style.paragraph.align = nil
-        style.paragraph.margin = style.paragraph.margin or {}
-        style.paragraph.margin.left = style.paragraph.margin.left or "1.75em"
-        style.paragraph.margin.right = style.paragraph.margin.right or "0.875em"
-        SILE.scratch.styles.needCompatibility = true
-      elseif style.paragraph.align == "poetry" then
-        style.paragraph.align = nil
-        style.paragraph.margin = style.paragraph.margin or {}
-        style.paragraph.margin.left = style.paragraph.margin.left or "0.75em"
-        SILE.scratch.styles.needCompatibility = true
-      elseif style.paragraph.align == "noparindent" then
-        style.paragraph.align = nil
-        style.paragraph.indent = false
-        SILE.scratch.styles.needCompatibility = true
-      elseif style.paragraph.align == "obeylines" then
-        style.paragraph.align = "left"
-        style.paragraph.lines = "preserve"
-        style.paragraph.indent = false
-        SILE.scratch.styles.needCompatibility = true
-      end
+  if style.paragraph and style.paragraph.align then
+    if style.paragraph.align == "block" then
+      style.paragraph.align = nil
+      style.paragraph.margin = style.paragraph.margin or {}
+      style.paragraph.margin.left = style.paragraph.margin.left or "2em"
+      style.paragraph.margin.right = style.paragraph.margin.right or "2em"
+      SILE.scratch.styles.needCompatibility = true
+    elseif style.paragraph.align == "quotation" then
+      style.paragraph.align = nil
+      style.paragraph.margin = style.paragraph.margin or {}
+      style.paragraph.margin.left = style.paragraph.margin.left or "1.75em"
+      style.paragraph.margin.right = style.paragraph.margin.right or "0.875em"
+      SILE.scratch.styles.needCompatibility = true
+    elseif style.paragraph.align == "poetry" then
+      style.paragraph.align = nil
+      style.paragraph.margin = style.paragraph.margin or {}
+      style.paragraph.margin.left = style.paragraph.margin.left or "0.75em"
+      SILE.scratch.styles.needCompatibility = true
+    elseif style.paragraph.align == "noparindent" then
+      style.paragraph.align = nil
+      style.paragraph.indent = false
+      SILE.scratch.styles.needCompatibility = true
+    elseif style.paragraph.align == "obeylines" then
+      style.paragraph.align = "left"
+      style.paragraph.lines = "preserve"
+      style.paragraph.indent = false
+      SILE.scratch.styles.needCompatibility = true
     end
   end
 end
@@ -208,17 +206,18 @@ function package.writeStyles () -- NOTE: Not called as a package method (invoked
   for _ in pairs(diffs) do
     count = count + 1
   end
-  if count == 0 then
-    if SILE.resilient.forceCompatibility and SILE.scratch.styles.needCompatibility then
-      SU.warn("Regenerating style file with compatibility adjustments.\n" .. [[
+  local needCompatibility = SILE.scratch.styles.needCompatibility
+  if needCompatibility then
+    SU.warn("Regenerating style file with compatibility adjustments.\n" .. [[
   If you style file is managed by version control, please review carefully the
   changes.
   Note that the previous implementation used settings for some values, which
-  are NOT taken into account, so you may want to adjust your style file accordingly.
+  are NOT taken into account, so you may want to adjust your style file
+  accordingly.
 ]])
-    else
-      return SU.debug("resilient.styles", "No new styles, no need to write style file")
-    end
+  end
+  if count == 0 and not needCompatibility then
+    return SU.debug("resilient.styles", "No new styles, no need to write style file")
   end
 
   local stydata = tableToYaml(SILE.scratch.styles.specs)
@@ -742,7 +741,7 @@ function package:registerCommands ()
       SILE.call("language", { main = "und" })
       SILE.process(content)
       SILE.typesetter:leaveHmode(1)
-    end)    
+    end)
   end, "(INTERNAL) Preserve line breaks and spaces in the content")
 
   self:registerCommand("style:apply:paragraph", function (options, content)
@@ -774,11 +773,11 @@ function package:registerCommands ()
     SILE.process(block)
 
     local ba = SU.boolean(parSty.after.vbreak, true)
-    if not ba then 
+    if not ba then
       SILE.call("novbreak")
     end
-    -- NOTE: SILE.call("par") would cause a parskip to be inserted.
-    -- Not really sure whether we expect this here or not.
+    -- FIXME NOTE: SILE.call("par") would cause a parskip to be inserted.
+    -- Not really sure whether we expect this here or not ???
     -- SILE.call("par")
 
     styleForAfterSkip(name, parSty)

--- a/packages/resilient/styles/init.lua
+++ b/packages/resilient/styles/init.lua
@@ -93,6 +93,73 @@ local function tableToYaml (value, indent, done)
   end
 end
 
+-- FIXME refactor these two functions
+-- It works, but it's messy and we could certainly handle it when resolving the style
+-- and applyng inheritance, rather at the last moment.
+local function propertyValueIfNotNull (prop)
+  if tostring(prop) == "yaml.null" then
+    -- Don't crash on null values (a special table with tinyyaml).
+    -- And be friendly with them (they cancel style inheritance).
+    return nil
+  end
+  if type(prop) == "table" then
+    SU.error("Unexpected table value for property")
+  end
+  return prop
+end
+local function shallowNonNullOptions (options)
+  -- When passing options to SILE commands, we want to avoid passing null
+  -- values from YAML style files.
+  local copy = {}
+  for k, v in pairs(options) do
+    if propertyValueIfNotNull(v) then
+      copy[k] = v
+    end
+  end
+  return copy
+end
+
+local function compatibilityHackV42 (style)
+  -- Transitional compatibility adapter for alignments (block, quotation, poetry)
+  -- Removed in v4.2, but keeping compatibility.
+  -- Note the bad separation of concerns:
+  --  - block, quotation are declared in the resilient.book class and based on a book.blockquote.margin setting
+  --  - poetry is declared in the resilient.poetry package and based on a poetry.margin setting
+  --  - noparindent is declared in the resilient.bookmatters package.
+  -- We are not querying those settings here, but just applying their defaults.
+  if SILE.resilient.forceCompatibility then
+    if style.paragraph and style.paragraph.align then
+      if style.paragraph.align == "block" then
+        style.paragraph.align = nil
+        style.paragraph.margin = style.paragraph.margin or {}
+        style.paragraph.margin.left = style.paragraph.margin.left or "2em"
+        style.paragraph.margin.right = style.paragraph.margin.right or "2em"
+        SILE.scratch.styles.needCompatibility = true
+      elseif style.paragraph.align == "quotation" then
+        style.paragraph.align = nil
+        style.paragraph.margin = style.paragraph.margin or {}
+        style.paragraph.margin.left = style.paragraph.margin.left or "1.75em"
+        style.paragraph.margin.right = style.paragraph.margin.right or "0.875em"
+        SILE.scratch.styles.needCompatibility = true
+      elseif style.paragraph.align == "poetry" then
+        style.paragraph.align = nil
+        style.paragraph.margin = style.paragraph.margin or {}
+        style.paragraph.margin.left = style.paragraph.margin.left or "0.75em"
+        SILE.scratch.styles.needCompatibility = true
+      elseif style.paragraph.align == "noparindent" then
+        style.paragraph.align = nil
+        style.paragraph.indent = false
+        SILE.scratch.styles.needCompatibility = true
+      elseif style.paragraph.align == "obeylines" then
+        style.paragraph.align = "left"
+        style.paragraph.lines = "preserve"
+        style.paragraph.indent = false
+        SILE.scratch.styles.needCompatibility = true
+      end
+    end
+  end
+end
+
 --- (Override) Register all styles provided by this package.
 function package:readStyles ()
   local yaml = require("resilient-tinyyaml")
@@ -118,6 +185,7 @@ function package:readStyles ()
         -- Try do define some style anyway.
         self:defineStyle(name, { inherit = inherit }, {}, spec.origin or "corrupted")
       else
+        compatibilityHackV42(styledef)
         SU.debug("resilient.styles", "Loading style", name)
         self:defineStyle(name, { inherit = inherit }, styledef, spec.origin)
       end
@@ -141,7 +209,16 @@ function package.writeStyles () -- NOTE: Not called as a package method (invoked
     count = count + 1
   end
   if count == 0 then
-    return SU.debug("resilient.styles", "No need to write style file (no new styles)")
+    if SILE.resilient.forceCompatibility and SILE.scratch.styles.needCompatibility then
+      SU.warn("Regenerating style file with compatibility adjustments.\n" .. [[
+  If you style file is managed by version control, please review carefully the
+  changes.
+  Note that the previous implementation used settings for some values, which
+  are NOT taken into account, so you may want to adjust your style file accordingly.
+]])
+    else
+      return SU.debug("resilient.styles", "No new styles, no need to write style file")
+    end
   end
 
   local stydata = tableToYaml(SILE.scratch.styles.specs)
@@ -156,6 +233,8 @@ function package.writeStyles () -- NOTE: Not called as a package method (invoked
   styfile:write(stydata)
   styfile:close()
 end
+
+local STANDARD_ALIGNMENTS = pl.Set { "center", "left", "right", "justify" }
 
 SILE.scratch.styles = {
   state = {
@@ -258,6 +337,8 @@ function package:hasStyle (name)
   return stylespec and true or false
 end
 
+local warnedUndefinedStyles = pl.Set()
+
 --- Resolve a paragraph style, applying defaults to missing fields.
 --
 -- @tparam string name Style name
@@ -267,6 +348,20 @@ function package:resolveParagraphStyle (name, discardable)
   local styledef = self:resolveStyle(name, discardable)
   -- Apply defaults
   styledef.paragraph = styledef.paragraph or {}
+  -- Compatibility between style v2.8 and v4.2
+  if styledef.paragraph.align and not STANDARD_ALIGNMENTS[styledef.paragraph.align] then
+      if not warnedUndefinedStyles[name] then
+        SU.warn("Paragraph style '" .. name .. "' has non-standard alignment '" .. styledef.paragraph.align .. "'\n" .. [[
+          Use paragraph.margin (right/left) to achieve the desired alignment margins,
+          paragraph.indent to false to disable paragraph indentation if needed,
+          and paragraph.align set to one of the standard values (center, left, right, justify).
+      ]])
+        warnedUndefinedStyles[name] = true
+      end
+      warnedUndefinedStyles[name] = true
+  end
+  styledef.paragraph.margin = styledef.paragraph.margin or {}
+  styledef.paragraph.indent = SU.boolean(propertyValueIfNotNull(styledef.paragraph.indent), true)
   styledef.paragraph.before = styledef.paragraph.before or {}
   styledef.paragraph.before.indent = SU.boolean(styledef.paragraph.before.indent, true)
   styledef.paragraph.before.vbreak = SU.boolean(styledef.paragraph.before.vbreak, true)
@@ -295,32 +390,6 @@ function package:freezeStyles ()
   SU.debug("resilient.styles", "Freezing styles")
 end
 
--- FIXME refactor these two functions
--- It works, but it's messy and we could certainly handle it when resolving the style
--- and applyng inheritance, rather at the last moment.
-local function propertyValueIfNotNull (prop)
-  if tostring(prop) == "yaml.null" then
-    -- Don't crash on null values (a special table with tinyyaml).
-    -- And be friendly with them (they cancel style inheritance).
-    return nil
-  end
-  if type(prop) == "table" then
-    SU.error("Unexpected table value for property")
-  end
-  return prop
-end
-local function shallowNonNullOptions (options)
-  -- When passing options to SILE commands, we want to avoid passing null
-  -- values from YAML style files.
-  local copy = {}
-  for k, v in pairs(options) do
-    if propertyValueIfNotNull(v) then
-      copy[k] = v
-    end
-  end
-  return copy
-end
-
 --- (Override) Register all commands provided by this package.
 function package:registerCommands ()
   self:registerCommand("style:font", function (options, content)
@@ -336,9 +405,39 @@ function package:registerCommands ()
     SILE.call("font", opts, content)
   end, "Applies a font, with additional support for relative sizes.")
 
-  -- Very naive cascading...
-  local function characterStyle (style, content, options)
-    options = options or {}
+    local function hackSubContent(content, name)
+    if type(content) == "table" then
+      if content.command or content.id then
+        -- We want to skip the calling content key values (id, command, etc.)
+        return SU.ast.subContent(content)
+      end
+      return content
+    end
+    if name ~= "footnote" then -- HACK: Could not avoid function call in resilient.footnotes...
+      SU.warn("Invocation of style '" .. name .. "'' with unexpected content ("
+        .. type(content) ..")" .. [[
+
+    For styles to apply correctly, the content should be an AST table.
+    Some constructs may fail or generate errors later (text case, position, etc.)
+]])
+    end
+    return content
+  end
+
+  -- Character style logic
+
+  -- Naive cascading for "other" properties (color, decoration, position, case)
+  --   color?(
+  --     decoration?(
+  --       position?(
+  --         case?(
+  --          content
+  --         )
+  --       )
+  --     )
+
+  local function characterStyleOther (style, content)
+
     if style.properties then
       local positionValue = propertyValueIfNotNull(style.properties.position)
       if positionValue and positionValue ~= "normal" then
@@ -371,73 +470,117 @@ function package:registerCommands ()
     if colorValue then
       content = SU.ast.createCommand("color", { color = colorValue }, content)
     end
-    if style.font and SU.boolean(options.font, true) then
-      content = SU.ast.createCommand("style:font", style.font, content)
-    end
     return content
   end
 
-  local function characterStyleNoFont (style, content)
-    return characterStyle(style, content, { font = false })
-  end
-
-  local function hackSubContent(content, name)
-    if type(content) == "table" then
-      if content.command or content.id then
-        -- We want to skip the calling content key values (id, command, etc.)
-        return SU.ast.subContent(content)
-      end
-      return content
-    end
-    if name ~= "footnote" then -- HACK: Could not avoid function call in resilient.footnotes...
-      SU.warn("Invocation of style '" .. name .. "'' with unexpected content ("
-        .. type(content) ..")" .. [[
-
-    For styles to apply correctly, the content should be an AST table.
-    Some constructs may fail or generate errors later (text case, position, etc.)
-]])
-    end
-    return content
-  end
-
-  local characterStyleFontOnly = function (style, content)
+  local function characterStyleFont (style, content)
     if style.font then
       content = SU.ast.createCommand("style:font", style.font, content)
     end
     return content
   end
 
-  local styleForAlignment = function (style, content, breakafter)
-    if style.paragraph and style.paragraph.align then -- FIXME: Code smell, re-tested below
-      if style.paragraph.align then
-        local alignCommand = SILE.scratch.styles.alignments[style.paragraph.align]
-        if not alignCommand then
-          SU.error("Invalid paragraph style alignment '"..style.paragraph.align.."'")
-        end
-        if not breakafter then SILE.call("novbreak") end
-        SILE.typesetter:leaveHmode()
-        -- Here we must apply the font, then the alignment, so that line heights are
-        -- correct even on the last paragraph. But the color introduces hboxes so
-        -- must be applied last, no to cause havoc with the noindent/indent and
-        -- centering etc. environments
-        local recontent = SU.ast.createCommand(alignCommand, {}, {
-          characterStyleNoFont(style, content),
-          not breakafter and SU.ast.createCommand("novbreak") or nil
-        })
-        if style.font then
-          recontent = characterStyleFontOnly(style, recontent)
-        end
-        SILE.process({ recontent })
-      else
-        SILE.process({ characterStyle(style, content) })
-        if not breakafter then SILE.call("novbreak") end
-        -- NOTE: SILE.call("par") would cause a parskip to be inserted.
-        -- Not really sure whether we expect this here or not.
-        SILE.typesetter:leaveHmode()
-      end
+  local function characterStyle (style, content)
+    return characterStyleFont(style, characterStyleOther(style, content))
+  end
+
+  local function wrapContentInNovbreak (style, content)
+    local before = style.paragraph.before
+    local after = style.paragraph.after
+    local novbreakBefore = not SU.boolean(before and before.vbreak, true)
+    local novbreakAfter = not SU.boolean(after and after.vbreak, true)
+    local block = (novbreakBefore and novbreakAfter) and
+      {
+        SU.ast.createCommand("novbreak"),
+        content,
+        SU.ast.createCommand("novbreak")
+      }
+      or (novbreakBefore and
+      {
+        SU.ast.createCommand("novbreak"),
+        content,
+      }
+      or (novbreakAfter and
+      {
+        content,
+        SU.ast.createCommand("novbreak")
+      })
+      or
+      {
+        content,
+      })
+    return block
+  end
+
+  -- Alignment and margin logic
+
+  local function styleForLineMode (style, content)
+    if style.paragraph.lines == "preserve" then
+      return SU.ast.createCommand("style:internal:preserve", {}, content)
     else
-      SILE.process({ characterStyle(style, content) })
+      return content
     end
+  end
+
+  local function styleForMargin (style, content)
+    local lmargin = propertyValueIfNotNull(style.paragraph.margin.left)
+    local rmargin = propertyValueIfNotNull(style.paragraph.margin.right)
+    -- QUESTION: We absolutize lskip and rskip after the font was applied,
+    -- so they are interpreted in the target font size.
+    -- This was the original behavior, but is it really what we wanted?
+    if lmargin or rmargin then
+      return SU.ast.createCommand("style:internal:margin", { left = lmargin, right = rmargin }, content)
+    else
+      return content
+    end
+  end
+
+  local function styleForAlign (style, content)
+    local align = propertyValueIfNotNull(style.paragraph.align)
+    if align then
+      local alignCommand = SILE.scratch.styles.alignments[align]
+      if not alignCommand then
+        SU.error("Invalid paragraph style alignment '"..style.paragraph.align.."'")
+      end
+      return SU.ast.createCommand(alignCommand, {}, content)
+    else
+      return content
+    end
+  end
+
+  local function styleForIndent (style, content)
+    if style.paragraph.indent == false then
+      return SU.ast.createCommand("style:internal:noparindent", {}, content)
+    else
+      return content
+    end
+  end
+
+  -- Naive cascading for paragraph properties
+  -- The font is applied first for other constructs evaluating font-relative units.
+  --    characterStyleFont(
+  --      styleForIndent(
+  --        styleForAlign(
+  --          styleForMargin(
+  --            styleForLineMode(
+  --              characterStyleOther(content)
+  --            )
+  --          )
+  --        )
+  --     )
+
+  local function styleForParagraphContent (style, content)
+    local withCharacterOther = characterStyleOther(style, content)
+    local withLineMode = styleForLineMode(style, withCharacterOther)
+    local withMargin = styleForMargin(style, withLineMode)
+    local withAlign = styleForAlign(style, withMargin)
+    local withIndent = styleForIndent(style, withAlign)
+    local withFont = characterStyleFont(style, withIndent)
+
+    -- We never know for suree if some of the above introduced a "par"
+    -- possibly a parskip.
+    local block = wrapContentInNovbreak(style, withFont)
+    return block
   end
 
   -- APPLY A CHARACTER STYLE
@@ -564,6 +707,44 @@ function package:registerCommands ()
     end
   end
 
+  self:registerCommand("style:internal:margin", function (options, content)
+    local lmargin = SU.cast("measurement", options.left or 0)
+    local rmargin = SU.cast("measurement", options.right or 0)
+    local lskip = SILE.settings:get("document.lskip") or SILE.types.node.glue()
+    local rskip = SILE.settings:get("document.rskip") or SILE.types.node.glue()
+    SILE.settings:temporarily(function ()
+      if lmargin:tonumber() ~= 0 then
+         SILE.settings:set("document.lskip", SILE.types.node.glue(lskip.width:absolute() + lmargin:absolute()))
+      end
+      if rmargin:tonumber() ~= 0 then
+         SILE.settings:set("document.rskip", SILE.types.node.glue(rskip.width:absolute() + rmargin:absolute()))
+      end
+      SILE.process(content)
+      SILE.typesetter:leaveHmode(1)
+    end)
+  end, "(INTERNAL) Typeset its contents with additional left and right margins.")
+
+  self:registerCommand("style:internal:noparindent", function (_, content)
+    SILE.settings:temporarily(function ()
+      SILE.settings:set("document.parindent", SILE.types.node.glue())
+      SILE.settings:set("current.parindent", SILE.types.node.glue())
+      SILE.process(content)
+      SILE.typesetter:leaveHmode(1)
+    end)
+  end, "(INTERNAL) Control whether paragraph indent should be applied to the content.")
+
+  self:registerCommand("style:internal:preserve", function (_, content)
+    SILE.settings:temporarily(function()
+      SILE.settings:set("typesetter.parseppattern", "\n")
+      SILE.settings:set("typesetter.obeyspaces", true) -- FIXME Dubious setting
+      SILE.settings:set("document.spaceskip", SILE.types.length("1spc"))
+      SILE.settings:set("shaper.variablespaces", false)
+      SILE.call("language", { main = "und" })
+      SILE.process(content)
+      SILE.typesetter:leaveHmode(1)
+    end)    
+  end, "(INTERNAL) Preserve line breaks and spaces in the content")
+
   self:registerCommand("style:apply:paragraph", function (options, content)
     local name = SU.required(options, "name", "style:apply:paragraph")
     local styledef = self:resolveParagraphStyle(name, options.discardable)
@@ -588,16 +769,19 @@ function package:registerCommands ()
       SILE.call("noindent")
     end
 
-    local ba = parSty.after.vbreak
-    styleForAlignment(styledef, content, ba)
+    local wrapped = wrapContentInNovbreak(styledef, content)
+    local block = styleForParagraphContent(styledef, wrapped)
+    SILE.process(block)
 
-    if not ba then SILE.call("novbreak") end
+    local ba = SU.boolean(parSty.after.vbreak, true)
+    if not ba then 
+      SILE.call("novbreak")
+    end
     -- NOTE: SILE.call("par") would cause a parskip to be inserted.
     -- Not really sure whether we expect this here or not.
-    SILE.typesetter:leaveHmode()
+    -- SILE.call("par")
 
     styleForAfterSkip(name, parSty)
-
     if parSty.after.indent then
       SILE.call("indent")
     else

--- a/packages/resilient/verbatim/init.lua
+++ b/packages/resilient/verbatim/init.lua
@@ -41,6 +41,9 @@ function package:registerCommands ()
     end)
   end)
 
+  -- FIXME: Deprecated, use styles instead (paragraph line preserve).
+  -- We warn in styles, so we don't need to do it here.
+  -- TO REMOVE IN A FUTURE REVISION.
   self:registerCommand("verbatim:block", function (_, content)
     local lskip = SILE.settings:get("document.lskip") or SILE.types.node.glue()
     local rskip = SILE.settings:get("document.rskip") or SILE.types.node.glue()
@@ -72,11 +75,13 @@ end
 function package:registerStyles ()
   base.registerStyles(self)
 
-  SILE.scratch.styles.alignments["obeylines"] = "verbatim:block"
+  SILE.scratch.styles.alignments["obeylines"] = "verbatim:block" -- FIXME DEPRECATED
 
   self:registerStyle("verbatim", { inherit = "code" }, {
     paragraph = {
-      align = "obeylines",
+      lines = "preserve",
+      indent = false,
+      align = "left",
       --after = {
         -- FIXME
         -- Some weird skip occurs naturally in the resilient manual (djot and markdown content)

--- a/packages/resilient/verbatim/init.lua
+++ b/packages/resilient/verbatim/init.lua
@@ -41,30 +41,6 @@ function package:registerCommands ()
     end)
   end)
 
-  -- FIXME: Deprecated, use styles instead (paragraph line preserve).
-  -- We warn in styles, so we don't need to do it here.
-  -- TO REMOVE IN A FUTURE REVISION.
-  self:registerCommand("verbatim:block", function (_, content)
-    local lskip = SILE.settings:get("document.lskip") or SILE.types.node.glue()
-    local rskip = SILE.settings:get("document.rskip") or SILE.types.node.glue()
-    SILE.typesetter:leaveHmode()
-    SILE.settings:temporarily(function()
-      SILE.settings:set("typesetter.parseppattern", "\n")
-      SILE.settings:set("typesetter.obeyspaces", true) -- FIXME Dubious setting
-      -- We handle the fixed part of right and left skip to support nesting.
-      -- We use use a true left alignment (= infinite right stretchability).
-      SILE.settings:set("document.lskip", SILE.types.node.glue(lskip.width.length))
-      SILE.settings:set("document.rskip", SILE.types.node.hfillglue(rskip.width.length))
-      SILE.settings:set("document.parindent", SILE.types.node.glue())
-      SILE.settings:set("current.parindent", SILE.types.node.glue())
-      SILE.settings:set("document.spaceskip", SILE.types.length("1spc"))
-      SILE.settings:set("shaper.variablespaces", false)
-      SILE.call("language", { main = "und" })
-      SILE.process(content)
-      SILE.typesetter:leaveHmode()
-    end)
-  end, "Typesets its contents in a left-aligned block honoring spaces and line-breaks.")
-
   self:registerCommand("verbatim", function (_, content)
     SILE.call("style:apply:paragraph", { name = "verbatim" }, content)
   end, "Typesets its contents styled as 'verbatim'.")
@@ -74,8 +50,6 @@ end
 --- (Override) Register all styles provided by this package.
 function package:registerStyles ()
   base.registerStyles(self)
-
-  SILE.scratch.styles.alignments["obeylines"] = "verbatim:block" -- FIXME DEPRECATED
 
   self:registerStyle("verbatim", { inherit = "code" }, {
     paragraph = {

--- a/schemas/stylefile.json
+++ b/schemas/stylefile.json
@@ -87,7 +87,38 @@
               "properties": {
                 "align": {
                   "description": "Alignment of the paragraph",
-                  "type": "string"
+                  "type": "string",
+                  "enum": [
+                    "left",
+                    "right",
+                    "center",
+                    "justify"
+                  ]
+                },
+                "indent": {
+                  "description": "Whether paragraphs should be indented (for all descendants)",
+                  "type": "boolean"
+                },
+                "margin": {
+                  "description": "Margins for the paragraph",
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "left": {
+                      "description": "Left margin (in absolute or relative units)",
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "right": {
+                      "description": "Right margin (in absolute or relative units)",
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  }
                 },
                 "before": {
                   "description": "Properties before the paragraph",


### PR DESCRIPTION
There are a bunch of "quick" hacks from the very original implementation of styles 4-5 years ago. I wanted to address them in a breaking major version, but we can already introduce the target syntax, with a path for a smooth transition.

## Migration

When compiling a document, styles will automatically be regenerated with these adjustments made for you.

However that some of the older alignment options relied on settings which are ignored by this compatibility rewrite.
 - You are safe if you didn't tweak those settings (probably the case for most users)
 - Otherwise you should then carefully review the generated styles and manually adjust them. Moreover these settings (see below) have been removed (as well as the internal-level commands supporting them).  **Yes**, this is a (slightly) breaking change. Maintaining compatibility shims didn't prove worth the effort.

Read also below for possible side-effects.

## Changes

1. Deprecate `block` and `quotation` paragraph alignments

   ```yaml
   style:
     ...
     paragraph:
       align: block|quotation
    ```

   Now use:

   ```yaml
    style:
      ...
      paragraph:
        margin:
          left: "somevalue"
          right: "somevalue"
   ```

   And alignment can be set orthogonally to the margins, allowing for more flexible layouts.
   The `book.blockquote.margin` setting is removed since margins can now be set in the style file.
   Its default value was 2em:
    - `block` used it on both sides (= `left: 2em` and `right: 2em`)
    - `quotation` used it on the left side, and half of it on the right side (= `left: 2em` and `right: 1em`).
   But you can now set any values you want, possibly different depending on the style.   

2. Deprecate `poetry` alignment:

   ```yaml
   style:
     ...
     paragraph:
       align: poetry
   ```

   Now use:

   ```yaml
    style:
      ...
      paragraph:
        margin:
          left: "0.75em" # what the (default) value for poetry.margin was
          ...
   ```

   The rationale is the same as above.
   The `poetry.margin` setting is also removed.

3. Deprecate `noparindent` alignment:

   ```yaml
   style:
     ...
     paragraph:
       align: noparindent
   ```

   Now use:

   ```yaml
    style:
      ...
      paragraph:
        indent: false
   ```

   This allows disabling indentation in all descendant content.
   For now it cannot be reversed once applied, but this could be done if really needed, and margins and alignment can be applied orthogonally to the indentation, allowing for more flexible layouts.

 4. Deprecate `obeylines` alignment:

    ```yaml
    style:
      ...
      paragraph:
        align: obeylines
    ```

    Now use::

    ```yaml
     style:
       ...
       paragraph:
         align: left
         indent: false
         lines: preserve
    ```

    The "obeylines" alignment was a bit of a hack introduced in the **resilient.verbatim** package, mixing several orthogonal aspects of paragraph formatting (alignment, indentation, and line breaking).

## Side-effects

The old logic was **very** messy in its handling of vertical breaks (well, disallowing them, e.g. after headers) and paragraphing (whether a paragraph skip is inserted or not).

The situation is a bit better, but still not perfect, and the implementation is somewhat cleaner, but we clearly have a parskip issue = #196 

The implication is that the output may slightly differ at places (but page breaks can then occur differently).
