### PR TITLE
fix: Make predefined skips collapsing and fix collapsing logic

### DIFF
--- a/guides/djot-markdown/sile-and-djot.dj
+++ b/guides/djot-markdown/sile-and-djot.dj
@@ -1236,6 +1236,7 @@ As for raw inlines (§[](#djot-raw-inlines)), this converter supports the `=sile
 Other annotations are ignored, and the block content is skipped.
 
 Let's combine several of the extensibility techniques we have seen so far, and do something cool.
+Why not "style" an EAN-13 ISBN as a nice barcode?
 
 ```=sile
 \use[module=packages.barcodes.ean13]
@@ -1249,8 +1250,6 @@ class:registerCommand("MyEan13", function (_, content)
   SILE.call("ean13", { scale="SC0", code = code })
 end)
 ```
-
-Why not "style" an EAN-13 ISBN as a nice barcode?
 
 [[978-2-9539896-6-3]{custom-style=MyEan13}]{custom-style=center}
 
@@ -1572,6 +1571,17 @@ A "readonly" boolean attribute is also supported, to make the element non-intera
 Note that the content of such form elements, if any, is ignored.
 It may still be useful, though, to provide some fallback content for other converters not supporting this feature.
 
+Name: []{.form}.
+
+Gender:
+
+ {.form}
+ - (X) Unspecified
+ - ( ) Male
+ - ( ) Female
+
+Language: []{.form choices="English, French, Other"}.
+
 {custom-style=CodeBlock}
 :::
 ```
@@ -1588,17 +1598,6 @@ Language: []{.form choices="English, French, Other"}.
 
 ```
 :::
-
-Name: []{.form}.
-
-Gender:
-
- {.form}
- - (X) Unspecified
- - ( ) Male
- - ( ) Female
-
-Language: []{.form choices="English, French, Other"}.
 
 As may be seen here, text fields and choice menus have a minimal width by default, but they expand to
 the full available line width.

--- a/guides/djot-markdown/sile-and-markdown.md
+++ b/guides/djot-markdown/sile-and-markdown.md
@@ -1165,6 +1165,8 @@ As for raw inlines (§[](#markdown-raw-inlines)), this converter supports the `{
 Other annotations are ignored, and the block content is skipped.
 
 Let's combine several of the extensibility techniques we have seen so far, and do something cool.
+Why not "style" an EAN-13 ISBN as a nice barcode?
+
 
 ```{=sile}
 \use[module=packages.barcodes.ean13]
@@ -1178,8 +1180,6 @@ class:registerCommand("MyEan13b", function (_, content)
   SILE.call("ean13", { scale="SC0", code = code })
 end)
 ```
-
-Why not "style" an EAN-13 ISBN as a nice barcode?
 
 [[978-2-9539896-6-3]{custom-style=MyEan13b}]{custom-style=center}
 

--- a/guides/resilient/resume-sample-styles.yml
+++ b/guides/resilient/resume-sample-styles.yml
@@ -1,5 +1,5 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/Omikhleia/resilient.sile/v2.8.0/schemas/stylefile.json
-# $schema: https://raw.githubusercontent.com/Omikhleia/resilient.sile/v2.8.0/schemas/stylefile.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Omikhleia/resilient.sile/v4.2.0/schemas/stylefile.json
+# $schema: https://raw.githubusercontent.com/Omikhleia/resilient.sile/v4.2.0/schemas/stylefile.json
 
 lists-enumerate-alternate1:
   inherit: "lists-enumerate-base"
@@ -251,7 +251,9 @@ verbatim:
   inherit: "code"
   style:
     paragraph:
-      align: "obeylines"
+      align: "left"
       before:
         skip: "smallskip"
+      indent: false
+      lines: "preserve"
 

--- a/guides/resilient/sile-resilient-manual-styles.yml
+++ b/guides/resilient/sile-resilient-manual-styles.yml
@@ -5,7 +5,7 @@ admon:
   style:
     paragraph:
       after:
-        skip: "medskip"
+        skip: "smallskip"
       align: "admon-framed"
       before:
         skip: "smallskip"

--- a/packages/markdown/commands.lua
+++ b/packages/markdown/commands.lua
@@ -297,6 +297,7 @@ function package:registerCommands ()
         height = options.height,
         width = not options.height and (options.width or "default")
       }
+      SILE.call("novbreak")
       SILE.call("smallskip")
       SILE.call("couyard", opts)
     elseif not hasClass(options, "none") then
@@ -725,7 +726,7 @@ function package:registerCommands ()
       local handler = SILE.rawHandlers.highlight
       handler(options, content)
     end
-    SILE.call("par")
+    SILE.typesetter:leaveHmode()
   end, "(Fenced) code block in Markdown (internal)")
 
   self:registerCommand("markdown:internal:lineblock", function (_, content)
@@ -837,7 +838,7 @@ function package:registerCommands ()
     SILE.call("noindent")
     SILE.call("font", { weight = 700 }, content)
     SILE.call("novbreak")
-    SILE.call("par")
+    SILE.typesetter:leaveHmode()
     SILE.call("novbreak")
   end, "A fallback default header if none exists for the requested sectioning level")
 
@@ -894,7 +895,9 @@ function package:registerCommands ()
       SU.debug("markdown.commands", "Feature detection: ignoring unknown custom style:", name)
       SILE.process(content)
       if scope == "block" then
-        SILE.call("par")
+        -- TODO NO SURE ABOUT THIS ONE
+        -- SILE.call("par")
+        SILE.typesetter:leaveHmode()
       end
     end
   end, "Default hook for custom style support in Markdown")

--- a/packages/resilient/epigraph/init.lua
+++ b/packages/resilient/epigraph/init.lua
@@ -171,8 +171,7 @@ package.documentation = [[\begin{document}
 
 The \autodoc:package{resilient.epigraph} package for SILE can be used to typeset
 a relevant quotation or saying as an epigraph, usually at either the start or end of
-a section. Various handles are provided to tweak the appearance.\footnote{This is
-very loosely inspired from the LaTeX \code{epigraph} package.}
+a section. Various handles are provided to tweak the appearance.
 
 The \autodoc:environment{epigraph} environment typesets an epigraph using the provided text.
 An optional source (author, book name, etc.) can also be defined, with

--- a/packages/resilient/plain/init.lua
+++ b/packages/resilient/plain/init.lua
@@ -78,7 +78,8 @@ function package:registerCommands ()
       -- In resilient, make these "predefined" skips collapsible
       -- instead of explicit glues.
       -- This does solve some issues (e.g. consecutive skips before/after a section)
-      -- but this may be very opinionated and introduce other concerns in some contexts.
+      -- but this may be bad design and introduce other concerns in some contexts.
+      -- See comments in the resilient typesetter ("sile·nt")
       SILE.typesetter:pushCollapsibleVglue(SILE.settings:get("plain." .. k .. "skipamount"))
     end, "Skip vertically by a " .. k .. " amount")
   end
@@ -232,7 +233,7 @@ function package:registerCommands ()
       SILE.settings:set("typesetter.parfillskip", SILE.types.node.glue())
       SILE.settings:set("document.spaceskip", SILE.types.length("1spc", 0, 0))
       SILE.process(content)
-      SILE.call("par")
+      SILE.typesetter:leaveHmode()
     end)
   end, "Typeset its contents in a centered block (keeping margins).")
 
