### PR TITLE
Fix several relative sizes

### DIFF
--- a/examples/en-book/book-styles.yml
+++ b/examples/en-book/book-styles.yml
@@ -19,7 +19,7 @@ Greek:
   style:
     font:
       family: "Libertinus Serif"
-      size: "0.95em"
+      adjust: "ex-height"
 
 blockquote:
   style:

--- a/examples/fr-book/book-styles.yml
+++ b/examples/fr-book/book-styles.yml
@@ -19,7 +19,7 @@ Greek:
   style:
     font:
       family: "Libertinus Serif"
-      size: "0.95em"
+      adjust: "ex-height"
 
 blockquote:
   style:

--- a/examples/sil/lefevre-tuor-idril.sil
+++ b/examples/sil/lefevre-tuor-idril.sil
@@ -1,7 +1,7 @@
 \begin[papersize=6in x 9in, class=resilient.book, layout=ateliers demiluxe, headers=novel]{document}
 \use[module=packages.resilient.epigraph]
 \use[module=packages.resilient.abbr]
-\use[module=packages.background]
+\use[module=packages.resilient.background]
 \use[module=packages.couyards]
 \use[module=packages.dropcaps]
 \use[module=packages.qrcode]
@@ -17,7 +17,7 @@
 \define[command=proper]{\hbox{\process}}
 \define[command=smallcaps]{\font[features=+smcp]{\process}}
 \define[command=foreign:en]{\em{\language[main=en]{\process}}}
-\define[command=foreign:gr]{\font[family=Libertinus Serif, style=italic, size=0.95em]{\language[main=und]{\process}}}
+\define[command=foreign:gr]{\font[family=Libertinus Serif, style=italic, adjust=ex-height]{\language[main=und]{\process}}}
 \define[command=JRR]{J.{\abbr:nbsp}R.{\abbr:nbsp}R}
 %
 % Wrapper around the dropcaps...

--- a/packages/dissilient/bibtex/init.lua
+++ b/packages/dissilient/bibtex/init.lua
@@ -347,7 +347,7 @@ function package:registerCommands ()
       local n = content[1] and tonumber(content[1]) or 3
       local width = n .. "em"
       SILE.call("raise", { height = "0.4ex" }, function ()
-         SILE.call("hrule", { height = "0.4pt", width = width })
+         SILE.call("hrule", { height = "0.04em", width = width }) -- 0.4pt at 10pt
       end)
    end)
 

--- a/packages/resilient/footnotes/init.lua
+++ b/packages/resilient/footnotes/init.lua
@@ -61,7 +61,7 @@ function package:registerCommands ()
     local width = SU.cast("measurement", options.width or "20%fw") -- "Usually 1/5 of the text block"
     local beforeskipamount = SU.cast("vglue", options.beforeskipamount or "2ex")
     local afterskipamount = SU.cast("vglue", options.afterskipamount or "1ex")
-    local thickness = SU.cast("measurement", options.thickness or "0.5pt")
+    local thickness = SU.cast("measurement", options.thickness or "0.05em") -- 0.5pt at 10pt
     SILE.call("footnote:separator", {}, function ()
       SILE.call("noindent")
       SILE.typesetter:pushExplicitVglue(beforeskipamount)

--- a/packages/resilient/liners/init.lua
+++ b/packages/resilient/liners/init.lua
@@ -166,7 +166,7 @@ function package:registerCommands ()
     end
     paintOptions.stroke = 'none'
     paintOptions.fill = color
-    paintOptions.strokeWidth = SU.cast("measurement", options.thickness or "0.5pt"):tonumber()
+    paintOptions.strokeWidth = SU.cast("measurement", options.thickness or "0.05em"):tonumber()  -- 0.5pt at 10pt
 
     SILE.typesetter:liner("resilient:liner:redacted", content,
       function (box, typesetter, line)
@@ -204,7 +204,7 @@ function package:registerCommands ()
     end
     paintOptions.stroke = "none"
     paintOptions.fill = color
-    paintOptions.strokeWidth = SU.cast("measurement", options.thickness or "0.5pt"):tonumber()
+    paintOptions.strokeWidth = SU.cast("measurement", options.thickness or "0.05em"):tonumber() -- 0.5pt at 10pt
 
     SILE.typesetter:liner("resilient:liner:mark", content,
       function (box, typesetter, line)

--- a/packages/resilient/lists/init.lua
+++ b/packages/resilient/lists/init.lua
@@ -268,7 +268,7 @@ function package:doNestedList (listType, options, content)
       --   such as "VG<text represention of the dimension>", possibly in a
       --   some relative unit ("non-absolutized").
       local prev = SILE.typesetter.state.outputQueue[#SILE.typesetter.state.outputQueue]
-      if prev:tostring() == SILE.settings:get("lists.parskip"):tostring() then
+      if prev and prev:tostring() == SILE.settings:get("lists.parskip"):tostring() then
         SU.debug("lists", "Replacing last lists.parskip by document.parskip")
         SILE.typesetter.state.outputQueue[#SILE.typesetter.state.outputQueue] = SILE.settings:get("document.parskip")
       else


### PR DESCRIPTION
Found when playing with the (WIP) presentation/slide class...

 - Some rules and strokes in drawing were hard-coded to 0.4 or 0.5pt. This is a fairly good value when the text is typeset at 10pt or so, but it should always have been font-relative -- Slides at 20-40pt make it obvious, those lines are then far too thin :) = Typically, bibtex (subsequent author) rule, liners, footnote rule.

 - Some page breaks could occur inside lists and cause a crash when trying to check the previous parskip (already shipped out)

 - By the way, some examples were written before "ex-height" font adjustment was implemented and used "ad hoc" relative sizes when switching fonts in the text flow. Modernizing them is the way to go :)