### PR TITLE
Generalize parskip and penalty collapsing

### DIFF
--- a/classes/resilient/override.lua
+++ b/classes/resilient/override.lua
@@ -224,8 +224,11 @@ function class.newPar (typesetter)
 end
 
 -- WARNING: not called as class method
-function class.endPar (typesetter)
-   typesetter:pushVglue(SILE.settings:get("document.parskip"))
+-- First argument is the typesetter (not used here)
+function class.endPar (_)
+  -- BEGIN RESILIENT CONSECUTIVE PARSKIP COLLAPSING
+  --   (MOVED TO THE TYPESETTER)
+  -- END RESILIENT CONSECUTIVE PARSKIP COLLAPSING
   -- BEGIN SILEX/RESILIENT HANGED LINES
   --   (MOVED TO THE TYPESETTER)
   -- END SILEX/RESILIENT HANGED LINES

--- a/guides/djot-markdown/sile-and-markdown-manual-styles.yml
+++ b/guides/djot-markdown/sile-and-markdown-manual-styles.yml
@@ -32,6 +32,12 @@ Difference:
       before:
         skip: "smallskip"
 
+DifferenceHeader:
+  style:
+    paragraph:
+      after:
+       vbreak: false
+
 FramedPara:
   style:
     paragraph:

--- a/guides/djot-markdown/sile-and-markdown.md
+++ b/guides/djot-markdown/sile-and-markdown.md
@@ -66,7 +66,9 @@ On these block elements, attributes are placed _after_ the element they are atta
  - Code blocks
 
 ::: {custom-style=Difference}
+:::: {custom-style=DifferenceHeader}
 ![](manicule.svg){height=1.3ex} **Main differences with Djot**
+::::
 
  - Slightly different syntax.
  - Supported on less elements.
@@ -81,7 +83,9 @@ On these block elements, attributes are placed _after_ the element they are atta
 Markdown treats multiple spaces as a single space.
 
 ::: {custom-style=Difference}
+:::: {custom-style=DifferenceHeader}
 ![](manicule.svg){height=1.3ex} **Main differences with Djot**