@@ -245,7 +246,7 @@ function package:registerCommands ()
       SILE.settings:set("typesetter.parfillskip", SILE.types.node.glue())
       SILE.settings:set("document.spaceskip", SILE.types.length("1spc", 0, 0))
       SILE.process(content)
-      SILE.call("par")
+      SILE.typesetter:leaveHmode()
     end)
   end, "Typeset its contents in a left aligned block (keeping margins).")
 
@@ -258,7 +259,7 @@ function package:registerCommands ()
       SILE.settings:set("typesetter.parfillskip", SILE.types.node.glue())
       SILE.settings:set("document.spaceskip", SILE.types.length("1spc", 0, 0))
       SILE.process(content)
-      SILE.call("par")
+      SILE.typesetter:leaveHmode()
     end)
   end, "Typeset its contents in a right aligned block (keeping margins).")
 
@@ -274,7 +275,7 @@ function package:registerCommands ()
       SILE.settings:set("typesetter.parfillskip", nil, false, true)
       SILE.settings:set("document.spaceskip", nil)
       SILE.process(content)
-      SILE.call("par")
+      SILE.typesetter:leaveHmode()
     end)
   end, "Typeset its contents in a justified block (keeping margins).")
 

--- a/packages/resilient/plain/init.lua
+++ b/packages/resilient/plain/init.lua
@@ -74,7 +74,12 @@ function package:registerCommands ()
   for k, _ in pairs(skips) do
     self:registerCommand(k .. "skip", function (_, _)
       SILE.typesetter:leaveHmode()
-      SILE.typesetter:pushExplicitVglue(SILE.settings:get("plain." .. k .. "skipamount"))
+      -- RESILIENT
+      -- In resilient, make these "predefined" skips collapsible
+      -- instead of explicit glues.
+      -- This does solve some issues (e.g. consecutive skips before/after a section)
+      -- but this may be very opinionated and introduce other concerns in some contexts.
+      SILE.typesetter:pushCollapsibleVglue(SILE.settings:get("plain." .. k .. "skipamount"))
     end, "Skip vertically by a " .. k .. " amount")
   end
 

