### PR TITLE
Additions to the e-invoicing Factur-X generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![License](https://img.shields.io/github/license/Omikhleia/resilient.sile?label=License)](LICENSE)
 [![Luacheck](https://img.shields.io/github/actions/workflow/status/Omikhleia/resilient.sile/luacheck.yml?branch=main&label=Luacheck&logo=Lua)](https://github.com/Omikhleia/resilient.sile/actions?workflow=Luacheck)
 [![Luarocks](https://img.shields.io/luarocks/v/Omikhleia/resilient.sile?label=Luarocks&logo=Lua)](https://luarocks.org/modules/Omikhleia/resilient.sile)
-[![Documentation](https://img.shields.io/badge/docs-GitHub%20Pages-blue)](https://omikhleia.github.io/resilient.sile/)
+[![Documentation](https://img.shields.io/badge/Docs-GitHub%20Pages-blue)](https://omikhleia.github.io/resilient.sile/)
 
 This collection of classes and packages for the [SILE](https://github.com/sile-typesetter/sile) typesetting system provides advanced classes, packages and tools for streamlining the production of high-quality books and documents.
 
@@ -26,7 +26,7 @@ The collection also includes additional components, such as:
 - A lightweight “résumé” class, for you to produce a colorful and yet professional-looking _curriculum vitæ_.
 - An “invoice” support module, with:
   - An easy-to-use YAML-based input format,
-  - Support for hybrid PDF/XML invoices following the Factur-X/ZUGFeRD standard.
+  - Support for hybrid PDF/XML invoices following the Factur-X/ZUGFeRD EN16931 standard.
 
 ## Demonstration
 

--- a/examples/invoice/invoice.yaml
+++ b/examples/invoice/invoice.yaml
@@ -3,7 +3,7 @@ invoice:
   language:      en                          # Optional, BCP47 language code, default "en"
                                              # Used for localized strings in the PDF
   id:            EX-SILE2025-01              # Mandatory, number or string identifying the invoice
-  order-id:      PO-SILE2025-01              # Optional, number or string identifying the related purchase order
+  # order-id:      PO-XXX-01                   # Optional, number or string identifying the related purchase order
   issue-date:    2025-11-05                  # Mandatory, YYYY-MM-DD format
   due-date:      2025-12-24                  # Mandatory, either an explicit date or a number of days
   delivery-date: 2025-11-23                  # Optional
@@ -19,8 +19,9 @@ invoice:
     name: Holmes Brothers & Associates       # Mandatory
     logo: sherlock.png                       # Optional. Not used in Factur-X but rendered in the PDF
     uri: https://sile-typesetter.org         # Optional, Not used in Factur-X but rendered in the PDF
-    tax-registration: GB1234567              # Optional.
-                                             # If present, shall have an ISO 3166-1 alpha-2 country code prefix
+    tax-registration: GB1234567              # Optional. Shall have an ISO 3166-1 alpha-2 country code prefix when present
+    # siret: "12345678901234"                  # Optional. Should be present for French companies: SIRET number (14 digits)
+
     address:                                 # Optional
       postal-code: NW1 6XE                   # Optional
       location:                              # Up to 3 location lines are used in Factur-X

--- a/examples/invoice/invoice.yaml
+++ b/examples/invoice/invoice.yaml
@@ -3,6 +3,7 @@ invoice:
   language:      en                          # Optional, BCP47 language code, default "en"
                                              # Used for localized strings in the PDF
   id:            EX-SILE2025-01              # Mandatory, number or string identifying the invoice
+  order-id:      PO-SILE2025-01              # Optional, number or string identifying the related purchase order
   issue-date:    2025-11-05                  # Mandatory, YYYY-MM-DD format
   due-date:      2025-12-24                  # Mandatory, either an explicit date or a number of days
   delivery-date: 2025-11-23                  # Optional

--- a/inputters/invoice.lua
+++ b/inputters/invoice.lua
@@ -711,7 +711,8 @@ local function mainInvoiceBox (invoice)
       CreateCommand("center", {}, {
         Box(
           Span(Style("invoice-date-label", I18n("invoice_issue_date") .. ":"), Date(invoice["issue-date"])),
-          invoice["delivery-date"] and Span(Style("invoice-date-label", I18n("invoice_delivery_date") .. ":"), Date(invoice["delivery-date"]))
+          invoice["delivery-date"] and Span(Style("invoice-date-label", I18n("invoice_delivery_date") .. ":"), Date(invoice["delivery-date"])),
+          invoice["order-id"] and Span(Style("invoice-date-label", I18n("purchase_order_reference") .. ":"), invoice["order-id"])
         ),
       }),
       Skip(),
@@ -849,7 +850,6 @@ function inputter:parse (doc)
 
    -- Load needed packages
   local neededPackages = {
-    "packages.background",
     "packages.framebox",
     "packages.image",
     "packages.ptable",

--- a/inputters/invoice.lua
+++ b/inputters/invoice.lua
@@ -414,6 +414,7 @@ end
 local function tradePartyBox (it)
   return Box(
     Box(Style("invoice-company", it.name)),
+    it.siret and Box("SIRET: " .. it.siret, CreateCommand("smallskip")),
     postalTradeAddress(it.address),
     it.uri and Style("invoice-website", Link(it.uri)),
     it.contact and Style("invoice-contact",

--- a/resilient/schemas/invoice/init.lua
+++ b/resilient/schemas/invoice/init.lua
@@ -64,6 +64,7 @@ local TradePartySchema = {
     logo = { type = "string" },
     uri = { type = "string" },
     ["tax-registration"] = { type = "string" },
+    siret = { type = "string" },
     address = PostalTradeAddressSchema,
     contact = DefinedTradeContactSchema,
   },

--- a/resilient/schemas/invoice/init.lua
+++ b/resilient/schemas/invoice/init.lua
@@ -133,6 +133,12 @@ local InvoiceContentSchema = {
       default = "en",
     },
     note = { type = "string" }, -- Not from Factur-X, but free text note for presentation
+    ["order-id"] = {
+      type = { -- oneOf
+        { type = "string" },
+        { type = "number" },
+      },
+    },
     ["issue-date"] = DateSchema,
     ["due-date"] = { type = {
         DateSchema,

--- a/resilient/support/invoice/facturx.lua
+++ b/resilient/support/invoice/facturx.lua
@@ -137,6 +137,20 @@ local function TradeContact (it)
   })
 end
 
+local function SpecifiedLegalOrganization (it)
+  -- A bit lame / ad hoc for now, we could want to support other legal organization identifiers
+  -- in the future, such as GLN (Global Location Number = 0088), etc.
+  -- But in France, mention of SIRET is mandatory for companies, so we want to support it at least.
+  if not it.siret then
+    return ""
+  end
+  return table.concat({
+    '<ram:SpecifiedLegalOrganization>',
+      xmlTagHelper("ram:ID", { schemeID = "0009" }, it.siret), -- SIRET with ISO 6523 ICD code as schemeID
+    '</ram:SpecifiedLegalOrganization>'
+  })
+end
+
 local function TradeParty (it)
   return table.concat({
     -- ID
@@ -144,7 +158,7 @@ local function TradeParty (it)
     xmlTagHelper("ram:Name", {}, it.name),
     -- RoleCode
     -- Description
-    -- SpecifiedLegalOrganization
+    SpecifiedLegalOrganization(it),
     TradeContact(it.contact),
     PostalTradeAddress(it.address),
     -- [BR-CL-25] - Endpoint identifier scheme identifier MUST belong to the CEF EAS code list

--- a/resilient/support/invoice/facturx.lua
+++ b/resilient/support/invoice/facturx.lua
@@ -391,6 +391,17 @@ local function SpecifiedTradeSettlementPaymentMeans (it)
   return table.concat(entries)
 end
 
+local function InvoiceReferencedDocument (it)
+  if not it["order-id"] then
+    return ""
+  end
+  return table.concat({
+    '<ram:InvoiceReferencedDocument>',
+      xmlTagHelper("ram:IssuerAssignedID", {}, it["order-id"]),
+    '</ram:InvoiceReferencedDocument>'
+  })
+end
+
 local function ApplicableHeaderTradeSettlement (it)
   local paymentMeans = SpecifiedTradeSettlementPaymentMeans(it)
   return table.concat({
@@ -420,7 +431,7 @@ local function ApplicableHeaderTradeSettlement (it)
         -- DirectDebitMandateID
       '</ram:SpecifiedTradePaymentTerms>',
       SpecifiedTradeSettlementHeaderMonetarySummation(it), -- mandatory
-      -- InvoiceReferencedDocument
+      InvoiceReferencedDocument(it),
       -- ReceivableSpecifiedTradeAccountingAccount
       -- SpecifiedAdvancePayment
     '</ram:ApplicableHeaderTradeSettlement>'

--- a/resilient/support/invoice/facturx.lua
+++ b/resilient/support/invoice/facturx.lua
@@ -114,8 +114,11 @@ local function TradeContact (it)
   end
   return table.concat({
     '<ram:DefinedTradeContact>',
-      xmlTagHelper("ram:PersonName", {}, it.name),
-      xmlTagHelper("ram:DepartmentName", {}, it.department),
+      -- [CII-SR-465] Only one BT-41 element is allowed on an invoice / [CII-SR-466] Only one BT-56 element is allowed on an invoice.
+      -- It excludes having both a department and a person name, so we prioritize the department if both are present.
+      it.department
+        and xmlTagHelper("ram:DepartmentName", {}, it.department)
+        or xmlTagHelper("ram:PersonName", {}, it.name),
       -- TypeCode
       it.phone
         and table.concat({

--- a/resilient/support/invoice/i18n/ca.lua
+++ b/resilient/support/invoice/i18n/ca.lua
@@ -5,6 +5,7 @@ return {
   invoice_delivery_date = "Data de lliurament",
   invoice_due_date = "Data de venciment",
   invoice_due_terms = "Pagament en un termini de {days} {day_terms}",
+  purchase_order_reference = "Comanda de compra",
   line_id = "ID",
   line_description = "Descripció",
   line_quantity = "Quantitat",

--- a/resilient/support/invoice/i18n/de.lua
+++ b/resilient/support/invoice/i18n/de.lua
@@ -5,6 +5,7 @@ return {
   invoice_delivery_date = "Lieferdatum",
   invoice_due_date = "Fälligkeitsdatum",
   invoice_due_terms = "Zahlbar innerhalb von {days} {day_terms}",
+  purchase_order_reference = "Auftragsbestätigung",
   line_id = "ID",
   line_description = "Beschreibung",
   line_quantity = "Menge",

--- a/resilient/support/invoice/i18n/en.lua
+++ b/resilient/support/invoice/i18n/en.lua
@@ -5,6 +5,7 @@ return {
   invoice_delivery_date = "Delivery Date",
   invoice_due_date = "Due Date",
   invoice_due_terms = "Payment within {days} {day_terms}",
+  purchase_order_reference = "Purchase Order",
   line_id = "ID",
   line_description = "Description",
   line_quantity = "Quantity",

--- a/resilient/support/invoice/i18n/es.lua
+++ b/resilient/support/invoice/i18n/es.lua
@@ -5,6 +5,7 @@ return {
   invoice_delivery_date = "Fecha de Entrega",
   invoice_due_date = "Fecha de Vencimiento",
   invoice_due_terms = "Pago dentro de {days} {day_terms}",
+  purchase_order_reference = "Orden de Compra",
   line_id = "ID",
   line_description = "Descripción",
   line_quantity = "Cantidad",

--- a/resilient/support/invoice/i18n/fr.lua
+++ b/resilient/support/invoice/i18n/fr.lua
@@ -5,6 +5,7 @@ return {
   invoice_delivery_date = "Date de livraison",
   invoice_due_date = "Date d’échéance",
   invoice_due_terms = "Paiement sous {days} {day_terms}",
+  purchase_order_reference = "Bon de commande",
   line_id = "ID",
   line_description = "Description",
   line_quantity = "Quantité",

--- a/resilient/support/invoice/i18n/is.lua
+++ b/resilient/support/invoice/i18n/is.lua
@@ -5,6 +5,7 @@ return {
   invoice_delivery_date = "Afhendingardagur",
   invoice_due_date = "Gjaldadagur",
   invoice_due_terms = "Greiðsla innan {days} {day_terms}",
+  purchase_order_reference = "Kauppöntun",
   line_id = "ID",
   line_description = "Lýsing",
   line_quantity = "Magn",

--- a/resilient/support/invoice/i18n/it.lua
+++ b/resilient/support/invoice/i18n/it.lua
@@ -5,6 +5,7 @@ return {
   invoice_delivery_date = "Data di Consegna",
   invoice_due_date = "Data di Scadenza",
   invoice_due_terms = "Pagamento entro {days} {day_terms}",
+  purchase_order_reference = "Ordine di Acquisto",
   line_id = "ID",
   line_description = "Descrizione",
   line_quantity = "Quantità",

--- a/resilient/support/invoice/i18n/nl.lua
+++ b/resilient/support/invoice/i18n/nl.lua
@@ -5,6 +5,7 @@ return {
   invoice_delivery_date = "Leveringsdatum",
   invoice_due_date = "Vervaldatum",
   invoice_due_terms = "Betaling binnen {days} {day_terms}",
+  purchase_order_reference = "Inkooporder",
   line_id = "ID",
   line_description = "Beschrijving",
   line_quantity = "Aantal",

--- a/resilient/support/invoice/i18n/pt.lua
+++ b/resilient/support/invoice/i18n/pt.lua
@@ -5,6 +5,7 @@ return {
   invoice_delivery_date = "Data de Entrega",
   invoice_due_date = "Data de Vencimento",
   invoice_due_terms = "Pagamento em {days} {day_terms}",
+  purchase_order_reference = "Ordem de Compra",
   line_id = "ID",
   line_description = "Descrição",
   line_quantity = "Quantidade",

--- a/resilient/support/invoice/i18n/ru.lua
+++ b/resilient/support/invoice/i18n/ru.lua
@@ -5,6 +5,7 @@ return {
   invoice_delivery_date = "Дата поставки",
   invoice_due_date = "Срок оплаты",
   invoice_due_terms = "Оплатить в течение {days} {day_terms}",
+  purchase_order_reference = "Заказ на покупку",
   line_id = "ID",
   line_description = "Описание",
   line_quantity = "кол-во", -- "Количество" is too long for usual table columns

--- a/resilient/support/xmp.lua
+++ b/resilient/support/xmp.lua
@@ -159,7 +159,7 @@ local XMPTemplateFacturX = [[
                   <pdfaProperty:name>DocumentFileName</pdfaProperty:name>
                   <pdfaProperty:valueType>Text</pdfaProperty:valueType>
                   <pdfaProperty:category>external</pdfaProperty:category>
-                  <pdfaProperty:description>name of the embedded XML invoice file</pdfaProperty:description>
+                  <pdfaProperty:description>The name of the embedded XML invoice file</pdfaProperty:description>
                 </rdf:li>
                 <rdf:li rdf:parseType="Resource">
                   <pdfaProperty:name>DocumentType</pdfaProperty:name>
@@ -251,7 +251,7 @@ local function xmpMetadata (documentKey, part, conformance, _, isFacturX)
       <fx:DocumentType>INVOICE</fx:DocumentType>
       <fx:DocumentFileName>factur-x.xml</fx:DocumentFileName>
       <fx:Version>1.0</fx:Version>
-      <fx:ConformanceLevel>BASIC</fx:ConformanceLevel>]])
+      <fx:ConformanceLevel>EN 16931</fx:ConformanceLevel>]])
     xmpContent = string.format(
       XMPTemplateFacturX,
       xmpPDFAidSnippet,


### PR DESCRIPTION
A few Factur-X related items:
 - feat: Add purchase order reference support in invoices
 - feat: Support SIRET number in invoices
 - fix: Target EN 16931 in XMP for Factur-X instead of BASIC compliance
 - fix: Enforce rules CII-SR-465/CII-SR-466 in Factur-X invoice for compliance