### PR TITLE
fix(packages): Ensure PDF form and attachment objects are only released once

### DIFF
--- a/packages/resilient/attachments/init.lua
+++ b/packages/resilient/attachments/init.lua
@@ -52,6 +52,7 @@ function package:_init (options)
     -- Use a closure to access 'this', check support and output attachments on the proper instance.
     if this._hasAttachmentSupport then
       this:_outputAttachments()
+      this._attachments = nil -- Clear attachments after output, for safety (should not be used after this point)
     end
   end)
 end

--- a/packages/resilient/forms/init.lua
+++ b/packages/resilient/forms/init.lua
@@ -197,6 +197,13 @@ function package:_releasePdfObjects ()
   for _, entry in self._parents:iter() do
     pdf.release(entry.fieldDict)
   end
+
+  -- CODE SMELL
+  -- We don't expect the method to be called multiple times,
+  -- but with SILE's plain class (i.e. not in resilient, which cancels "multiple" package re-loads),
+  -- this is possible... So we clear our list of objects to release, just in case.
+  self._objectsToRelease = {}
+  self._parents = pl.Map()
 end
 
 --- (Private) Create an appearance stream XObject.


### PR DESCRIPTION

When using a re·sil·ient document class such as resilient.book, multiple re-init of packages, a feature introduced in SILE 0.14 if my memory serves me well, is disabled. I was never convinced by this behaviour, and it makes things harder actually for package developers.

However, when using a non-resilient class, such as SILE's plain document class, SILE's default behavior applies. In some cases where other packages or the document explicitly load package.forms or package.attachments, it results in multiple instances. These packages use the "prefinish" hook of the outputter to perform cleanup of PDF resources at the end of the document compilation. Due to keeping global "scratch" variables for other reasons (mostly historical), attempts can be made to release the same resources multiple times, leading to an obscure libtexpdf crash.

Of course, the proper fix would be to avoid shared contexts and scratch variables. Yet, a minimal fix is easier for now, clearing our lists of resources after processing, in case hooks run multiple times due to the multiple instances of the same packages.