--- a/typesetters/silent.lua
+++ b/typesetters/silent.lua
@@ -348,26 +348,38 @@ function typesetter:pushVbox (spec)
 end
 
 --- Push a vglue node into the current vertical list.
-function typesetter:pushVglue (spec)
+function typesetter:pushVglue (spec, options)
+   options = options or {}
    local node = SU.type(spec) == "vglue" and spec or SILE.types.node.vglue(spec)
-   return self:pushVertical(node)
+   self:pushVertical(node)
 end
 
 --- Push an explicit vglue node into the current vertical list.
-function typesetter:pushExplicitVglue (spec)
+function typesetter:pushExplicitVglue (spec, options)
+   options = options or {}
    local node = SU.type(spec) == "vglue" and spec or SILE.types.node.vglue(spec)
    node.explicit = true
    node.discardable = false
-   return self:pushVertical(node)
+   self:pushVertical(node)
 end
 
--- Check for a preceding penalty in the vertical list, and return it if found.
+-- FIXME COLLABPSBLE
+-- The whole "collapsible skip" logic is a total mess and the wrong approach
+-- to the matter.
+-- We ought to properly track states, rather than do these ugly introspections
+-- of the output queue, which cannot be robust and is a source of inconsistencies.
+
+-- Check for a preceding penalty in the vertical list, and return it if found (COLLAPSIBLE)
 function typesetter:_precedingVpenalty ()
    for i = #self.state.outputQueue, 1, -1 do
       local node = self.state.outputQueue[i]
       -- We stop at the first vbox, and return the first penalty found (if any),
       -- skipping over any other nodes, typically vglue, that may be in between.
       if node.is_vbox then
+         return nil
+      elseif node.is_vglue and not node._style_ then
+         -- FIXME QUESTIONAME
+         -- Should we really stop at the first vglue that's not marked as a style skip?
          return nil
       elseif node.is_penalty then
          return node, i
@@ -395,6 +407,7 @@ function typesetter:pushVpenalty (spec)
          SILE.outputter:popColor()
       end
    end
+   -- COLLABSIBLE
    if node.penalty <= eject_penalty then
       -- An eject or supereject penalty: always push the forced break penalty.
       SU.debug("resilient.skips", "Pushing a forced break penalty", node.penalty)
@@ -818,7 +831,7 @@ function typesetter:chuck () -- emergency shipout everything
    end
 end
 
--- Check for a preceding styling skip in the typesetter output queue.
+-- Check for a preceding styling skip in the typesetter output queue. (COLLAPSIBLE)
 function typesetter:_prevCollapsibleSkipInQueue ()
    for i = #self.state.outputQueue, 1, -1 do
       local n = self.state.outputQueue[i]