+::::
 
 Backslash-escaped spaces are not interpreted as non-breaking spaces.
 To obtain a non-breaking space, the alternative is to use the HTML entity `&nbsp;` (see §[](#markdown-html-elements)).
@@ -105,7 +109,9 @@ Hard line breaks...\
 
 
 ::: {custom-style=Difference}
+:::: {custom-style=DifferenceHeader}
 ![](manicule.svg){height=1.3ex} **Main differences with Djot**
+::::
 
 Markdown also supports using two trailing spaces at the end of a line to create a hard line break.
 While this syntax comes from the original Markdown specification, it is not recommended to use it, as these spaces are "invisible" and may be easily lost in the editing process.
@@ -128,7 +134,9 @@ Straight double quotes (`"`) and single quotes (`'`) are converted into appropri
 This converter takes into account the current language when converting straight double and single quotation marks to the appropriate typographic variant.
 
 ::: {custom-style=Difference}
+:::: {custom-style=DifferenceHeader}
 ![](manicule.svg){height=1.3ex} **Main differences with Djot**
+::::
 
 The smart quotes feature is less robust than in Djot, and may sometimes be defeated (producing the wrong quotes).
 In some documents, it may be better to disable it (see §[](#markdown-configuration)).
@@ -152,7 +160,9 @@ _This is _an emphasis inside_ an emphasis._
 :::
 
 ::: {custom-style=Difference}
+:::: {custom-style=DifferenceHeader}
 ![](manicule.svg){height=1.3ex} **Main differences with Djot**
+::::
 
  - Slightly different syntax.
  - Edge cases are handled differently.
@@ -168,7 +178,9 @@ Thus, ~~deletion~~ is `~~deletion~~`
 For this converter, this is equivalent to a span with a `.strike` pseudo-class respectively (see §[](#markdown-spans) for details and styling).
 
 ::: {custom-style=Difference}
+:::: {custom-style=DifferenceHeader}
 ![](manicule.svg){height=1.3ex} **Main differences with Djot**
+::::
 
  - Different syntax and interpretation.
  - No direct support for "insertions"
@@ -184,7 +196,9 @@ You thus get an ==highlight== with `==highlight==`
 For this converter, this is equivalent to a span with a `.mark` pseudo-class (see §[](#markdown-spans) for details and styling).
 
 ::: {custom-style=Difference}
+:::: {custom-style=DifferenceHeader}
 ![](manicule.svg){height=1.3ex} **Main differences with Djot**
+::::
 
  - Different syntax.
 
@@ -204,7 +218,9 @@ Thus, H~2~O is a liquid, and 2^10^ is 1024.
 This converter assumes that the content of a superscript or subscript consists of text, as it tries to use font features or text scaling techniques to render it.
 
 ::: {custom-style=Difference}
+:::: {custom-style=DifferenceHeader}
 ![](manicule.svg){height=1.3ex} **Main differences with Djot**
+::::
 
  - No attribute support on these elements.
 
@@ -266,7 +282,9 @@ Oxford is located at 51° 45' 7" N, 1° 15' 27" W
 
 
 ::: {custom-style=Difference}
+:::: {custom-style=DifferenceHeader}
 ![](manicule.svg){height=1.3ex} **Main differences with Djot**
+::::
 
  - Prime conversion is specific to this Markdown converter.
 
@@ -286,7 +304,9 @@ Attributes are optional, and are passed through to the underlying SILE package.
 You can notably specify the required image width and/or height, as done just above, by appending the `{width=... height=...}` attributes --- Note that any unit system supported by SILE is accepted, as well as percentages (see §[](#final-notes-units)).
 
 ::: {custom-style=Difference}
+:::: {custom-style=DifferenceHeader}
 ![](manicule.svg){height=1.3ex} **Main differences with Djot**
+::::
 
  - The "indirect" syntax is supported too, but does not support attributes (yet), so it is probably not very useful at this point.
 
@@ -465,7 +485,9 @@ $$\pi=\sum_{k=0}^\infty\frac{1}{16^k}(\frac{4}{8k+1} − \frac{2}{8k+4} − \fra
 :::
 
 ::: {custom-style=Difference}
+:::: {custom-style=DifferenceHeader}
 ![](manicule.svg){height=1.3ex} **Main differences with Djot**
+::::
 
  - Different syntax (delimiters).
  - Sometimes ambiguous, although the converter tries to be smart about it.
@@ -496,7 +518,9 @@ They are introduced with directly with the caret `^`, immediately followed by th
 :::
 
 ::: {custom-style=Difference}
+:::: {custom-style=DifferenceHeader}
 ![](manicule.svg){height=1.3ex} **Main differences with Djot**
+::::
 
  - Direct inline footnotes are not supported in Djot.
 
@@ -525,7 +549,9 @@ For more information, you may also want to check _The SILE Book_ [@sile, chapter
 ### Symbols
 
 ::: {custom-style=Difference}
+:::: {custom-style=DifferenceHeader}
 ![](manicule.svg){height=1.3ex} **Main differences with Djot**
+::::
 
   - No support for symbols in Markdown.
 
@@ -613,7 +639,9 @@ Here is an example illustrating the use of these attributes:
 :::
 
 ::: {custom-style=Difference}
+:::: {custom-style=DifferenceHeader}
 ![](manicule.svg){height=1.3ex} **Main differences with Djot**
+::::
 
  - Attributes come after the heading text, not on a separate line before it.
  - The heading text must be on the same line as the `#` characters.
@@ -637,7 +665,9 @@ It does not support more than two levels of headings.
 It consists of a line of `=` or `-` characters under the heading text, for level 1 and 2 headings, respectively.
 
 ::: {custom-style=Difference}
+:::: {custom-style=DifferenceHeader}
 ![](manicule.svg){height=1.3ex} **Main differences with Djot**
+::::
 
  - The "Setext" syntax is not supported in Djot.
 
@@ -661,7 +691,9 @@ The contents of the block quote are parsed as block-level content.
 > > Such quotes can be nested.
 
 ::: {custom-style=Difference}
+:::: {custom-style=DifferenceHeader}
 ![](manicule.svg){height=1.3ex} **Main differences with Djot**
+::::
 
  - Attributed quotes (epigraphs) are not supported.
 
@@ -707,7 +739,9 @@ With this converter, the list marker is not significant, and the supporting pack
     - It can be nested.
 
 ::: {custom-style=Difference}
+:::: {custom-style=DifferenceHeader}
 ![](manicule.svg){height=1.3ex} **Main differences with Djot**
+::::
 
  - Subtle differences regarding how spaces are handled.
  - Djot is stricter on where it expects blank lines.
@@ -768,7 +802,9 @@ Your starting number, however, is honored, would you want to start at a differen
 
 
 ::: {custom-style=Difference}
+:::: {custom-style=DifferenceHeader}
 ![](manicule.svg){height=1.3ex} **Main differences with Djot**
+::::
 
  - The hash enumerator is specific to Markdown, with no equivalent in Djot.
  - Numbering schemes enclosed in parentheses are not (yet) supported
@@ -799,7 +835,9 @@ citrus
 
 
 ::: {custom-style=Difference}
+:::: {custom-style=DifferenceHeader}
 ![](manicule.svg){height=1.3ex} **Main differences with Djot**
+::::
 
  - Different syntax.
  - No support for attributes on definition lists.
@@ -837,7 +875,9 @@ This is a regular footnote.[^markdown-fnt]
 :::
 
 ::: {custom-style=Difference}
+:::: {custom-style=DifferenceHeader}
 ![](manicule.svg){height=1.3ex} **Main differences with Djot**
+::::
 
  - No support for attributes on footnotes references.
  - Hence,
@@ -871,7 +911,9 @@ Markdown supports the "pipe table" syntax, with its own way for marking the opti
 With default styles, captioned tables are numbered, and added to the list of tables.
 
 ::: {custom-style=Difference}
+:::: {custom-style=DifferenceHeader}
 ![](manicule.svg){height=1.3ex} **Main differences with Djot**
+::::
 
  - Different syntax for introducing the caption.
  - No support for table attributes.
@@ -902,7 +944,9 @@ This is obtained by indenting the content by at least four spaces...
 :::
 
 ::: {custom-style=Difference}
+:::: {custom-style=DifferenceHeader}
 ![](manicule.svg){height=1.3ex} **Main differences with Djot**
+::::
 
  - Different syntax for introducing the format string.
  - Block attributes go after the opening fence (instead of the format string), not before it.
@@ -1054,7 +1098,9 @@ This converter recognizes a few specific attributes on divs:
  - The `lang` attribute, see §[](#djot-language-changes)
 
 ::: {custom-style=Difference}
+:::: {custom-style=DifferenceHeader}
 ![](manicule.svg){height=1.3ex} **Main differences with Djot**
+::::
 
  - Different syntax for introducing the class name or attributes.
  - No support for divs with a caption (Djot extension)
@@ -1103,7 +1149,9 @@ With all these variants at your disposal, you should be able to typeset print-qu
 books and novels, with the appropriate dividers within chapters, or at the end of thereof.
 
 ::: {custom-style=Difference}
+:::: {custom-style=DifferenceHeader}
 ![](manicule.svg){height=1.3ex} **Main differences with Djot**
+::::
 
  - _Ad hoc_ interpretation of separators, so as to produce more typographically sound results despite not supporting attributes on horizontal rules.
  - Less flexibility than the class-based approach in Djot.
@@ -1176,7 +1224,9 @@ We can now use our new command as a custom style (see §[](#markdown-custom-styl
 Other converters will likely ignore the style, and the ISBN will be displayed as-is, so this technique degrades gracefully.
 
 ::: {custom-style=Difference}
+:::: {custom-style=DifferenceHeader}
 ![](manicule.svg){height=1.3ex} **Main differences with Djot**
+::::
 
  - Curly braces around the `{=sile}` and `{=sile-lua}` annotations.
 
@@ -1233,7 +1283,9 @@ It is assumed to implement the same features and options ---namely, `numbering` 
 ~~~
 
 :::{custom-style=Difference}
+:::: {custom-style=DifferenceHeader}
 ![](manicule.svg){height=1.3ex} **Main differences with Djot**
+::::
 
  - Line blocks are not (yet) supported in Djot, and Mardown shines here.
 
@@ -1307,7 +1359,9 @@ While you could invoke _any_ SILE command with this feature, we recommend, thoug
 Another more powerful way to leverage Djot with SILE’s full processing capabilities, and benefit from the best of both worlds, is to use the "raw" annotations, described in §[](#markdown-raw-inlines) and §[](#markdown-raw-blocks).
 
 ::: {custom-style=Difference}
+:::: {custom-style=DifferenceHeader}
 ![](manicule.svg){height=1.3ex} **Main differences with Djot**
+::::
 
  - Only works on divs and spans (versus almost any element in Djot).
 

--- a/guides/resilient/manual-front.dj
+++ b/guides/resilient/manual-front.dj
@@ -1,12 +1,15 @@
-``` =sile
+```=sile
 % Some initial and dirt hacks...
 \footnote:rule
-% This is a quick but bad implementation. We ought to have used properly defined styles.
-\define[command=admon]{%
-\novbreak
-\smallskip%
-\novbreak
+% Quick and dirty definition of new custom styles
+% using some "resilient" styling feature.
+%
+\define[command=ShadowFramed]{%
+\framebox[padding=0, shadow=true, shadowcolor=220]{\process}}
+%
+\define[command=admonframe]{%
 \set[parameter=document.parindent, value=0]{%
+\set[parameter=current.parindent, value=0]%
 \roughbox[enlarge=true, singlestroke=true, preserve=true,
 padding=2%fw, bordercolor=#59b24c, fillcolor=230, shadowcolor=#96A8C7, shadow=false]{%
 % Beware, wrap color around the parbox so it stays in horizontal mode
@@ -14,9 +17,21 @@ padding=2%fw, bordercolor=#59b24c, fillcolor=230, shadowcolor=#96A8C7, shadow=fa
 % Colors aren't settings so they propagate to the parbox, whatever settings logic it has.
 \color[color=100]{\parbox[width=96%lw]{\set[parameter=document.parindent, value=0]\font[size=9pt]{\process}\par}}%
 }}%
-\medskip}%
-\define[command=ShadowFramed]{%
-\framebox[padding=0, shadow=true, shadowcolor=220]{\process}}
+\par}%
+```
+
+```=sile-lua
+-- Tapping into the internal scratch variable of the resilient.styles
+-- package is not a good practice.
+SILE.scratch.styles.alignments["admon-framed"] = "admonframe"
+local class = SILE.documentState.documentClass
+class:registerStyle("admon", {}, {
+  paragraph = {
+    before = { skip = "smallskip" },
+    after = { skip = "medskip" },
+    align = "admon-framed"
+  }
+})
 ```
 
 {.unnumbered .notoc}

--- a/guides/resilient/sile-resilient-manual-styles.yml
+++ b/guides/resilient/sile-resilient-manual-styles.yml
@@ -1,6 +1,15 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/Omikhleia/resilient.sile/v4.2.0/schemas/stylefile.json
 # $schema: https://raw.githubusercontent.com/Omikhleia/resilient.sile/v4.2.0/schemas/stylefile.json
 
+admon:
+  style:
+    paragraph:
+      after:
+        skip: "medskip"
+      align: "admon-framed"
+      before:
+        skip: "smallskip"
+
 blockquote:
   style:
     font:

--- a/packages/resilient/lists/init.lua
+++ b/packages/resilient/lists/init.lua
@@ -235,11 +235,7 @@ function package:doNestedList (listType, options, content)
           enforceListType(content[i].command)
         end
         SILE.process({ content[i] })
-        if not SILE.typesetter:vmode() then
-          SILE.call("par")
-        else
-          SILE.typesetter:leaveHmode()
-        end
+        SILE.call("par")
       elseif type(content[i]) == "string" then
         -- All text nodes are ignored in structure tags, but just warn
         -- if there do not just consist in spaces.
@@ -251,37 +247,7 @@ function package:doNestedList (listType, options, content)
     end
   end)
 
-  if not SILE.typesetter:vmode() then
-      SILE.call("par")
-  else
-    SILE.typesetter:leaveHmode()
-    if not((SILE.settings:get("lists.current.itemize.depth")
-        + SILE.settings:get("lists.current.enumerate.depth")) > 0)
-    then
-      -- So we reached the list top level:
-      -- We want to have a document.parskip here, but the previous level already
-      -- added a lists.parskip normally.
-      -- HACK:
-      --   Having to check the typesetter's internal queue is probably fragile.
-      --   Having to compare glue references too...
-      --   So we just compare their string representation, which is someting
-      --   such as "VG<text represention of the dimension>", possibly in a
-      --   some relative unit ("non-absolutized").
-      local prev = SILE.typesetter.state.outputQueue[#SILE.typesetter.state.outputQueue]
-      if prev and prev:tostring() == SILE.settings:get("lists.parskip"):tostring() then
-        SU.debug("lists", "Replacing last lists.parskip by document.parskip")
-        SILE.typesetter.state.outputQueue[#SILE.typesetter.state.outputQueue] = SILE.settings:get("document.parskip")
-      else
-        -- Shouldn't occur, but let's be cautious:
-        -- The problem here is that we need to make them absolute to perform a
-        -- computation. "Too early" absolutization may be problematic, however,
-        -- that's why we tried to avoid it. Bah.
-        SU.debug("lists", "Compensating last lists.parskip")
-        local g = SILE.settings:get("document.parskip").height:absolute() - SILE.settings:get("lists.parskip").height:absolute()
-        SILE.typesetter:pushVglue(g)
-      end
-    end
-  end
+  SILE.call("par")
 end
 
 --- (Internal) Render a checkbox form element.

--- a/packages/resilient/styles/init.lua
+++ b/packages/resilient/styles/init.lua
@@ -605,113 +605,46 @@ function package:registerCommands ()
 
   -- APPLY A PARAGRAPH STYLE
 
-  -- Check for a preceding styling skip in the typesetter output queue.
-  local function prevStyleSkipInQueue ()
-    for i = #SILE.typesetter.state.outputQueue, 1, -1 do
-      local n = SILE.typesetter.state.outputQueue[i]
-      if n.is_vbox then return nil end
-      if n.is_vglue and n._style_ then
-        return n, i
-      end
-    end
-    return nil
-  end
-
-  -- Return a cloned styling skip from the given glue.
-  -- The reasons for cloning are multiple
-  --  - Some glues (e.g. a medskip etc.) are always the same node but here we
-  --    want to store the information about the style so we need a distinct
-  --    node.
-  --  - Also, being the same node implies then when made 'explicit' it applies
-  --    to all subsequent use. Maybe that was on purpose, but we want to be
-  --    able to control it.
-  --  - We overload the output routine to add our own debug on these skips.
-  local function cloneStyleSkip (vglue, id)
-    local output = vglue.outputYourself
-    vglue = pl.tablex.copy(vglue)
-    vglue._style_ = id
-    vglue.outputYourself = function (s, t, l)
-      if SU.debugging("resilient.styles") then
-        local X = t.frame.state.cursorX
-        local Y = t.frame.state.cursorY
-        local H = s.height:tonumber() + s.depth:tonumber() + s.adjustment:tonumber()
-        SILE.outputter:pushColor(SILE.types.color("orange"))
-        -- Show a box representing the skip
-        SILE.outputter:drawRule(X, Y, 0.4, H)
-        SILE.outputter:drawRule(X, Y, 30, 0.4)
-        SILE.outputter:drawRule(X + 29.6, Y, 0.4, H)
-        SILE.outputter:drawRule(X, Y + H, 30, 0.4)
-        -- And show its stretch/shrink adjustment
-        SILE.outputter:drawRule(X + 10, Y, 10, s.adjustment:tonumber())
-        SILE.outputter:popColor()
-      end
-      output(s, t, l)
-    end
-    -- Be sure not inheriting non-discardability and explicit flag from the
-    -- original glue.
-    vglue.explicit = false
-    vglue.discardable = true
-    return SILE.types.node.vglue(vglue)
-  end
-
   local function styleForBeforeSkip(name, parSty, styledef)
-    local prevSkip, index = prevStyleSkipInQueue()
     local skip = parSty.before.skip
-    local vglue = skip and SILE.scratch.styles.skips[skip] or SU.cast("vglue", skip)
-    if prevSkip then
-      -- Collapse consecutive styling skips
-      if skip and prevSkip.height:tonumber() < vglue.height:tonumber() then
-        SU.debug("resilient.styles", "Changing", prevSkip._style_, "consecutive skip before", name)
-        vglue = cloneStyleSkip(vglue, name)
-        SILE.typesetter.state.outputQueue[index] = vglue
-      else
-        SU.debug("resilient.styles", "Ignoring", prevSkip._style_, "consecutive skip before", name)
-      end
-    else
-      local novbreak = not parSty.before.vbreak
-      if styledef.sectioning and styledef.sectioning.settings
-        and styledef.sectioning.settings and SU.boolean(styledef.sectioning.settings.goodbreak, true) then
-        SU.debug("resilient.styles", "Inserting goodbreak before", name)
-        SILE.call("goodbreak")
-        if novbreak then
-          SU.warn("Sectioning style '" .. name .. "' has inconsistent goodbreak and paragraph novbreak")
-        end
-      end
-      if skip then
-        SU.debug("resilient.styles", "Inserting skip before", name)
-        if novbreak then SILE.call("novbreak") end
-        vglue = cloneStyleSkip(vglue, name)
-        -- Not sure here whether it should be an explicit glue or not,
-        -- but it seems so to me...
-        SILE.typesetter:pushVglue(vglue)
-      end
-      if novbreak then SILE.call("novbreak") end
+    local novbreak = not parSty.before.vbreak
+    if novbreak then
+      SU.debug("resilient.skips", "Inserting novbreak before paragraph for style", name)
+      SILE.call("novbreak")
+    end
+    local goodbreak = styledef.sectioning and styledef.sectioning.settings
+      and styledef.sectioning.settings and SU.boolean(styledef.sectioning.settings.goodbreak, true)
+    if goodbreak and novbreak then
+       SU.warn("Sectioning style '" .. name .. "' has inconsistent goodbreak and paragraph before vbreak")
+    end
+    if goodbreak then
+      SU.debug("resilient.skips", "Inserting goodbreak before paragraph for style", name)
+      SILE.call("goodbreak")
+    end
+    if not skip then
+      return -- Done
+    end
+    local vglue = SILE.scratch.styles.skips[skip] or SU.cast("vglue", skip)
+    SILE.typesetter:pushCollapsibleVglue(vglue, name .. "_before")
+    if novbreak then
+      SILE.call("novbreak")
     end
   end
 
   local function styleForAfterSkip(name, parSty)
-    local prevSkip, index = prevStyleSkipInQueue()
     local skip = parSty.after.skip
-    local vglue = skip and SILE.scratch.styles.skips[skip] or SU.cast("vglue", skip)
-    if prevSkip then
-      -- Collapse consecutive styling skips
-      if skip and prevSkip.height:tonumber() < vglue.height:tonumber() then
-        SU.debug("resilient.styles", "Changing", prevSkip._style_, "consecutive skip after", name)
-        vglue = cloneStyleSkip(vglue, name, true, 120)
-        SILE.typesetter.state.outputQueue[index] = vglue
-      else
-        SU.debug("resilient.styles", "Ignoring", prevSkip._style_, "consecutive skip after", name)
-      end
-    else
-      local novbreak = not parSty.after.vbreak
-      if skip then
-        SU.debug("resilient.styles", "Inserting skip after", name)
-        if novbreak then SILE.call("novbreak") end
-        vglue = cloneStyleSkip(vglue, name, true, 30)
-        -- Not an explicit glue, so it can be cancelled at the bottom of a page!
-        SILE.typesetter:pushVglue(vglue)
-      end
-      if novbreak then SILE.call("novbreak") end
+    local novbreak = not parSty.after.vbreak
+    if novbreak then
+      SU.debug("resilient.skips", "Inserting novbreak after paragraph for style", name)
+      SILE.call("novbreak")
+    end
+    if not skip then
+      return -- Done
+    end
+    local vglue = SILE.scratch.styles.skips[skip] or SU.cast("vglue", skip)
+    SILE.typesetter:pushCollapsibleVglue(vglue, name .. "_after")
+    if novbreak then
+      SILE.call("novbreak")
     end
   end
 
@@ -728,7 +661,7 @@ function package:registerCommands ()
          SILE.settings:set("document.rskip", SILE.types.node.glue(rskip.width:absolute() + rmargin:absolute()))
       end
       SILE.process(content)
-      SILE.typesetter:leaveHmode(1)
+      SILE.call("par")
     end)
   end, "(INTERNAL) Typeset its contents with additional left and right margins.")
 
@@ -737,7 +670,7 @@ function package:registerCommands ()
       SILE.settings:set("document.parindent", SILE.types.node.glue())
       SILE.settings:set("current.parindent", SILE.types.node.glue())
       SILE.process(content)
-      SILE.typesetter:leaveHmode(1)
+      SILE.call("par")
     end)
   end, "(INTERNAL) Control whether paragraph indent should be applied to the content.")
 
@@ -749,7 +682,7 @@ function package:registerCommands ()
       SILE.settings:set("shaper.variablespaces", false)
       SILE.call("language", { main = "und" })
       SILE.process(content)
-      SILE.typesetter:leaveHmode(1)
+      SILE.call("par")
     end)
   end, "(INTERNAL) Preserve line breaks and spaces in the content")
 
@@ -762,17 +695,12 @@ function package:registerCommands ()
 
     -- FIXME
     -- This whole logic is still a mix of AST manipulation and direct typesetter calls, and is quite messy.
-    --  - Leaveing hmode vs. calling "par" is a mess
-    --  - However many dubious attempts at inserting "novbreak" to avoid unwanted page breaks,
-    --    there are still some cases where unwanted breaks can occur ?!
-    --    E.g. between a figure and its caption
+    -- However many dubious attempts at inserting "novbreak" to avoid unwanted page breaks,
+    -- there are still some cases where unwanted breaks can occur ?!
     local bb = SU.boolean(parSty.before.vbreak, true)
 
     -- Close previous paragraph if any.
-    -- FIXME: We should use a "par" to insert a parskip if needed.
-    -- But we currently have an issue with multiple consecutive "parskips"...
-    --SILE.call("par") -- Close previous paragraph
-    SILE.typesetter:leaveHmode()
+    SILE.call("par")
 
     if not bb then
       SILE.call("novbreak")
@@ -795,10 +723,7 @@ function package:registerCommands ()
       SILE.call("novbreak")
     end
     -- Close this paragraph block
-    -- FIXME: We should use a "par" to insert a parskip if needed.
-    -- But we currently have an issue with multiple consecutive "parskips"...
-    --SILE.call("par") -- Close previous paragraph
-    SILE.typesetter:leaveHmode()
+    SILE.call("par")
 
     styleForAfterSkip(name, parSty)
 

--- a/typesetters/silent.lua
+++ b/typesetters/silent.lua
@@ -75,7 +75,7 @@ mixin(typesetter, require("typesetters.mixins.totext"))
 
 -- This is the default typesetter. You are, of course, welcome to create your own.
 local inf_bad = 10000 -- CODE SMELL: VALUES REPEATED / USED AT SEVERAL PLACES
--- local eject_penalty = -inf_bad
+local eject_penalty = -inf_bad
 local supereject_penalty = 2 * -inf_bad
 -- local deplorable = 100000
 
@@ -361,10 +361,50 @@ function typesetter:pushExplicitVglue (spec)
    return self:pushVertical(node)
 end
 
+-- Check for a preceding penalty in the vertical list, and return it if found.
+function typesetter:_precedingVpenalty ()
+   for i = #self.state.outputQueue, 1, -1 do
+      local node = self.state.outputQueue[i]
+      -- We stop at the first vbox, and return the first penalty found (if any),
+      -- skipping over any other nodes, typically vglue, that may be in between.
+      if node.is_vbox then
+         return nil
+      elseif node.is_penalty then
+         return node, i
+      end
+   end
+   return nil
+end
+
 --- Push a penalty node into the current vertical list.
+--
+-- Consecutive penalties of the same value are ignored, and if a penalty is pushed
+-- after a penalty, the more severe one is kept.
+-- An exception is made for forced break penalties, which are always pushed.
 function typesetter:pushVpenalty (spec)
    local node = SU.type(spec) == "penalty" and spec or SILE.types.node.penalty(spec)
-   return self:pushVertical(node)
+   if node.penalty <= eject_penalty then
+      -- An eject or supereject penalty: always push the forced break penalty.
+      SU.debug("resilient.skips", "Pushing a forced break penalty", node.penalty)
+      self:pushVertical(node)
+   else
+      local preceding, i = self:_precedingVpenalty()
+      if preceding and preceding.penalty > eject_penalty then
+         if preceding.penalty == node.penalty then
+            SU.debug("resilient.skips", "Ignoring consecutive penalties of same value", node.penalty)
+            return -- Done
+         end
+         if preceding.penalty > node.penalty then
+            SU.debug("resilient.skips", "Ignoring less severe penalty", node.penalty, "after more severe penalty", preceding.penalty)
+            return -- Done
+         end
+         SU.debug("resilient.skips", "Replacing previous penalty", preceding.penalty, "with more severe penalty", node.penalty)
+         self.state.outputQueue[i] = node
+      else
+         SU.debug("resilient.skips", "Pushing vertical penalty", node.penalty)
+         self:pushVertical(node)
+      end
+   end
 end
 
 --- Split the input text into paragraphs, and push them to the current horizontal list.
@@ -437,6 +477,8 @@ end
 --- Leave horizontal mode and end the current paragraph.
 function typesetter:endline ()
    self:leaveHmode()
+   local vglue = SILE.settings:get("document.parskip")
+   self:pushCollapsibleVglue(vglue, "_parskip_") -- Not a style name
    SILE.documentState.documentClass.endPar(self)
 end
 
@@ -761,6 +803,80 @@ function typesetter:chuck () -- emergency shipout everything
       SU.debug("typesetter", "Emergency shipout", #self.state.outputQueue, "lines in frame", self.frame.id)
       self:outputLinesToPage(self.state.outputQueue)
       self.state.outputQueue = {}
+   end
+end
+
+-- Check for a preceding styling skip in the typesetter output queue.
+function typesetter:_prevCollapsibleSkipInQueue ()
+   for i = #self.state.outputQueue, 1, -1 do
+      local n = self.state.outputQueue[i]
+      if n.is_vbox then return nil end
+      if n.is_vglue and n._style_ then
+         return n, i
+      end
+   end
+   return nil
+end
+
+-- Return a cloned styling skip from the given glue.
+-- The reasons for cloning are multiple
+--  - Some glues (e.g. a medskip etc.) are always the same node but here we
+--    want to store the information about the style so we need a distinct
+--    node.
+--  - Also, being the same node implies then when made 'explicit' it applies
+--    to all subsequent use. Maybe that was on purpose, but we want to be
+--    able to control it.
+--  - We overload the output routine to add our own debug on these skips.
+function typesetter:_cloneCollapsibleSkip (vglue, id, color)
+   local output = vglue.outputYourself
+   vglue = pl.tablex.copy(vglue)
+   vglue._style_ = id
+   vglue.outputYourself = function (s, t, l)
+      if SU.debugging("resilient.skips") then
+         local X = t.frame.state.cursorX
+         local Y = t.frame.state.cursorY
+         local H = s.height:tonumber() + s.depth:tonumber() + s.adjustment:tonumber()
+         SILE.outputter:pushColor(SILE.types.color(color))
+         -- Show a box representing the skip
+         SILE.outputter:drawRule(X, Y, 0.4, H)
+         SILE.outputter:drawRule(X, Y, 30, 0.4)
+         SILE.outputter:drawRule(X + 29.6, Y, 0.4, H)
+         SILE.outputter:drawRule(X, Y + H, 30, 0.4)
+         -- And show its stretch/shrink adjustment
+         SILE.outputter:drawRule(X + 10, Y, 10, s.adjustment:tonumber())
+         SILE.outputter:popColor()
+      end
+      output(s, t, l)
+   end
+   -- Be sure not inheriting non-discardability and explicit flag from the
+   -- original glue.
+   vglue.explicit = false
+   vglue.discardable = true
+   return SILE.types.node.vglue(vglue)
+end
+
+-- Push or collapse a styling skip into the current vertical list.
+function typesetter:pushCollapsibleVglue (vglue, id)
+   local prevSkip, i = self:_prevCollapsibleSkipInQueue()
+   if prevSkip then
+      -- Collapse consecutive skips
+      if prevSkip.height:tonumber() < vglue.height:tonumber() then
+         SU.debug("resilient.skips", "Altering consecutive skip from", prevSkip._style_, "to", id)
+         vglue = self:_cloneCollapsibleSkip(vglue, id, "orange")
+          -- In-place replacement of the previous skip with the new one.
+          -- This is dubious, but perhaps less than altering the output queue
+          -- by removing the skip.
+         self.state.outputQueue[i] = SILE.types.node.vglue(0)
+         -- Push the larger skip, at the end of the output queue.
+         -- So penalties etc. are not affected by the skip replacement.
+         self:pushVglue(vglue)
+      else
+         SU.debug("resilient.skips", "Ignoring consecutive skip", id, "after", prevSkip._style_)
+      end
+   else
+      SU.debug("resilient.skips", "Inserting skip", id)
+      vglue = self:_cloneCollapsibleSkip(vglue, id, "blue")
+      self:pushVglue(vglue)
    end
 end
 


### PR DESCRIPTION
Closes #196

I mentioned the topic of collapsing skips more than once (incl. in the resilient user guide),  but it's hard to engage knowledgeable readers, if any, on this subtle topic...

_A bit of history_

This is a bit touchy, and initially I didn't want to consider it before I had a chance to possibly switch to the new 'page builder' I had experimented long ago... But this hasn't occurred yet, and a number of things weren't addressed and started bothering me:
 - Consecutive skip collapsing as originally done in the styles package was always some sort of workaround, known to fail in some cases...
 - Environments that needed to close a paragraph had different strategies - either just leaving horizontal mode or issuing a "par", when not doing more dubious things[^1]. It resulted in either missing paragraph skips or duplicated paragraph skips. SILE's core distribution had some sort of workaround too (as stated in the original issue), but not general enough in my views, and still resulting in multiple skips under certain circumstances (e.g. a parskip followed by a medskip, etc.). Skip collapsing thus had to be addressed differently, and include paragraph skips in the vision...
 - It turns out penalties also need some sort of collapsing, as there were still cases where unexpected breaks occurred (e.g. between a heading and a sub-heading, or a figure and its caption), as soon as those started being complex enough in terms of nested content and/or styling...

The approach I had considered with the alternate / experimental page builder cannot be adapted without huge changes, though a less drastic but more dubious method is all I came with for now...

_A tentative solution_

This PR ire-implements on fresh grounds consecutive skip _and_ penalty collapsing.

I am not happy with it, but it does seem to (at least) fix the problems I had in several books with either weird skips or incorrect page breaks. In a way, it's more predictable done this way...

It's still likely fragile: is not a general solution; it's possibly too clever for its own sake, and potentially misbehaving for users having their own packages or classes tinkering with the typesetter's internals... But sometimes, a partial fix is better than doing nothing.

**For debug**: Run with `-d resilient.skips`. It generates (quite verbose) debug logs, and also visuals hint in the PDF.

|^1]: As the lists package did, for instance, checking for a previous list parskip in order to adjust a "final" paragraph skip...