@@ -829,14 +842,20 @@ function typesetter:_prevCollapsibleSkipInQueue ()
          -- over that boundary..
          return nil
       end
-      if n.is_vglue and n._style_ then
-         return n, i
+      if n.is_vglue then
+        if n._style_ then
+            return n, i
+        else
+         -- A non-styling skip is found, we stop here, and don't collapse previous skips
+         -- over that boundary (?)
+         return nil
+        end
       end
    end
    return nil
 end
 
--- Return a cloned styling skip from the given glue.
+-- Return a cloned styling skip from the given glue. (COLLAPSIBLE)
 -- The reasons for cloning are multiple
 --  - Some glues (e.g. a medskip etc.) are always the same node but here we
 --    want to store the information about the style so we need a distinct
@@ -869,9 +888,10 @@ function typesetter:_cloneCollapsibleSkip (vglue, id, color)
    return SILE.types.node.vglue(vglue)
 end
 
--- Push or collapse a styling skip into the current vertical list.
+-- Push or collapse a styling skip into the current vertical list. (COLLAPSIBLE)
 function typesetter:pushCollapsibleVglue (vglue, id)
    local prevSkip, i = self:_prevCollapsibleSkipInQueue()
+   id = id or "_unknown_"
    if prevSkip then
       -- Collapse consecutive skips
       if prevSkip.height:tonumber() < vglue.height:tonumber() then
@@ -886,7 +906,7 @@ function typesetter:pushCollapsibleVglue (vglue, id)
          SU.debug("resilient.skips", "Ignoring consecutive skip", id, "after", prevSkip._style_)
       end
    else
-      SU.debug("resilient.skips", "Inserting skip", id or "xxx", "new skip", vglue)
+      SU.debug("resilient.skips", "Inserting skip", id, "new skip", vglue)
       vglue = self:_cloneCollapsibleSkip(vglue, id, "blue")
       self:pushVglue(vglue)
    end

--- a/typesetters/silent.lua
+++ b/typesetters/silent.lua
@@ -383,6 +383,18 @@ end
 -- An exception is made for forced break penalties, which are always pushed.
 function typesetter:pushVpenalty (spec)
    local node = SU.type(spec) == "penalty" and spec or SILE.types.node.penalty(spec)
+   node.outputYourself = function (s, t, _)
+      if SU.debugging("resilient.skips") then
+         local color = s.penalty >= 10000 and "red" -- red for novbreak
+            or s.penalty <= 0 and "green" -- green for negative penalties (incl. goodbreak etc.)
+            or "blue" -- blue for other penalties
+         local X = t.frame.state.cursorX
+         local Y = t.frame.state.cursorY
+         SILE.outputter:pushColor(SILE.types.color(color))
+         SILE.outputter:drawRule(X-5, Y, 5, 2)
+         SILE.outputter:popColor()
+      end
+   end
    if node.penalty <= eject_penalty then
       -- An eject or supereject penalty: always push the forced break penalty.
       SU.debug("resilient.skips", "Pushing a forced break penalty", node.penalty)
@@ -811,6 +823,12 @@ function typesetter:_prevCollapsibleSkipInQueue ()
    for i = #self.state.outputQueue, 1, -1 do
       local n = self.state.outputQueue[i]
       if n.is_vbox then return nil end
+      if n.is_penalty and n.penalty <= eject_penalty
+      then
+         -- A forced break penalty is found, we stop here, and don't collapse previous skips
+         -- over that boundary..
+         return nil
+      end
       if n.is_vglue and n._style_ then
          return n, i
       end
@@ -848,10 +866,6 @@ function typesetter:_cloneCollapsibleSkip (vglue, id, color)
       end
       output(s, t, l)
    end
-   -- Be sure not inheriting non-discardability and explicit flag from the
-   -- original glue.
-   vglue.explicit = false
-   vglue.discardable = true
    return SILE.types.node.vglue(vglue)
 end
 
@@ -863,10 +877,8 @@ function typesetter:pushCollapsibleVglue (vglue, id)
       if prevSkip.height:tonumber() < vglue.height:tonumber() then
          SU.debug("resilient.skips", "Altering consecutive skip from", prevSkip._style_, "to", id)
          vglue = self:_cloneCollapsibleSkip(vglue, id, "orange")
-          -- In-place replacement of the previous skip with the new one.
-          -- This is dubious, but perhaps less than altering the output queue
-          -- by removing the skip.
-         self.state.outputQueue[i] = SILE.types.node.vglue(0)
+         -- Remove the previous skip from the output queue
+         table.remove(self.state.outputQueue, i)
          -- Push the larger skip, at the end of the output queue.
          -- So penalties etc. are not affected by the skip replacement.
          self:pushVglue(vglue)
@@ -874,7 +886,7 @@ function typesetter:pushCollapsibleVglue (vglue, id)
          SU.debug("resilient.skips", "Ignoring consecutive skip", id, "after", prevSkip._style_)
       end
    else
-      SU.debug("resilient.skips", "Inserting skip", id)
+      SU.debug("resilient.skips", "Inserting skip", id or "xxx", "new skip", vglue)
       vglue = self:_cloneCollapsibleSkip(vglue, id, "blue")
       self:pushVglue(vglue)
    end


### PR DESCRIPTION
Regression introduced via #206 

Break occurring between a figure and a caption:
 - Observed where compiling "dragon-de-brume-adm/dragon-de-brume-charte-ce.silm" 
 - Other smoke tests were passing
 - Analysis: #206 changed how the preceding skip is collapsed.
    - Before, we were doing an in-place replacement by the larger glue, but it could result in having the appropriate penalties around it.
    - After, we replaced it with a vglue(0), keeping the larger glue at its final position in the queue.

Using a vglue(0) is indeed fragile...
 - it can become a break point, if the preceding node is "discardable", if I read correctly the page builder.
 - But removing the collapsed glue totally had led to another regression, observed in the resilient manual = a break occurring between a table and its caption...
 - Analysis: package ptable uses standard skips (smallskip IIRC) around the table. These are not collapsible, and altering the package to use our styling logic would mean moving it to resilient and rewriting part of its logic. While considered (https://github.com/Omikhleia/ptable.sile/issues/22), but if it occurs, it would be a major release.

Considerations:
 - This "collapsible" glue/penalty logic was aimed at solving a problem with repeated glues (e.g. before and after headings mostly) but it's getting complex = the approach is certainly not robust, as stated in #206 
 - I am still lacking understanding regarding some concepts:
    - What are "explicit" vglues are, and what are they really supposed to solve...
    - Why are "small/med/big" skips such "explicit" glues...
    - What does the current page builder exactly assume in its short but hard-to-follow logic...

Exploration:
 - The solution that would consist in not having direct skips in the ptable package, but rather delegate the skips to the resilient styling logic is not doable yet. But a "workaround" is to change all "small/med/big" skips to non-explicit collapsible glues..
 - Note that we cannot make all vglues collapsible, or all "vfill" would be killed...

It's messy. Making all predefined med/small/big skips "collapsible" has another consequence, moreover. `\bigskip\medskip` (for instance) will result in only one `\bigskip` (collapsing to the biggest glue). 

TBH, this last point doesn't trouble me that much. It's a change in behavior, but for a bad use case:
 - If one wants a custom skip, it should define it (`\skip`), not try to stack multiple predefined skips...
 - SILE already differs from TeX in a number of ways (e.g. using several `\vfill` in sequence is probably a bad pattern too, but SILE's stretching has only one "infinite" (actually very large) value, where TeX has things such as "2fil"

Conclusion:
 - Make predefined skips collapsing
 - Fix collapsing logic accordingly
    - Remove the preceding skip = do not use a "vglue(0)"
    - Consider eject/supereject penalties to be boundaries for skip collapsing

Let's do another campaign of smoke/regressing tests.


